### PR TITLE
Make `TORCH_CUDA_ARCH_LIST` as an environment variable

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CUDA_SEPARABLE_COMPILATION ON)
 list(APPEND CUDA_NVCC_FLAGS "-O3")
 list(APPEND CUDA_NVCC_FLAGS "--ptxas-options=--verbose,--register-usage-level=10,--warn-on-local-memory-usage")
 
-set(TORCH_CUDA_ARCH_LIST "9.0")
+set(TORCH_CUDA_ARCH_LIST "9.0 10.0")
 find_package(CUDAToolkit REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(Torch REQUIRED)

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CUDA_SEPARABLE_COMPILATION ON)
 list(APPEND CUDA_NVCC_FLAGS "-O3")
 list(APPEND CUDA_NVCC_FLAGS "--ptxas-options=--verbose,--register-usage-level=10,--warn-on-local-memory-usage")
 
-set(TORCH_CUDA_ARCH_LIST "9.0 10.0")
+set(TORCH_CUDA_ARCH_LIST "9.0")
 find_package(CUDAToolkit REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(Torch REQUIRED)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ if __name__ == '__main__':
     print(f'NVSHMEM directory: {nvshmem_dir}')
 
     # TODO: currently, we only support Hopper architecture, we may add Ampere support later
-    os.environ['TORCH_CUDA_ARCH_LIST'] = '9.0 10.0'
+    if os.getenv('TORCH_CUDA_ARCH_LIST', None) is None:
+        os.environ['TORCH_CUDA_ARCH_LIST'] = '9.0'
     cxx_flags = ['-O3', '-Wno-deprecated-declarations', '-Wno-unused-variable',
                  '-Wno-sign-compare', '-Wno-reorder', '-Wno-attributes']
     nvcc_flags = ['-O3', '-Xcompiler', '-O3', '-rdc=true', '--ptxas-options=--register-usage-level=10']

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     print(f'NVSHMEM directory: {nvshmem_dir}')
 
     # TODO: currently, we only support Hopper architecture, we may add Ampere support later
-    os.environ['TORCH_CUDA_ARCH_LIST'] = '9.0'
+    os.environ['TORCH_CUDA_ARCH_LIST'] = '9.0 10.0'
     cxx_flags = ['-O3', '-Wno-deprecated-declarations', '-Wno-unused-variable',
                  '-Wno-sign-compare', '-Wno-reorder', '-Wno-attributes']
     nvcc_flags = ['-O3', '-Xcompiler', '-O3', '-rdc=true', '--ptxas-options=--register-usage-level=10']


### PR DESCRIPTION
This PR adds the 10.0 to TORCH_CUDA_ARCH_LIST to support compilation for Blackwell GPUs.