### PR TITLE
Avoid hang due to small rdma_chunk_size

### DIFF
--- a/csrc/kernels/internode.cu
+++ b/csrc/kernels/internode.cu
@@ -1770,6 +1770,7 @@ void combine(cudaDataType_t type,
     EP_HOST_ASSERT(num_forwarder_warps > NUM_MAX_NVL_PEERS and num_forwarder_warps % num_rdma_ranks == 0);
     EP_HOST_ASSERT(num_max_nvl_chunked_recv_tokens % num_rdma_ranks == 0);
     EP_HOST_ASSERT(num_max_nvl_chunked_recv_tokens / num_rdma_ranks > std::max(num_max_rdma_chunked_send_tokens, num_max_nvl_chunked_send_tokens));
+    EP_HOST_ASSERT(num_max_rdma_chunked_send_tokens >= num_warps_per_forwarder);
     EP_HOST_ASSERT(type == CUDA_R_16BF);
 
     SETUP_LAUNCH_CONFIG(num_channels * 2, (num_forwarder_warps + 1) * 32, stream);


### PR DESCRIPTION
For example, if we have two nodes, `num_warps_per_forwarder` will be 16 / 2 = 8. 

https://github.com/deepseek-ai/DeepEP/blob/e6012370b01a86e821ace99193f5d912b3f66d06/csrc/kernels/internode.cu#L1550

If `num_max_rdma_chunked_send_tokens` is 4 < 8, then `token_end_idx` - `token_start_idx` = 4, the 'forwarder_nvl_head' for subwarp 4, 5, 6, 7 will always be 0 and `min_head` in forwarder kCoordinator will always be 0. So, the `NVLSender `warp won't work after the NVL buffer is full for the first time because the head value it reads is always 0.

https://github.com/deepseek-ai/DeepEP/blob/e6012370b01a86e821ace99193f5d912b3f66d06/csrc/kernels/internode.cu#L1570-L1605