### PR TITLE
remove redundant variable num_scales

### DIFF
--- a/csrc/deep_ep.cpp
+++ b/csrc/deep_ep.cpp
@@ -1096,7 +1096,7 @@ Buffer::low_latency_dispatch(const torch::Tensor& x, const torch::Tensor& topk_i
     }
 
     auto num_tokens = static_cast<int>(x.size(0)), hidden = static_cast<int>(x.size(1));
-    auto num_scales = hidden / 128, num_topk = static_cast<int>(topk_idx.size(1));
+    auto num_topk = static_cast<int>(topk_idx.size(1));
     auto num_local_experts = num_experts / num_ranks;
 
     // Buffer control


### PR DESCRIPTION
Remove redundant variable `num_scales` in deep_ep.cpp .