### PR TITLE
Fix get_nvl_buffer_size_hint and get_rdma_buffer_size_hint

### DIFF
--- a/csrc/config.hpp
+++ b/csrc/config.hpp
@@ -59,14 +59,15 @@ struct Config {
         const int num_channels = num_sms / 2;
 
         size_t num_bytes = 0;
-        num_bytes += num_channels * num_nvl_ranks * (2 * num_rdma_ranks + 3) * sizeof(int);
+        num_bytes += num_channels * num_nvl_ranks * (2 * num_rdma_ranks + 2) * sizeof(int);
         num_bytes += num_channels * num_nvl_ranks * num_max_nvl_chunked_recv_tokens * hidden_bytes;
 #ifndef DISABLE_NVSHMEM
         num_bytes += num_channels * num_nvl_ranks * num_max_nvl_chunked_recv_tokens * internode::get_source_meta_bytes();
 #endif
-        num_bytes += num_channels * num_nvl_ranks * num_max_nvl_chunked_recv_tokens * kNumMaxTopK * sizeof(topk_idx_t);
+        num_bytes += num_channels * num_nvl_ranks * num_max_nvl_chunked_recv_tokens * kNumMaxTopK * sizeof(int);
         num_bytes += num_channels * num_nvl_ranks * num_max_nvl_chunked_recv_tokens * kNumMaxTopK * sizeof(float);
         num_bytes += num_channels * num_nvl_ranks * num_max_nvl_chunked_recv_tokens * kNumMaxScales * sizeof(float);
+        num_bytes += num_channels * num_nvl_ranks * num_max_nvl_chunked_recv_tokens * sizeof(int4);
         num_bytes = ((num_bytes + 127) / 128) * 128;
         return num_bytes;
     }
@@ -90,10 +91,11 @@ struct Config {
         num_bytes += num_channels * num_rdma_ranks * (NUM_MAX_NVL_PEERS * 2 + 2) * 2 * sizeof(int);
         num_bytes += num_channels * num_rdma_ranks * num_max_rdma_chunked_recv_tokens * hidden_bytes * 2;
         num_bytes += num_channels * num_rdma_ranks * num_max_rdma_chunked_recv_tokens * internode::get_source_meta_bytes() * 2;
-        num_bytes += num_channels * num_rdma_ranks * num_max_rdma_chunked_recv_tokens * kNumMaxTopK * sizeof(topk_idx_t) * 2;
+        num_bytes += num_channels * num_rdma_ranks * num_max_rdma_chunked_recv_tokens * kNumMaxTopK * sizeof(int) * 2;
         num_bytes += num_channels * num_rdma_ranks * num_max_rdma_chunked_recv_tokens * kNumMaxTopK * sizeof(float) * 2;
         num_bytes += num_channels * num_rdma_ranks * num_max_rdma_chunked_recv_tokens * kNumMaxScales * sizeof(float) * 2;
         num_bytes += num_channels * num_rdma_ranks * num_max_rdma_chunked_recv_tokens * sizeof(int4) * 2;
+        num_bytes += num_channels * num_rdma_ranks * 2 * sizeof(uint64_t) * 2;
         num_bytes = ((num_bytes + 127) / 128) * 128;
         return num_bytes;
 #else


### PR DESCRIPTION
If I understand correctly,
1. L62 is corresponding to https://github.com/deepseek-ai/DeepEP/blob/e02e4d2e1fbfdf09e02e870b6acc5831cbd11e39/csrc/kernels/internode.cu#L416
2. L67 is corresponding to https://github.com/deepseek-ai/DeepEP/blob/e02e4d2e1fbfdf09e02e870b6acc5831cbd11e39/csrc/kernels/internode.cu#L579-L581 , and it is also counted as `sizeof(int)` in `get_num_bytes_per_token`
3. L70 is corresponding to int4 alignment: https://github.com/deepseek-ai/DeepEP/blob/e02e4d2e1fbfdf09e02e870b6acc5831cbd11e39/csrc/kernels/internode.cu#L45-L47
4. L94 is similar to L67
5. L98 is corresponding to https://github.com/deepseek-ai/DeepEP/blob/e02e4d2e1fbfdf09e02e870b6acc5831cbd11e39/csrc/kernels/internode.cu#L417-L418

Before change:
```
>>> deep_ep.Config(24, 8, 512, 16, 128).get_nvl_buffer_size_hint(7168, 16)
453380736
>>> deep_ep.Config(24, 8, 512, 16, 128).get_rdma_buffer_size_hint(7168, 16)
56774016
```

After change:
```
>>> deep_ep.Config(24, 8, 512, 16, 128).get_nvl_buffer_size_hint(7168, 16)
429000960
>>> deep_ep.Config(24, 8, 512, 16, 128).get_rdma_buffer_size_hint(7168, 16)
53629056
```