### PR TITLE
Feat: enhance nvidia peer memory detection

### DIFF
--- a/third-party/nvshmem.patch
+++ b/third-party/nvshmem.patch
@@ -421,3 +421,17 @@ index ea1e284..e6640d6 100644
 --
 2.25.1
 
+diff --git a/src/modules/transport/common/transport_ib_common.cpp b/src/modules/transport/common/transport_ib_common.cpp
+index c89f408..f99018a 100644
+--- a/src/modules/transport/common/transport_ib_common.cpp
++++ b/src/modules/transport/common/transport_ib_common.cpp
+@@ -26,6 +26,9 @@ int nvshmemt_ib_common_nv_peer_mem_available() {
+     if (access("/sys/kernel/mm/memory_peers/nvidia-peermem/version", F_OK) == 0) {
+         return NVSHMEMX_SUCCESS;
+     }
++    if (access("/sys/module/nvidia_peermem/version", F_OK) == 0) {
++        return NVSHMEMX_SUCCESS;
++    }
+ 
+     return NVSHMEMX_ERROR_INTERNAL;
+ }


### PR DESCRIPTION
In my H800 environment which NVIDIA Driver is `550.54.15` and `nvidia_peermem` module has been loaded successfully, but NVSHMEM detections of `nvidia_peermem` existence never pass, then I will get some error messages like `neither nv_peer_mem, or nvidia_peermem detected. Skipping transport.`. That's because there is not neither `/sys/kernel/mm/memory_peers/nv_mem/version` nor `/sys/kernel/mm/memory_peers/nv_mem_nc/version` file in my machine.
According to [NCCL's implementation](https://github.com/NVIDIA/nccl/blob/3000e3c797b4b236221188c07aa09c1f3a0170d4/src/transport/net_ib.cc#L711) I use `/sys/module/nvidia_peermem/version` file as an indication of the existence of `nvidia_peermem`, then I can run DeepDP `internode`、`intronode` and `low_latency` over multiple nodes successfully after patching it.

