### PR TITLE
Support UE8M0 data format.

### DIFF
--- a/csrc/deep_ep.hpp
+++ b/csrc/deep_ep.hpp
@@ -141,7 +141,8 @@ public:
     low_latency_dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
                          const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
                          int num_max_dispatch_tokens_per_rank, int num_experts,
-                         bool use_fp8, bool async, bool return_recv_hook);
+                         bool use_fp8, bool round_scale, bool use_ue8m0,
+                         bool async, bool return_recv_hook);
 
     std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::function<void()>>>
     low_latency_combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const torch::Tensor& topk_weights,

--- a/csrc/kernels/CMakeLists.txt
+++ b/csrc/kernels/CMakeLists.txt
@@ -4,8 +4,8 @@ function(add_deep_ep_library target_name source_file)
             POSITION_INDEPENDENT_CODE ON
             CXX_STANDARD_REQUIRED ON
             CUDA_STANDARD_REQUIRED ON
-            CXX_STANDARD 14
-            CUDA_STANDARD 14
+            CXX_STANDARD 17
+            CUDA_STANDARD 17
             CUDA_SEPARABLE_COMPILATION ON
     )
     target_link_libraries(${target_name} PUBLIC nvshmem cudart cudadevrt mlx5)

--- a/csrc/kernels/api.cuh
+++ b/csrc/kernels/api.cuh
@@ -57,6 +57,7 @@ void dispatch(void* recv_x, float* recv_x_scales, int* recv_src_idx, int64_t* re
               int* send_head, const void* x, const float* x_scales, const int64_t* topk_idx, const float* topk_weights,
               const bool* is_token_in_rank, const int* channel_prefix_matrix,
               int num_tokens, int num_worst_tokens, int hidden_int4, int num_topk, int num_experts, int num_scales,
+              int scale_token_stride, int scale_hidden_stride,
               void** buffer_ptrs, int rank, int num_ranks,
               cudaStream_t stream, int num_sms,
               int num_max_send_tokens, int num_recv_buffer_tokens);
