### PR TITLE
Fix DeepEP cannot be used together with code that needs GIL such as Mooncake transfer engine

### DIFF
--- a/csrc/deep_ep.cpp
+++ b/csrc/deep_ep.cpp
@@ -614,6 +614,8 @@ Buffer::internode_dispatch(const torch::Tensor& x, const std::optional<torch::Te
                            const std::optional<torch::Tensor>& cached_rdma_channel_prefix_matrix, const std::optional<torch::Tensor>& cached_recv_rdma_rank_prefix_sum,
                            const std::optional<torch::Tensor>& cached_gbl_channel_prefix_matrix, const std::optional<torch::Tensor>& cached_recv_gbl_rank_prefix_sum,
                            int expert_alignment, const Config& config, std::optional<EventHandle>& previous_event, bool async, bool allocate_on_comm_stream) {
+    pybind11::gil_scoped_release release;
+
     const int num_channels = config.num_sms / 2;
     EP_HOST_ASSERT(config.num_sms % 2 == 0);
     EP_HOST_ASSERT(0 < get_num_rdma_ranks() and get_num_rdma_ranks() <= NUM_MAX_RDMA_PEERS);


### PR DESCRIPTION
When using DeepEP with Mooncake transfer engine, DeepEP's dispatch will hold the GIL for a long time, and thus other libraries such as Mooncake transfer engine, which uses Python code in another thread, cannot obtain the GIL and thus get stuck. Therefore, in this PR, I make DeepEP release GIL to fix this.