### PR TITLE
Allow using few SMs for low-latency mode

### DIFF
--- a/csrc/kernels/internode_ll.cu
+++ b/csrc/kernels/internode_ll.cu
@@ -339,7 +339,9 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               void* workspace, int num_device_sms,
               cudaStream_t stream, int phases) {
     constexpr int kNumMaxTopK = 9;
-    const int num_warp_groups = ceil_div(num_experts, num_device_sms);
+    const int num_warp_groups = ((phases & LOW_LATENCY_RECV_PHASE) == 0)
+        ? 9
+        : ceil_div(num_experts, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;
     EP_HOST_ASSERT(num_warp_groups > 0 and num_warps_per_group > 0);
     EP_HOST_ASSERT(kNumMaxTopK + 1 <= num_warp_groups * num_warps_per_group);
@@ -548,7 +550,9 @@ void combine(void* combined_x,
              void* workspace, int num_device_sms,
              cudaStream_t stream, int phases, bool zero_copy) {
     constexpr int kNumMaxTopk = 9;
-    const int num_warp_groups = ceil_div(num_experts, num_device_sms);
+    const int num_warp_groups = ((phases & LOW_LATENCY_RECV_PHASE) == 0)
+        ? 9
+        : ceil_div(num_experts, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;
     EP_HOST_ASSERT(num_warp_groups > 0 and num_warps_per_group > 0);
 


### PR DESCRIPTION
The code diff is surely not for merging, but for demonstration how the experiments below are done. If anyone is interested / this direction looks acceptable to be merged, I am happy to polish and further work on the code!

The code and experiment data are extracted from old experiments for my previous https://github.com/deepseek-ai/DeepEP/pull/249.

Figure 1: num-sm vs performance
As can be seen, when using 9 warpgroup - ie few SMs, the performance only slightly slow down. Thus this makes a simple overlapping between this and computation feasible.

![image](https://github.com/user-attachments/assets/be50bf75-3c42-4ad4-8aec-0b9c665ebbc5)

For dispatch we may need to do extra work though, since the warp specialization may be suboptimal when there are few SMs. 