### PR TITLE
fix ll test script when --num-tokens == 1

### DIFF
--- a/tests/test_low_latency.py
+++ b/tests/test_low_latency.py
@@ -77,6 +77,8 @@ def test_main(num_tokens: int, hidden: int, num_experts: int, num_topk: int,
                             assert num_valid_tokens == (recv_layout_range & int_mask).sum().item(), f'{num_valid_tokens} != {recv_layout_range & int_mask}.sum().item()'
                             assert num_valid_tokens == (all_topk_idx == expert_id).sum().item(), f'{num_valid_tokens} != {(all_topk_idx == expert_id).sum().item()}'
 
+                            if num_valid_tokens == 0:
+                                continue
                             # Check received data
                             if current_x is x:
                                 recv_x = recv_x[:num_valid_tokens]


### PR DESCRIPTION
test command:

```
NCCL_DEBUG=WARN NVSHMEM_DEBUG=WARN python3 ./tests/test_low_latency_bak.py --num-tokens 20 --hidden 2048 --num-topk 1 --num-experts 8
```


assert : `calc_diff(recv_x[:, -1], recv_src_info.view(-1))` is nan when `--num-tokens == 1`