### PR TITLE
fix potential hang in pollcq

### DIFF
--- a/csrc/kernels/ibgda_device.cuh
+++ b/csrc/kernels/ibgda_device.cuh
@@ -472,7 +472,7 @@ ibgda_poll_cq(nvshmemi_ibgda_device_cq_t *cq, uint64_t idx) {
     const auto cqe64 = static_cast<mlx5_cqe64*>(cq->cqe);
     const uint32_t ncqes = cq->ncqes;
     memory_fence_cta();
-
+    if (*cq->cons_idx >= idx) return;
     // NOTES: this while loop is part of do-while below.
     // `wqe_counter` is the HW consumer index. However, we always maintain `index + 1`.
     // To be able to compare with the index, we need to use `wqe_counter + 1`.


### PR DESCRIPTION
Hi, DeepEP will now execute pollcq before post wqe. The first time pollcq is performed, cqe is invalid (DeepEP does not check it now), but the existing logic will determine wqe_counter, when nvshmem is initialized, it will be initialized to 0xff. Therefore, when the queue depth is small, it may hang here. 

DeepEP:
```cpp
do {
        wqe_counter = HtoBE16(ld_na_relaxed(&cqe64->wqe_counter));
    } while ((static_cast<uint16_t>(static_cast<uint16_t>(idx) - wqe_counter - static_cast<uint16_t>(2)) < ncqes));
```

nvshmem:
```cpp
status = cudaMemset(cq_mobject->base.gpu_ptr, 0xff, cq_mobject->base.size);
```