### PR TITLE
fix combine timeout due to delayed forwarder min head update

### DIFF
--- a/csrc/kernels/internode.cu
+++ b/csrc/kernels/internode.cu
@@ -1654,6 +1654,7 @@ combine(int4* combined_x, float* combined_topk_weights,
                     start_time = clock64();
                     while (cached_nvl_channel_tail_idx <= expected_head) {
                         cached_nvl_channel_tail_idx = ld_acquire_sys_global(nvl_channel_tail.buffer(lane_id));
+                        if (forwarder_nvl_head[warp_id][lane_id] < expected_head) forwarder_nvl_head[warp_id][lane_id] = expected_head;
 
                         // Timeout check
                         if (clock64() - start_time > NUM_TIMEOUT_CYCLES and lane_id < NUM_MAX_NVL_PEERS) {


### PR DESCRIPTION
This PR provides a fix for #314.

The configuration that causes the combine timeout in #314 is:
num_sms = 48
nvl_chunk_size = 32
nvl_buffer_size = 80
rdma_chunk_size = 20
rdma_buffer_size = 128

In `kNVLAndRDMAForwarder`, we first read `expected_head`, then compare with the `tail`, combine the token, issue RDMA send, finally update `forwarder_nvl_head` with `expected_head + 1`, then the coordinator updates the `min_head`.

In the above configuration, a rare case will happen: in the **first** iteration of the below 'for' loop, some threads will be trapped in the while loop comparing `nvl_tail` and `nvl_head`. As we update the  `forwarder_nvl_head` at the end of the iteration, even if  `eapected_head` is larger than the `forwarder_nvl_head`, it won't get updated, same for `min_head`.

https://github.com/deepseek-ai/DeepEP/blob/26cf250a3388c770ee628d2fd0271e1c6c52157a/csrc/kernels/internode.cu#L1646-L1664

So, I just simply update `forwarder_nvl_head` with `expected_head` (not `expected_head + 1` in the fix) for the rare cases. 

Besides, for the `kRDMAReceiver`, the design is to update `rdma_receiver_rdma_head` with `expected_head`, before consuming the token. So maybe an update for `rdma_receiver_rdma_head` with `expected_head + 1` should be added after the token consuming in the last 'for' loop iteration. I guess there may be rare cases where this could potentially cause a timeout. But I haven't found a configuration for that.