### PR TITLE
Support other ways of fp8 quantization

### DIFF
--- a/csrc/kernels/internode_ll.cu
+++ b/csrc/kernels/internode_ll.cu
@@ -119,8 +119,6 @@ dispatch(void* packed_recv_x, float* packed_recv_x_scales,
                     // Reduce amax and scale
                     EP_STATIC_ASSERT(kNumElemsPerRead * 32 / kNumPerChannels == 2, "Invalid vectorization");
 
-                    // NOTE MODIFIED
-//                     amax = half_warp_reduce_max(amax), scale = kFP8Amax / amax, scale_inv = amax * kFP8AmaxInv;
                     amax = half_warp_reduce_max(amax);
                     scale_inv = amax * kFP8AmaxInv;
                     scale_inv = exp2f(ceilf(log2f(fmaxf(fabsf(scale_inv), 1e-10f))));


### PR DESCRIPTION
I tested the code e2e and it works. The current code is not to be merged (I just removed the old code instead of making a switch between the two versions) and I just want to hear what kind of switch do you like (compile-time flag, c++ template, bool arg, etc), and I will update it.