@@ -99,8 +100,9 @@ void dispatch(void* recv_x, float* recv_x_scales, int64_t* recv_topk_idx, float*
               int* recv_rdma_channel_prefix_matrix, int* recv_gbl_channel_prefix_matrix,
               const int* rdma_channel_prefix_matrix, const int* recv_rdma_rank_prefix_sum,
               const int* gbl_channel_prefix_matrix, const int* recv_gbl_rank_prefix_sum,
-              int num_tokens, int hidden_int4, int num_scales, int num_topk, int num_experts,
               const bool* is_token_in_rank,
+              int num_tokens, int hidden_int4, int num_scales, int num_topk, int num_experts,
+              int scale_token_stride, int scale_hidden_stride,
               void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
               void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
               int rank, int num_ranks, bool is_cached_dispatch,
@@ -135,7 +137,7 @@ void clean_low_latency_buffer(int* clean_0, int num_clean_int_0,
                               int* clean_1, int num_clean_int_1,
                               cudaStream_t stream);
 
-void dispatch(void* packed_recv_x, float* packed_recv_x_scales,
+void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               int* packed_recv_src_info, int64_t* packed_recv_layout_range,
               int* packed_recv_count,
               int* cumulative_local_expert_recv_stats,
@@ -143,7 +145,8 @@ void dispatch(void* packed_recv_x, float* packed_recv_x_scales,
               const void* x, const int64_t* topk_idx,
               int* next_clean, int num_next_clean_int,
               int num_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
-              int num_topk, int num_experts, int rank, int num_ranks, bool use_fp8,
+              int num_topk, int num_experts, int rank, int num_ranks,
+              bool use_fp8, bool round_scale, bool use_ue8m0,
               void* workspace, int* usage_flag,
               cudaStream_t stream, int phases);
 

--- a/csrc/kernels/utils.cuh
+++ b/csrc/kernels/utils.cuh
@@ -401,6 +401,43 @@ __forceinline__ __device__ int get_lane_id() {
     return lane_id;
 }
 
+constexpr float kFP8Margin = 1e-4;
+constexpr float kFinfoAmaxE4M3 = 448.0f;
+constexpr float kFinfoAmaxInvE4M3 = 1 / 448.0f;
+
+__forceinline__ __device__ float fast_pow2(int x) {
+    // We can ensure `-126 <= x and x <= 127`
+    uint32_t bits_x = (x + 127) << 23;
+    return *reinterpret_cast<float*>(&bits_x);
+}
+
+__forceinline__ __device__ int fast_log2_ceil(float x) {
+    auto bits_x = *reinterpret_cast<uint32_t*>(&x);
+    auto exp_x = (bits_x >> 23) & 0xff;
+    auto man_bits = bits_x & ((1 << 23) - 1);
+    return exp_x - 127 + (man_bits != 0);
+}
+
+__forceinline__ __device__ void calculate_fp8_scales(float amax, float& scale, float& scale_inv, bool round_scale) {
+    if (round_scale) {
+        auto exp_scale_inv = fast_log2_ceil(amax * kFinfoAmaxInvE4M3);
+        scale = fast_pow2(-exp_scale_inv);
+        scale_inv = fast_pow2(exp_scale_inv);
+    } else {
+        scale_inv = amax * kFinfoAmaxInvE4M3;
+        scale = kFinfoAmaxE4M3 / amax;
+    }
+}
+
+template <bool kIsUE8M0, typename out_dtype_t = std::conditional_t<kIsUE8M0, uint8_t, float>>
+__forceinline__ __device__ out_dtype_t extract_required_scale_format(float value) {
+    if constexpr (kIsUE8M0) {
+        return static_cast<uint8_t>((*reinterpret_cast<uint32_t*>(&value)) >> 23);
+    } else {
+        return value;
+    }
+}
+
 template <int kNumRanks>
 __forceinline__ __device__ void
 barrier_block(int** barrier_signal_ptrs, int rank) {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,12 @@
+# Change current directory into project root
+original_dir=$(pwd)
+script_dir=$(dirname "$0")
+cd "$script_dir"
+
+# Remove old dist file, build, and install
+rm -rf dist
+python setup.py bdist_wheel
+pip install dist/*.whl
+
+# Open users' original directory
+cd "$original_dir"

--- a/tests/test_intranode.py
+++ b/tests/test_intranode.py
@@ -21,6 +21,7 @@ def test_main(num_sms: int, local_rank: int, num_ranks: int, rank: int, buffer: 
     x = torch.ones((num_tokens, hidden), dtype=torch.bfloat16, device='cuda') * rank
     x_pure_rand = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
     x_e4m3 = per_token_cast_to_fp8(x) if deep_ep.Buffer.is_sm90_compiled() else None
+    x_e4m3 = (x_e4m3[0], x_e4m3[1].T.contiguous().T) if x_e4m3 is not None else None
     scores = torch.randn((num_tokens, num_experts), dtype=torch.float32, device='cuda').abs() + 1
     topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)[1]
     topk_weights = torch.ones((num_tokens, num_topk), dtype=torch.float32, device='cuda') * rank

--- a/tests/test_low_latency.py
+++ b/tests/test_low_latency.py
@@ -34,61 +34,68 @@ def test_main(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
     hash_value, num_times = 0, 0
     for return_recv_hook in (False, True):
         for dispatch_use_fp8 in (False, True):
-            num_times += 1
-            for i in range((num_times % 2) + 1):
-                cumulative_local_expert_recv_stats = torch.zeros((num_local_experts, ), dtype=torch.int, device='cuda')
-                packed_recv_x, packed_recv_count, handle, event, hook = \
-                    buffer.low_latency_dispatch(x, topk_idx, num_tokens, num_experts, use_fp8=dispatch_use_fp8,
-                                                cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
-                                                async_finish=not return_recv_hook, return_recv_hook=return_recv_hook)
-                hook() if return_recv_hook else event.current_stream_wait()
-            packed_recv_x = (packed_recv_x[0], packed_recv_x[1].contiguous()) if dispatch_use_fp8 else packed_recv_x
-            simulated_gemm_x = per_token_cast_back(packed_recv_x[0].view(-1, hidden), packed_recv_x[1].view(-1, hidden // 128)).view(packed_recv_x[0].shape) \
-                if dispatch_use_fp8 else packed_recv_x.clone()
-            all_topk_idx = torch.empty((num_ranks, num_tokens, num_topk), dtype=topk_idx.dtype, device='cuda')
-            dist.all_gather_into_tensor(all_topk_idx, topk_idx, group=group)
-            for i in range(num_local_experts if do_check else 0):
-                expert_id = rank * num_local_experts + i
-                recv_x = per_token_cast_back(packed_recv_x[0][i], packed_recv_x[1][i]) if dispatch_use_fp8 else packed_recv_x[i]
-                recv_count, recv_src_info, recv_layout_range = packed_recv_count[i], handle[0][i], handle[1][i]
+            for round_scale in (False, True) if dispatch_use_fp8 else (False, ):
+                for use_ue8m0 in (False, True) if round_scale else (False, ):
+                    num_times += 1
+                    for i in range((num_times % 2) + 1):
+                        cumulative_local_expert_recv_stats = torch.zeros((num_local_experts, ), dtype=torch.int, device='cuda')
+                        packed_recv_x, packed_recv_count, handle, event, hook = \
+                            buffer.low_latency_dispatch(x, topk_idx, num_tokens, num_experts,
+                                                        use_fp8=dispatch_use_fp8, round_scale=round_scale, use_ue8m0=use_ue8m0,
+                                                        cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
+                                                        async_finish=not return_recv_hook, return_recv_hook=return_recv_hook)
+                        hook() if return_recv_hook else event.current_stream_wait()
+                    packed_recv_x = (packed_recv_x[0], packed_recv_x[1].contiguous()) if dispatch_use_fp8 else packed_recv_x
+                    simulated_gemm_x = per_token_cast_back(packed_recv_x[0].view(-1, hidden), packed_recv_x[1].view(-1, hidden // 128)).view(packed_recv_x[0].shape) \
+                        if dispatch_use_fp8 else packed_recv_x.clone()
+                    all_topk_idx = torch.empty((num_ranks, num_tokens, num_topk), dtype=topk_idx.dtype, device='cuda')
+                    dist.all_gather_into_tensor(all_topk_idx, topk_idx, group=group)
+                    for i in range(num_local_experts if do_check else 0):
+                        expert_id = rank * num_local_experts + i
+                        recv_x = per_token_cast_back(packed_recv_x[0][i], packed_recv_x[1][i]) if dispatch_use_fp8 else packed_recv_x[i]
+                        recv_count, recv_src_info, recv_layout_range = packed_recv_count[i], handle[0][i], handle[1][i]
 
-                # Check expert indices
-                int_mask = (2 ** 32) - 1
-                num_valid_tokens = recv_count.item()
-                assert cumulative_local_expert_recv_stats[i].item() == num_valid_tokens, f'{cumulative_local_expert_recv_stats[i].item()} != {num_valid_tokens}'
-                assert num_valid_tokens == (recv_layout_range & int_mask).sum().item(), f'{num_valid_tokens} != {recv_layout_range & int_mask}.sum().item()'
-                assert num_valid_tokens == (all_topk_idx == expert_id).sum().item(), f'{num_valid_tokens} != {(all_topk_idx == expert_id).sum().item()}'
+                        # Check expert indices
+                        int_mask = (2 ** 32) - 1
+                        num_valid_tokens = recv_count.item()
+                        assert cumulative_local_expert_recv_stats[i].item() == num_valid_tokens, f'{cumulative_local_expert_recv_stats[i].item()} != {num_valid_tokens}'
+                        assert num_valid_tokens == (recv_layout_range & int_mask).sum().item(), f'{num_valid_tokens} != {recv_layout_range & int_mask}.sum().item()'
+                        assert num_valid_tokens == (all_topk_idx == expert_id).sum().item(), f'{num_valid_tokens} != {(all_topk_idx == expert_id).sum().item()}'
 
-                # Check received data
-                recv_x = recv_x[:num_valid_tokens]
-                recv_x_amin = recv_x[:, :-128].amin(dim=-1)
-                recv_src_info = recv_src_info[:num_valid_tokens]
-                assert torch.equal(recv_x_amin, recv_x[:, :-128].amax(dim=-1))
-                assert (recv_x[:, -128:] - recv_src_info.view(-1, 1) % num_tokens).sum().item() == 0
-                for j in range(num_ranks):
-                    begin_idx, count = (recv_layout_range[j] >> 32).item(), (recv_layout_range[j] & int_mask).item()
-                    assert (recv_x_amin == j - rank_offset).sum().item() == (all_topk_idx[j] == expert_id).sum().item()
-                    assert (recv_x[begin_idx:begin_idx + count][:-128] - j).sum().item() == 0
-                if dispatch_use_fp8:
-                    hash_value ^= hash_tensor(packed_recv_x[0][i, :num_valid_tokens])
-                    hash_value ^= hash_tensor(packed_recv_x[1][i, :num_valid_tokens])
-                else:
-                    hash_value ^= hash_tensor(packed_recv_x[i, :num_valid_tokens])
+                        # Check received data
+                        recv_x = recv_x[:num_valid_tokens]
+                        recv_x_amin = recv_x[:, :-128].amin(dim=-1)
+                        recv_src_info = recv_src_info[:num_valid_tokens]
+                        assert torch.equal(recv_x_amin, recv_x[:, :-128].amax(dim=-1))
+                        if round_scale:
+                            assert calc_diff(recv_x[:, -1], recv_src_info.view(-1)) < 0.007
+                        else:
+                            assert (recv_x[:, -128:] - recv_src_info.view(-1, 1) % num_tokens).sum().item() == 0
+                        for j in range(num_ranks):
+                            begin_idx, count = (recv_layout_range[j] >> 32).item(), (recv_layout_range[j] & int_mask).item()
+                            if not round_scale:
+                                assert (recv_x_amin == j - rank_offset).sum().item() == (all_topk_idx[j] == expert_id).sum().item()
+                            assert (recv_x[begin_idx:begin_idx + count][:-128] - j).sum().item() == 0
+                        if dispatch_use_fp8:
+                            hash_value ^= hash_tensor(packed_recv_x[0][i, :num_valid_tokens])
+                            hash_value ^= hash_tensor(packed_recv_x[1][i, :num_valid_tokens])
+                        else:
+                            hash_value ^= hash_tensor(packed_recv_x[i, :num_valid_tokens])
 
-            # Check combine correctness
-            for zero_copy in (False, True):
-                if zero_copy:
-                    buffer.get_next_low_latency_combine_buffer(handle)[:, :, :] = simulated_gemm_x
-                out = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
-                combined_x, event, hook = buffer.low_latency_combine(simulated_gemm_x, topk_idx, topk_weights, handle,
-                                                                     async_finish=not return_recv_hook, zero_copy=zero_copy,
-                                                                     return_recv_hook=return_recv_hook, out=out)
-                hook() if return_recv_hook else event.current_stream_wait()
-                if do_check:
-                    diff = calc_diff(x * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(-1, 1), combined_x)
-                    assert torch.isnan(combined_x).sum().item() == 0
-                    assert diff < 1e-5, f'Error: {diff=}, {zero_copy=}'
-                    hash_value ^= hash_tensor(combined_x)
+                    # Check combine correctness
+                    for zero_copy in (False, True):
+                        if zero_copy:
+                            buffer.get_next_low_latency_combine_buffer(handle)[:, :, :] = simulated_gemm_x
+                        out = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
+                        combined_x, event, hook = buffer.low_latency_combine(simulated_gemm_x, topk_idx, topk_weights, handle,
+                                                                             async_finish=not return_recv_hook, zero_copy=zero_copy,
+                                                                             return_recv_hook=return_recv_hook, out=out)
+                        hook() if return_recv_hook else event.current_stream_wait()
+                        if do_check:
+                            diff = calc_diff(x * topk_weights.masked_fill(topk_idx == -1, 0).sum(dim=1).view(-1, 1), combined_x)
+                            assert torch.isnan(combined_x).sum().item() == 0
+                            assert diff < (7e-4 if round_scale else 1e-5), f'Error: {diff=}, {zero_copy=}'
+                            hash_value ^= hash_tensor(combined_x)
 
     def create_test_cast_with_outliers(num_outliers):
         tmp = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
@@ -112,7 +119,7 @@ def test_main(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
         recv_x, recv_count, handle, event, hook = \
             buffer.low_latency_dispatch(x, topk_idx, num_tokens, num_experts,
                                         cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
-                                        async_finish=False, return_recv_hook=return_recv_hook)
+                                        use_fp8=True, async_finish=False, return_recv_hook=return_recv_hook)
         large_gemm_with_hook(hook) if return_recv_hook else None
         if zero_copy:
             buffer.get_next_low_latency_combine_buffer(handle)[:, :, :] = simulated_gemm_x
@@ -169,6 +176,10 @@ def test_loop(local_rank: int, num_local_ranks: int):
         ref_hash = test_main(num_tokens, hidden, num_experts, num_topk, rank, num_ranks, group, buffer, seed=seed)
         for i in range(20):
             assert test_main(num_tokens, hidden, num_experts, num_topk, rank, num_ranks, group, buffer, seed=seed) == ref_hash, f'Error: seed={seed}'
+
+    # Destroy the communication group
+    dist.barrier()
+    dist.destroy_process_group()
 
 
 if __name__ == '__main__':

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,6 +43,9 @@ def per_token_cast_to_fp8(x: torch.Tensor):
 
 
 def per_token_cast_back(x_fp8: torch.Tensor, x_scales: torch.Tensor):
+    if x_scales.dtype == torch.int:
+        x_scales = x_scales.view(dtype=torch.int8).to(torch.int) << 23
+        x_scales = x_scales.view(dtype=torch.float)
     x_fp32 = x_fp8.to(torch.float32).view(x_fp8.size(0), -1, 128)
     x_scales = x_scales.view(x_fp8.size(0), -1, 1)
     return (x_fp32 * x_scales).view(x_fp8.shape).to(torch.bfloat16)


### PR DESCRIPTION
Hi DeepEP Team,
This PR is submitted by NVIDIA and introduces support for UE8M0 (unsigned 8-bit exponent, 0-bit mantissa) data format.

# Key Changes

1. **Normal Mode**:
   - Add input arguments `scale_token_stride` and `scale_hidden_stride`, which are used to calculate the scale's offset in the buffer.

2. **Low Latency Mode**:
   - Add input argument `round_scale` to indicate whether round the scaling factors into power of 2.
   - Add input argument `use_ue8m0` to indicate whether to use UE8M0 as scaling factor format (available only with `round_scale=True`).
