### PR TITLE
fix combined RdmaReciver return slow head

### DIFF
--- a/csrc/kernels/internode.cu
+++ b/csrc/kernels/internode.cu
@@ -1789,7 +1789,7 @@ combine(int4* combined_x, float* combined_topk_weights,
                     for (int i = 0; i < kNumRDMAReceivers; ++ i) if (not rdma_receiver_retired[i])
                         min_head = min(min_head, rdma_receiver_rdma_head[i][dst_rdma_rank]);
                     if (min_head != std::numeric_limits<int>::max() and min_head >= last_rdma_head + num_max_rdma_chunked_send_tokens and lane_id < kNumRDMARanks) {
-                        nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_head.buffer(rdma_rank), min_head - last_rdma_head,
+                        nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_head.buffer(rdma_rank), min_head - last_rdma_head + 1,
                                                         translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank), channel_id + num_channels, dst_rdma_rank == rdma_rank);
                         last_rdma_head = min_head;
                     }


### PR DESCRIPTION
internode-combined {RDMAReiciver} need return expect_head + 1,but return the min_head of rdma_receiver_rdma_head,
although this smaller head update in the response won't cause a hang, nor lead to accuracy issues, it still represents a potential bug.