### PR TITLE
Shuffling the starting index of target rank for different ranks and channels

### DIFF
--- a/csrc/kernels/internode.cu
+++ b/csrc/kernels/internode.cu
@@ -703,7 +703,8 @@ dispatch(int4* recv_x, float* recv_x_scales, int64_t* recv_topk_idx, float* recv
         int last_issued_tail = 0;
         while (__any_sync(0xffffffff, num_tokens_to_send > 0)) {
             for (int i = 0, synced_num_tokens_to_send; i < kNumRDMARanks; ++ i) {
-                int dst_rdma_rank = (i + channel_id) % kNumRDMARanks;
+                // To mitigate incast congestion, shuffle the starting index of target rank for different ranks and channels
+                int dst_rdma_rank = (i + channel_id + rdma_rank) % kNumRDMARanks;
                 synced_num_tokens_to_send = __shfl_sync(0xffffffff, num_tokens_to_send, dst_rdma_rank);
                 if (synced_num_tokens_to_send == 0)
                     continue;


### PR DESCRIPTION
To mitigate incast congestion, shuffle the starting index of target rank for different ranks and channels. cc @LyricZhao 

# Example

When the number of ranks and channels is unequal (e.g., 4 ranks and 5 channels), distributing the initial target rank positions through rank-channel shuffling can balance the send/receive network traffic per rank, thereby mitigating incast congestion.
The following demonstrates the target rank positions computed per iteration for each rank and channel under two shuffling modes.

## channel shuffle
Round-0
| RDMA-RANK/CHANNEL-ID | Channel0 | Channel1 |Channel2 |Channel3 |Channel4 |
|    :----:   |    :----:   |    :----:   |    :----:   |    :----:   |    :----:   | 
| Rank0       |0  |1  |2  |3  |0  |
| Rank1       |0  |1  |2  |3  |0  |
| Rank2       |0  |1  |2  |3  |0  |
| Rank3       |0  |1  |2  |3  |0  |

Round-1
| RDMA-RANK/CHANNEL-ID | Channel0 | Channel1 |Channel2 |Channel3 |Channel4 |
|    :----:   |    :----:   |    :----:   |    :----:   |    :----:   |    :----:   | 
| Rank0       |1  |2  |3  |0  |1  |
| Rank1       |1  |2  |3  |0  |1  |
| Rank2       |1  |2  |3  |0  |1  |
| Rank3       |1  |2  |3  |0  |1  |

## channel-rank shuffle

Round-0
| RDMA-RANK/CHANNEL-ID | Channel0 | Channel1 |Channel2 |Channel3 |Channel4 |
|    :----:   |    :----:   |    :----:   |    :----:   |    :----:   |    :----:   | 
| Rank0       |0  |1  |2  |3  |0  |
| Rank1       |1  |2  |3  |0  |1  |
| Rank2       |2  |3  |0  |1  |2  |
| Rank3       |3  |0  |1  |2  |3  |

Round-1

| RDMA-RANK/CHANNEL-ID | Channel0 | Channel1 |Channel2 |Channel3 |Channel4 |
|    :----:   |    :----:   |    :----:   |    :----:   |    :----:   |    :----:   | 
| Rank0       |1  |2  |3  |0  |1  |
| Rank1       |2  |3  |0  |1  |2  |
| Rank2       |3  |0  |1  |2  |3  |
| Rank3       |0  |1  |2  |3  |0  |