### PR TITLE
Higher Performance with Lower SM Occupancy through Zero-Copy and TMA Offloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build/
 .cache/
 .vscode/
 */cmake-build-*/
-work_dirs/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 .cache/
 .vscode/
 */cmake-build-*/
+work_dirs/

--- a/csrc/config.hpp
+++ b/csrc/config.hpp
@@ -248,7 +248,7 @@ struct InternodeDispatchLayout {
         total_bytes += num_bytes_source_meta;
         EP_HOST_ASSERT(total_bytes % 16 == 0);
 
-        EP_HOST_ASSERT(total_bytes <= NUM_INPUT_BYTES_PER_ZCOPY_BUFFER);
+        EP_HOST_ASSERT(total_bytes <= NUM_DISPATCH_INPUT_BYTES_PER_ZCOPY_BUFFER);
 
         for (int i=0; i<num_buffers; ++i) {
             auto tmp = rdma_fused_buffer;
@@ -259,10 +259,10 @@ struct InternodeDispatchLayout {
                 with_topk ? advance_ptr<float*>(tmp, num_bytes_topk_weights) : nullptr,  // topk_weights
                 advance_ptr(tmp, num_bytes_source_meta),  // source_meta
             });
-            advance_ptr(rdma_fused_buffer, NUM_INPUT_BYTES_PER_ZCOPY_BUFFER);
+            advance_ptr(rdma_fused_buffer, NUM_DISPATCH_INPUT_BYTES_PER_ZCOPY_BUFFER);
         }
 
-        total_bytes = NUM_INPUT_BYTES_PER_ZCOPY_BUFFER * num_buffers;
+        total_bytes = NUM_DISPATCH_INPUT_BYTES_PER_ZCOPY_BUFFER * num_buffers;
     }
 };
 
@@ -293,7 +293,7 @@ struct InternodeCombineLayout {
             total_bytes += num_bytes_topk_weights;
         }
 
-        EP_HOST_ASSERT(total_bytes <= NUM_INPUT_BYTES_PER_ZCOPY_BUFFER);
+        EP_HOST_ASSERT(total_bytes <= NUM_COMBINE_INPUT_BYTES_PER_ZCOPY_BUFFER);
 
         EP_HOST_ASSERT(total_bytes % 16 == 0);
 
@@ -303,10 +303,10 @@ struct InternodeCombineLayout {
                 tmp,
                 with_topk ? advance<float*>(tmp, num_bytes_x) : nullptr
             });
-            advance_ptr(nvl_buffer, NUM_INPUT_BYTES_PER_ZCOPY_BUFFER);
+            advance_ptr(nvl_buffer, NUM_COMBINE_INPUT_BYTES_PER_ZCOPY_BUFFER);
         }
 
-        total_bytes = NUM_INPUT_BYTES_PER_ZCOPY_BUFFER * num_buffers;
+        total_bytes = NUM_COMBINE_INPUT_BYTES_PER_ZCOPY_BUFFER * num_buffers;
     }
 };
 

--- a/csrc/config.hpp
+++ b/csrc/config.hpp
@@ -213,7 +213,7 @@ size_t get_low_latency_rdma_size_hint(int num_max_dispatch_tokens_per_rank, int 
 struct InternodeDispatchBuffer {
     void* x = nullptr;
     float* x_scales = nullptr;
-    int64_t* topk_idx = nullptr;
+    topk_idx_t* topk_idx = nullptr;
     float* topk_weights = nullptr;
     void* source_meta = nullptr;
 };
@@ -243,7 +243,7 @@ struct InternodeDispatchLayout {
         }
 
         if (with_topk) {
-            num_bytes_topk_idx = num_tokens * num_topk * sizeof(int64_t);
+            num_bytes_topk_idx = num_tokens * num_topk * sizeof(topk_idx_t);
             total_bytes += num_bytes_topk_idx;
 
             num_bytes_topk_weights = num_tokens * num_topk * sizeof(float);
@@ -261,7 +261,7 @@ struct InternodeDispatchLayout {
             buffers.push_back({
                 advance_ptr(tmp, num_bytes_x),  // x
                 use_fp8 ? advance_ptr<float*>(tmp, num_bytes_x_scales) : nullptr,  // x_scales
-                with_topk ? advance_ptr<int64_t*>(tmp, num_bytes_topk_idx) : nullptr,  // topk_idx
+                with_topk ? advance_ptr<topk_idx_t*>(tmp, num_bytes_topk_idx) : nullptr,  // topk_idx
                 with_topk ? advance_ptr<float*>(tmp, num_bytes_topk_weights) : nullptr,  // topk_weights
                 advance_ptr(tmp, num_bytes_source_meta),  // source_meta
             });

--- a/csrc/config.hpp
+++ b/csrc/config.hpp
@@ -69,7 +69,10 @@ struct Config {
         size_t num_bytes = 0;
         if (zero_copy) {
             num_bytes += ZCOPY_NOTIFY_NVL_METADATA_OFFSET_INTS * sizeof(int);
-            num_bytes += num_channels * num_nvl_ranks * 1 * sizeof(int);
+            num_bytes += std::max(
+                num_channels * num_nvl_ranks * (2 * num_rdma_ranks + 2) * sizeof(int), // Dispatch
+                num_channels * num_nvl_ranks * 1 * sizeof(int) // Combine
+            );
             return num_bytes;
         }
         num_bytes += num_channels * num_nvl_ranks * (2 * num_rdma_ranks + 3) * sizeof(int);

--- a/csrc/deep_ep.cpp
+++ b/csrc/deep_ep.cpp
@@ -1518,7 +1518,7 @@ Buffer::get_internode_dispatch_buffer(int num_tokens, int hidden, int num_topk, 
 
     auto x = use_fp8 ? torch::from_blob(buffer.x, {num_tokens, hidden}, torch::TensorOptions().dtype(torch::kFloat8_e4m3fn).device(torch::kCUDA)) : torch::from_blob(buffer.x, {num_tokens, hidden}, torch::TensorOptions().dtype(torch::kBFloat16).device(torch::kCUDA));
     auto x_scales = use_fp8 ? std::make_optional(torch::from_blob(buffer.x_scales, {num_tokens, hidden / 128}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA))) : std::optional<torch::Tensor>();
-    auto topk_idx = with_topk ? std::make_optional(torch::from_blob(buffer.topk_idx, {num_tokens, num_topk}, torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA))) : std::optional<torch::Tensor>();
+    auto topk_idx = with_topk ? std::make_optional(torch::from_blob(buffer.topk_idx, {num_tokens, num_topk}, torch::TensorOptions().dtype(c10::CppTypeToScalarType<deep_ep::topk_idx_t>::value).device(torch::kCUDA))) : std::optional<torch::Tensor>();
     auto topk_weights = with_topk ? std::make_optional(torch::from_blob(buffer.topk_weights, {num_tokens, num_topk}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA))) : std::optional<torch::Tensor>();
 
     return {x, x_scales, topk_idx, topk_weights};

--- a/csrc/deep_ep.hpp
+++ b/csrc/deep_ep.hpp
@@ -35,7 +35,8 @@ private:
     void* buffer_ptrs[NUM_MAX_NVL_PEERS] = {nullptr};
     void** buffer_ptrs_gpu = nullptr;
 
-    // For zero-copy send/recv
+    // For zero-copy NVLink send/recv
+    int64_t buffer_fused_bytes;
     void* buffer_fused_ptrs[NUM_MAX_NVL_PEERS] = {nullptr};
     void** buffer_fused_ptrs_gpu = nullptr;
 
@@ -44,7 +45,7 @@ private:
     void* rdma_buffer_ptr = nullptr;
     void* rdma_fused_buffer_ptr = nullptr;
 
-    // Splitting buffers for multi-batch overlapping
+    // Splitting zero-copy buffers for multi-batch overlapping
     int num_zcopy_buffers;
 
     // Shrink mode buffer

--- a/csrc/kernels/CMakeLists.txt
+++ b/csrc/kernels/CMakeLists.txt
@@ -15,7 +15,8 @@ add_deep_ep_library(runtime_cuda runtime.cu)
 add_deep_ep_library(layout_cuda layout.cu)
 add_deep_ep_library(intranode_cuda intranode.cu)
 add_deep_ep_library(internode_cuda internode.cu)
+add_deep_ep_library(internode_zcopy_cuda internode_zcopy.cu)
 add_deep_ep_library(internode_ll_cuda internode_ll.cu)
 
 # Later, we should link all libraries in `EP_CUDA_LIBRARIES`
-set(EP_CUDA_LIBRARIES runtime_cuda layout_cuda intranode_cuda internode_cuda internode_ll_cuda PARENT_SCOPE)
+set(EP_CUDA_LIBRARIES runtime_cuda layout_cuda intranode_cuda internode_cuda internode_zcopy_cuda internode_ll_cuda PARENT_SCOPE)

--- a/csrc/kernels/api.cuh
+++ b/csrc/kernels/api.cuh
@@ -113,7 +113,7 @@ void dispatch(void* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, flo
               void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
               void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
               int rank, int num_ranks, bool is_cached_dispatch,
-              bool zero_copy,
+              bool zero_copy, int num_zcopy_buffers, int zcopy_buffer_id,
               cudaStream_t stream, int num_channels, bool low_latency_mode);
 
 void cached_notify(int hidden_int4, int num_scales, int num_topk_idx, int num_topk_weights,
@@ -136,7 +136,7 @@ void combine(cudaDataType_t type,
              int num_tokens, int num_combined_tokens, int hidden, int num_topk,
              void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
              void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
-             int rank, int num_ranks, bool zero_copy, cudaStream_t stream, int num_channels, bool low_latency_mode);
+             int rank, int num_ranks, bool zero_copy, int zcopy_buffer_id, cudaStream_t stream, int num_channels, bool low_latency_mode);
 
 } // namespace internode
 
@@ -164,7 +164,7 @@ void dispatch(void* recv_x, float* recv_x_scales, int64_t* recv_topk_idx, float*
               const bool* is_token_in_rank,
               int num_tokens, int hidden_int4, int num_scales, int num_topk, int num_experts,
               void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
-              void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
+              void** buffer_fused_ptrs, void** buffer_ptrs, int num_zcopy_buffers, int buffer_id, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
               int rank, int num_ranks, bool is_cached_dispatch,
               cudaStream_t stream, int num_channels, bool low_latency_mode);
 
@@ -178,7 +178,7 @@ void combine(cudaDataType_t type,
              const int* recv_gbl_rank_prefix_sum_fwd,
              int num_tokens, int num_combined_tokens, int hidden, int num_topk,
              void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
-             void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
+             void** buffer_fused_ptrs, void** buffer_ptrs, int buffer_id, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
              int rank, int num_ranks, cudaStream_t stream, int num_channels, bool low_latency_mode);
 
 } // namespace internode_zcopy

--- a/csrc/kernels/api.cuh
+++ b/csrc/kernels/api.cuh
@@ -154,8 +154,8 @@ std::pair<int, int> get_rdma_clean_meta(int hidden_int4, int num_scales, int num
                                         int num_topk_weights, int num_rdma_ranks, int num_rdma_recv_buffer_tokens,
                                         int num_channels, bool is_dispatch);
 
-void dispatch(void* recv_x, float* recv_x_scales, int64_t* recv_topk_idx, float* recv_topk_weights, void* recv_src_meta,
-              const void* x, const float* x_scales, const int64_t* topk_idx, const float* topk_weights,
+void dispatch(void* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, float* recv_topk_weights, void* recv_src_meta,
+              const void* x, const float* x_scales, const topk_idx_t* topk_idx, const float* topk_weights,
               int* send_rdma_head, int* send_nvl_head,
               int* recv_rdma_channel_prefix_matrix, int* recv_gbl_channel_prefix_matrix,
               const int* rdma_channel_prefix_matrix, const int* recv_rdma_rank_prefix_sum,

--- a/csrc/kernels/buffer.cuh
+++ b/csrc/kernels/buffer.cuh
@@ -11,11 +11,11 @@ private:
     uint8_t* ptr;
 
 public:
-    int total_bytes;
+    uint32_t total_bytes;
 
     __device__ __forceinline__ Buffer() : ptr(nullptr), total_bytes(0) {}
 
-    __device__ __forceinline__ Buffer(void* &gbl_ptr, int num_elems, int offset = 0) {
+    __device__ __forceinline__ Buffer(void* &gbl_ptr, uint32_t num_elems, uint32_t offset = 0) {
         total_bytes = num_elems * sizeof(dtype_t);
         ptr = reinterpret_cast<uint8_t*>(gbl_ptr) + offset * sizeof(dtype_t);
         gbl_ptr = reinterpret_cast<uint8_t*>(gbl_ptr) + total_bytes;
@@ -30,47 +30,47 @@ public:
         return reinterpret_cast<dtype_t*>(ptr);
     }
 
-    __device__ __forceinline__ dtype_t& operator[](int idx) {
+    __device__ __forceinline__ dtype_t& operator[](uint32_t idx) {
         return buffer()[idx];
     }
 };
 
-template <typename dtype_t, int kNumRanks = 1>
+template <typename dtype_t, uint32_t kNumRanks = 1>
 struct AsymBuffer {
 private:
     uint8_t* ptrs[kNumRanks];
-    int num_bytes;
+    uint32_t num_bytes;
 
 public:
-    int total_bytes;
+    uint32_t total_bytes;
 
-    __device__ __forceinline__ AsymBuffer(void* &gbl_ptr, int num_elems, int num_ranks,
-                                          int sm_id = 0, int num_sms = 1, int offset = 0) {
+    __device__ __forceinline__ AsymBuffer(void* &gbl_ptr, uint32_t num_elems, uint32_t num_ranks,
+                                          uint32_t sm_id = 0, uint32_t num_sms = 1, uint32_t offset = 0) {
         EP_STATIC_ASSERT(kNumRanks == 1, "");
         num_bytes = num_elems * sizeof(dtype_t);
 
-        int per_channel_bytes = num_bytes * num_ranks;
+        uint32_t per_channel_bytes = num_bytes * num_ranks;
         total_bytes = per_channel_bytes * num_sms;
         ptrs[0] = reinterpret_cast<uint8_t*>(gbl_ptr) + per_channel_bytes * sm_id + num_bytes * offset;
         gbl_ptr = reinterpret_cast<uint8_t*>(gbl_ptr) + total_bytes;
     }
 
-    __device__ __forceinline__ AsymBuffer(void** gbl_ptrs, int num_elems, int num_ranks,
-                                          int sm_id = 0, int num_sms = 1, int offset = 0) {
+    __device__ __forceinline__ AsymBuffer(void** gbl_ptrs, uint32_t num_elems, uint32_t num_ranks,
+                                          uint32_t sm_id = 0, uint32_t num_sms = 1, uint32_t offset = 0) {
         EP_STATIC_ASSERT(kNumRanks > 1, "");
         num_bytes = num_elems * sizeof(dtype_t);
 
-        int per_channel_bytes = num_bytes * num_ranks;
+        uint32_t per_channel_bytes = num_bytes * num_ranks;
         total_bytes = per_channel_bytes * num_sms;
-        for (int i = 0; i < kNumRanks; ++ i) {
+        for (uint32_t i = 0; i < kNumRanks; ++ i) {
             ptrs[i] = reinterpret_cast<uint8_t*>(gbl_ptrs[i]) + per_channel_bytes * sm_id + num_bytes * offset;
             gbl_ptrs[i] = reinterpret_cast<uint8_t*>(gbl_ptrs[i]) + total_bytes;
         }
     }
 
-    __device__ __forceinline__ void advance(int shift) {
+    __device__ __forceinline__ void advance(uint32_t shift) {
         #pragma unroll
-        for (int i = 0; i < kNumRanks; ++ i)
+        for (uint32_t i = 0; i < kNumRanks; ++ i)
             ptrs[i] = ptrs[i] + shift * sizeof(dtype_t);
     }
 
@@ -79,19 +79,19 @@ public:
         return *this;
     }
 
-    template<int kNumAlsoRanks>
+    template<uint32_t kNumAlsoRanks>
     __device__ __forceinline__ AsymBuffer advance_also(void** gbl_ptrs) {
-        for (int i = 0; i < kNumAlsoRanks; ++ i)
+        for (uint32_t i = 0; i < kNumAlsoRanks; ++ i)
             gbl_ptrs[i] = reinterpret_cast<uint8_t*>(gbl_ptrs[i]) + total_bytes;
         return *this;
     }
 
-    __device__ __forceinline__ dtype_t* buffer(int idx = 0) {
+    __device__ __forceinline__ dtype_t* buffer(uint32_t idx = 0) {
         EP_STATIC_ASSERT(kNumRanks == 1, "`buffer` is only available for single rank case");
         return reinterpret_cast<dtype_t*>(ptrs[0] + num_bytes * idx);
     }
 
-    __device__ __forceinline__ dtype_t* buffer_by(int rank_idx, int idx = 0) {
+    __device__ __forceinline__ dtype_t* buffer_by(uint32_t rank_idx, uint32_t idx = 0) {
         EP_STATIC_ASSERT(kNumRanks > 1, "`buffer` is only available for single rank case");
         return reinterpret_cast<dtype_t*>(ptrs[rank_idx] + num_bytes * idx);
     }
@@ -103,33 +103,33 @@ private:
     // NOTES: for non-decoupled case, `recv_ptr` is not used
     uint8_t* send_ptr;
     uint8_t* recv_ptr;
-    int num_bytes;
+    uint32_t num_bytes;
 
 public:
-    int total_bytes;
+    uint32_t total_bytes;
 
-    __device__ __forceinline__ SymBuffer(void* &gbl_ptr, int num_elems, int num_ranks,
-                                         int sm_id = 0, int num_sms = 1) {
+    __device__ __forceinline__ SymBuffer(void* &gbl_ptr, uint32_t num_elems, uint32_t num_ranks,
+                                         uint32_t sm_id = 0, uint32_t num_sms = 1) {
         num_bytes = num_elems * sizeof(dtype_t);
 
-        int per_channel_bytes = num_bytes * num_ranks;
+        uint32_t per_channel_bytes = num_bytes * num_ranks;
         total_bytes = per_channel_bytes * num_sms * (static_cast<int>(kDecoupled) + 1);
         send_ptr = reinterpret_cast<uint8_t*>(gbl_ptr) + per_channel_bytes * sm_id;
         recv_ptr = reinterpret_cast<uint8_t*>(gbl_ptr) + per_channel_bytes * (sm_id + num_sms);
         gbl_ptr = reinterpret_cast<uint8_t*>(gbl_ptr) + total_bytes;
     }
 
-    __device__ __forceinline__ dtype_t* send_buffer(int idx = 0) {
+    __device__ __forceinline__ dtype_t* send_buffer(uint32_t idx = 0) {
         EP_STATIC_ASSERT(kDecoupled, "`send_buffer` is only available for non-decoupled case");
         return reinterpret_cast<dtype_t*>(send_ptr + num_bytes * idx);
     }
 
-    __device__ __forceinline__ dtype_t* recv_buffer(int idx = 0) {
+    __device__ __forceinline__ dtype_t* recv_buffer(uint32_t idx = 0) {
         EP_STATIC_ASSERT(kDecoupled, "`recv_buffer` is only available for non-decoupled case");
         return reinterpret_cast<dtype_t*>(recv_ptr + num_bytes * idx);
     }
 
-    __device__ __forceinline__ dtype_t* buffer(int idx = 0) {
+    __device__ __forceinline__ dtype_t* buffer(uint32_t idx = 0) {
         EP_STATIC_ASSERT(not kDecoupled, "`buffer` is only available for decoupled case");
         return reinterpret_cast<dtype_t*>(send_ptr + num_bytes * idx);
     }

--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -5,6 +5,14 @@
 #define NUM_WORKSPACE_BYTES (32 * 1024 * 1024)
 #define NUM_MAX_LOCAL_EXPERTS 1024
 #define NUM_BUFFER_ALIGNMENT_BYTES 128
+// TODO: Zero-copy: Make these configurable options
+#define NUM_OUTPUT_BUFFER_BYTES (4096 * 8192 * 2)
+#define NUM_MAX_SGE_PER_WQE 60 // The DS field of WQE is only 6 bits; 2^6 - 1 = 63
+#define NUM_MAX_ZCOPY_DISPATCH_TOKENS 32768
+// In the zero-copy variants of internode kernels, the kernel itself uses very little NVL buffer.
+// So we reserve this (heuristically large-enough) length of memory for the dispatch/combine
+// kernels and use the following space for metadata sync in notify.
+#define ZCOPY_NOTIFY_NVL_METADATA_OFFSET_INTS 65536
 
 #define FINISHED_SUM_TAG 1024
 #define NUM_WAIT_NANOSECONDS 500

--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -6,14 +6,16 @@
 #define NUM_MAX_LOCAL_EXPERTS 1024
 #define NUM_BUFFER_ALIGNMENT_BYTES 128
 // TODO: Zero-copy: Make these configurable options
-#define NUM_OUTPUT_BUFFER_BYTES (4096 * 8192 * 2)
 #define NUM_MAX_SGE_PER_WQE 60 // The DS field of WQE is only 6 bits; 2^6 - 1 = 63
-#define NUM_MAX_ZCOPY_DISPATCH_TOKENS 32768
 // In the zero-copy variants of internode kernels, the kernel itself uses very little NVL buffer.
 // So we reserve this (heuristically large-enough) length of memory for the dispatch/combine
 // kernels and use the following space for metadata sync in notify.
 #define ZCOPY_NOTIFY_NVL_METADATA_OFFSET_INTS 65536
 #define ZCOPY_TMA_SMEM_ALIGNMENT 1024
+#define NUM_MAX_ZCOPY_DISPATCH_TOKENS 4096
+// Zero-copy: for the 8-of-256 experts case, *8 is no smaller than the average recv count.
+#define NUM_OUTPUT_BYTES_PER_ZCOPY_BUFFER ((unsigned long)NUM_MAX_ZCOPY_DISPATCH_TOKENS * 16384 * 8)
+#define NUM_INPUT_BYTES_PER_ZCOPY_BUFFER ((unsigned long)NUM_MAX_ZCOPY_DISPATCH_TOKENS * 16384 * 8)
 
 #define FINISHED_SUM_TAG 1024
 #define NUM_WAIT_NANOSECONDS 500

--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -13,6 +13,7 @@
 // So we reserve this (heuristically large-enough) length of memory for the dispatch/combine
 // kernels and use the following space for metadata sync in notify.
 #define ZCOPY_NOTIFY_NVL_METADATA_OFFSET_INTS 65536
+#define ZCOPY_TMA_SMEM_ALIGNMENT 1024
 
 #define FINISHED_SUM_TAG 1024
 #define NUM_WAIT_NANOSECONDS 500

--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -5,7 +5,7 @@
 #define NUM_WORKSPACE_BYTES (32 * 1024 * 1024)
 #define NUM_MAX_LOCAL_EXPERTS 1024
 #define NUM_BUFFER_ALIGNMENT_BYTES 128
-// TODO: Zero-copy: Make these configurable options
+// TODO: Zero-copy: Make these runtime configurable options
 #define NUM_MAX_SGE_PER_WQE 60 // The DS field of WQE is only 6 bits; 2^6 - 1 = 63
 // In the zero-copy variants of internode kernels, the kernel itself uses very little NVL buffer.
 // So we reserve this (heuristically large-enough) length of memory for the dispatch/combine
@@ -14,8 +14,13 @@
 #define ZCOPY_TMA_SMEM_ALIGNMENT 1024
 #define NUM_MAX_ZCOPY_DISPATCH_TOKENS 4096
 // Zero-copy: for the 8-of-256 experts case, *8 is no smaller than the average recv count.
-#define NUM_OUTPUT_BYTES_PER_ZCOPY_BUFFER ((unsigned long)NUM_MAX_ZCOPY_DISPATCH_TOKENS * 16384 * 8)
-#define NUM_INPUT_BYTES_PER_ZCOPY_BUFFER ((unsigned long)NUM_MAX_ZCOPY_DISPATCH_TOKENS * 16384 * 8)
+#define NUM_DISPATCH_INPUT_BYTES_PER_ZCOPY_BUFFER ((unsigned long)NUM_MAX_ZCOPY_DISPATCH_TOKENS * 16384)
+#define NUM_DISPATCH_OUTPUT_BYTES_PER_ZCOPY_BUFFER ((unsigned long)NUM_MAX_ZCOPY_DISPATCH_TOKENS * 16384 * 8)
+#define NUM_COMBINE_INPUT_BYTES_PER_ZCOPY_BUFFER ((unsigned long)NUM_MAX_ZCOPY_DISPATCH_TOKENS * 16384 * 8)
+static_assert(NUM_DISPATCH_INPUT_BYTES_PER_ZCOPY_BUFFER % NUM_BUFFER_ALIGNMENT_BYTES == 0 and
+    NUM_DISPATCH_OUTPUT_BYTES_PER_ZCOPY_BUFFER % NUM_BUFFER_ALIGNMENT_BYTES == 0 and
+    NUM_COMBINE_INPUT_BYTES_PER_ZCOPY_BUFFER % NUM_BUFFER_ALIGNMENT_BYTES == 0,
+    "Zero-copy buffer sizes are not properly aligned");
 
 #define FINISHED_SUM_TAG 1024
 #define NUM_WAIT_NANOSECONDS 500

--- a/csrc/kernels/internode.cu
+++ b/csrc/kernels/internode.cu
@@ -1053,8 +1053,9 @@ void dispatch(void* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, flo
               void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
               void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
               int rank, int num_ranks, bool is_cached_dispatch,
-              bool zero_copy,
+              bool zero_copy, int num_zcopy_buffers, int zcopy_buffer_id,
               cudaStream_t stream, int num_channels, bool low_latency_mode) {
+    // TODO: Zero-copy: move this into zcopy.cu
     if (zero_copy) {
         // TODO: Zero-copy: Support ue8m0 scenario
         EP_HOST_ASSERT((scale_token_stride == num_scales and scale_hidden_stride == 1) or (scale_token_stride == 0 and scale_hidden_stride == 0));
@@ -1069,7 +1070,7 @@ void dispatch(void* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, flo
             is_token_in_rank,
             num_tokens, hidden_int4, num_scales, num_topk, num_experts,
             rdma_buffer_ptr, num_max_rdma_chunked_send_tokens, num_max_rdma_chunked_recv_tokens,
-            buffer_fused_ptrs, buffer_ptrs, num_max_nvl_chunked_send_tokens, num_max_nvl_chunked_recv_tokens,
+            buffer_fused_ptrs, buffer_ptrs, num_zcopy_buffers, zcopy_buffer_id, num_max_nvl_chunked_send_tokens, num_max_nvl_chunked_recv_tokens,
             rank, num_ranks, is_cached_dispatch,
             stream, num_channels, low_latency_mode
         );
@@ -1906,7 +1907,7 @@ void combine(cudaDataType_t type,
              int num_tokens, int num_combined_tokens, int hidden, int num_topk,
              void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
              void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
-             int rank, int num_ranks, bool zero_copy, cudaStream_t stream, int num_channels, bool low_latency_mode) {
+             int rank, int num_ranks, bool zero_copy, int zcopy_buffer_id, cudaStream_t stream, int num_channels, bool low_latency_mode) {
     if (zero_copy) {
         return internode_zcopy::combine(
             type, combined_x, combined_topk_weights,
@@ -1918,7 +1919,7 @@ void combine(cudaDataType_t type,
             recv_gbl_rank_prefix_sum_fwd,
             num_tokens, num_combined_tokens, hidden, num_topk,
             rdma_buffer_ptr, num_max_rdma_chunked_send_tokens, num_max_rdma_chunked_recv_tokens,
-            buffer_fused_ptrs, buffer_ptrs, num_max_nvl_chunked_send_tokens, num_max_nvl_chunked_recv_tokens,
+            buffer_fused_ptrs, buffer_ptrs, zcopy_buffer_id, num_max_nvl_chunked_send_tokens, num_max_nvl_chunked_recv_tokens,
             rank, num_ranks, stream, num_channels, low_latency_mode
         );
     }

--- a/csrc/kernels/internode.cu
+++ b/csrc/kernels/internode.cu
@@ -1055,7 +1055,6 @@ void dispatch(void* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, flo
               int rank, int num_ranks, bool is_cached_dispatch,
               bool zero_copy, int num_zcopy_buffers, int zcopy_buffer_id,
               cudaStream_t stream, int num_channels, bool low_latency_mode) {
-    // TODO: Zero-copy: move this into zcopy.cu
     if (zero_copy) {
         // TODO: Zero-copy: Support ue8m0 scenario
         EP_HOST_ASSERT((scale_token_stride == num_scales and scale_hidden_stride == 1) or (scale_token_stride == 0 and scale_hidden_stride == 0));

--- a/csrc/kernels/internode_zcopy.cu
+++ b/csrc/kernels/internode_zcopy.cu
@@ -1,0 +1,1186 @@
+#include "configs.cuh"
+#include "api.cuh"
+#include "buffer.cuh"
+#include "exception.cuh"
+#include "launch.cuh"
+#include "utils.cuh"
+#include "ibgda_device.cuh"
+
+namespace deep_ep {
+
+namespace internode {
+
+extern nvshmem_team_t cpu_rdma_team;
+
+}
+
+namespace internode_zcopy {
+
+// TODO: Zero-copy: Eliminate duplicate definitions...
+struct SourceMeta {
+    int src_rdma_rank, is_token_in_nvl_rank_bits;
+    int token_idx; // Used in local token dispatch as an indirect reference to the original token
+    int dummy;
+
+    EP_STATIC_ASSERT(NUM_MAX_NVL_PEERS == 8, "Invalid number of maximum NVL peers");
+
+    __forceinline__ SourceMeta() = default;
+
+    // TODO: faster encoding
+    __device__ __forceinline__ SourceMeta(int rdma_rank, const bool* is_token_in_nvl_ranks, int token_idx = 0) {
+        src_rdma_rank = rdma_rank;
+        is_token_in_nvl_rank_bits = is_token_in_nvl_ranks[0];
+        this->token_idx = token_idx;
+        #pragma unroll
+        for (int i = 1; i < NUM_MAX_NVL_PEERS; ++ i)
+            is_token_in_nvl_rank_bits |= is_token_in_nvl_ranks[i] << i;
+    }
+
+    __device__ __forceinline__ bool is_token_in_nvl_rank(int nvl_rank) const {
+        return (is_token_in_nvl_rank_bits >> nvl_rank) & 1;
+    }
+};
+
+EP_STATIC_ASSERT(sizeof(SourceMeta) == get_source_meta_bytes(), "Invalid size of `SourceMeta`");
+
+// TODO: Zero-copy: Eliminate duplicate definitions...
+template<int SourceMetaBytes = sizeof(SourceMeta)>
+__host__ __device__ __forceinline__
+int get_num_bytes_per_token(int hidden_int4, int num_scales, int num_topk_idx, int num_topk_weights) {
+    return static_cast<int>(align_up(hidden_int4 * sizeof(int4) + SourceMetaBytes + num_scales * sizeof(float) + num_topk_idx * sizeof(topk_idx_t) + num_topk_weights * sizeof(float), sizeof(int4)));
+}
+
+__host__ __device__
+std::pair<int, int> get_rdma_clean_meta(int hidden_int4, int num_scales, int num_topk_idx,
+                                        int num_topk_weights, int num_rdma_ranks, int num_rdma_recv_buffer_tokens,
+                                        int num_channels, bool is_dispatch) {
+    if (is_dispatch) {
+        return {
+            get_num_bytes_per_token<get_source_meta_bytes()>(hidden_int4, num_scales, num_topk_idx, num_topk_weights) * num_rdma_recv_buffer_tokens * num_rdma_ranks * 1 * num_channels / sizeof(int) + // recv buffer
+            get_source_meta_bytes() * ceil_div(NUM_MAX_ZCOPY_DISPATCH_TOKENS, num_channels) * num_rdma_ranks * 1 * num_channels / sizeof(int), // send buffer for SourceMeta
+            (NUM_MAX_NVL_PEERS * 2 + 2) * num_rdma_ranks * 2 * num_channels + // meta
+            3 * num_rdma_ranks * 1 * num_channels * sizeof(uint64_t) / sizeof(int) // head & tail & recv finish signal
+        };
+    }
+    return {
+        get_num_bytes_per_token<get_source_meta_bytes()>(hidden_int4, num_scales, num_topk_idx, num_topk_weights) * num_rdma_recv_buffer_tokens * num_rdma_ranks * 2 * num_channels / sizeof(int), // recv buffer
+        2 * num_rdma_ranks * 1 * num_channels * sizeof(uint64_t) / sizeof(int) // head & tail
+    };
+}
+
+template <bool kLowLatencyMode>
+__forceinline__ __device__ int translate_dst_rdma_rank(const int dst_rdma_rank, const int nvl_rank) {
+    return kLowLatencyMode ? (dst_rdma_rank * NUM_MAX_NVL_PEERS + nvl_rank) : dst_rdma_rank;
+}
+
+template <bool kLowLatencyMode>
+__forceinline__ __device__ void nvshmem_barrier_with_same_gpu_idx(const nvshmem_team_t& rdma_team) {
+    kLowLatencyMode ? void(nvshmem_barrier(rdma_team)) : nvshmem_barrier_all();
+}
+
+// At most 8 RDMA ranks to be sent
+constexpr int get_num_topk_rdma_ranks(int num_rdma_ranks) {
+    return num_rdma_ranks < 8 ? num_rdma_ranks : 8;
+}
+
+template <bool kLowLatencyMode, int kNumRDMARanks, bool kCachedMode,
+          size_t kNvlFwdTMASMemLen,
+          int kNumDispatchRDMASenderWarps, int kNumTopkRDMARanks = get_num_topk_rdma_ranks(kNumRDMARanks)>
+__global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 2 + NUM_MAX_NVL_PEERS) * 32), 1)  // 2 + 1 + 1 + 8 = 12
+dispatch(int4* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, float* recv_topk_weights, SourceMeta* recv_src_meta,
+         const int4* x, const float* x_scales, const topk_idx_t* topk_idx, const float* topk_weights,
+         int* send_rdma_head, int* send_nvl_head,
+         int* recv_rdma_channel_prefix_matrix, int* recv_gbl_channel_prefix_matrix,
+         const int* rdma_channel_prefix_matrix, const int* recv_rdma_rank_prefix_sum,
+         const int* gbl_channel_prefix_matrix, const int* recv_gbl_rank_prefix_sum,
+         const int* recv_gbl_rank_prefix_sum_fwd,
+         const bool* is_token_in_rank,
+         int num_tokens, int hidden_int4, int num_scales, int num_topk, int num_experts,
+         void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
+         void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
+         int rank, int num_ranks) {
+    enum class WarpRole {
+        kRDMASender,
+        kRDMAAndNVLForwarder,
+        kForwarderCoordinator,
+        kNVLReceivers
+    };
+
+    const auto sm_id = static_cast<int>(blockIdx.x);
+    const auto num_threads = static_cast<int>(blockDim.x), num_warps = num_threads / 32;
+    const auto thread_id = static_cast<int>(threadIdx.x), warp_id = thread_id / 32, lane_id = get_lane_id();
+    const auto num_channels = static_cast<int>(gridDim.x), channel_id = sm_id;
+    const auto rdma_rank = rank / NUM_MAX_NVL_PEERS, nvl_rank = rank % NUM_MAX_NVL_PEERS;
+
+    const auto role_meta = [=]() -> std::pair<WarpRole, int> {
+        if (warp_id < kNumDispatchRDMASenderWarps) {
+            return {WarpRole::kRDMASender, -1};
+        } else if (warp_id == kNumDispatchRDMASenderWarps) {
+            return {WarpRole::kNVLReceivers, -1};
+        } else if (warp_id == kNumDispatchRDMASenderWarps + 1) {
+            return {WarpRole::kForwarderCoordinator, -1};
+        } else {
+            return {WarpRole::kRDMAAndNVLForwarder, (warp_id + channel_id - kNumDispatchRDMASenderWarps - 2) % NUM_MAX_NVL_PEERS};
+        }
+    }();
+    auto warp_role = role_meta.first;
+    auto target_rank = role_meta.second; // Not applicable for RDMA senders and NVL receivers
+    EP_DEVICE_ASSERT(num_warps == kNumDispatchRDMASenderWarps + 2 + NUM_MAX_NVL_PEERS);
+
+    // Data checks
+    EP_DEVICE_ASSERT(num_topk <= 32);
+
+    // RDMA symmetric layout
+    EP_STATIC_ASSERT(NUM_MAX_NVL_PEERS * sizeof(bool) == sizeof(uint64_t), "Invalid number of NVL peers");
+    auto hidden_bytes = hidden_int4 * sizeof(int4);
+    auto num_bytes_per_rdma_token = get_num_bytes_per_token(hidden_int4, num_scales, num_topk, num_topk);
+
+    // TODO: Zero-copy: The RDMA data buffer for myself is unused now; can try to save this memory
+    auto rdma_channel_data = SymBuffer<int8_t, false>(rdma_buffer_ptr, num_max_rdma_chunked_recv_tokens * num_bytes_per_rdma_token, kNumRDMARanks, channel_id, num_channels);
+    EP_DEVICE_ASSERT(num_tokens <= NUM_MAX_ZCOPY_DISPATCH_TOKENS);
+    auto rdma_channel_src_meta = SymBuffer<SourceMeta, false>(rdma_buffer_ptr, ceil_div(NUM_MAX_ZCOPY_DISPATCH_TOKENS, num_channels), kNumRDMARanks, channel_id, num_channels);
+    auto rdma_channel_meta = SymBuffer<int>(rdma_buffer_ptr, NUM_MAX_NVL_PEERS * 2 + 2, kNumRDMARanks, channel_id, num_channels);
+    auto rdma_channel_head = SymBuffer<uint64_t, false>(rdma_buffer_ptr, 1, kNumRDMARanks, channel_id, num_channels);
+    auto rdma_channel_tail = SymBuffer<uint64_t, false>(rdma_buffer_ptr, 1, kNumRDMARanks, channel_id, num_channels);
+    // Each element indicates the RDMA rank has finished receiving (1) or not (0)
+    // TODO: We can replace this with polling CQ
+    auto rdma_channel_recv_finish_signal = SymBuffer<uint64_t, false>(rdma_buffer_ptr, 1, kNumRDMARanks, channel_id, num_channels);
+
+    // NVL buffer layouts
+    // NOTES: `rs_wr_buffer_ptr` means "Read for Senders, Write for Receivers", `ws_rr_buffer_ptr` means "Write for Senders, Read for Receivers"
+    void *ws_rr_buffer_ptr = nullptr;
+    void *ws_rr_fused_buffer_ptr = nullptr;
+    if (warp_role == WarpRole::kRDMAAndNVLForwarder) {
+        ws_rr_fused_buffer_ptr = buffer_fused_ptrs[target_rank];
+        ws_rr_buffer_ptr = buffer_ptrs[target_rank];
+    }
+    if (warp_role == WarpRole::kNVLReceivers) {
+        ws_rr_buffer_ptr = buffer_ptrs[nvl_rank];
+    }
+
+    ws_rr_buffer_ptr = reinterpret_cast<void *>(reinterpret_cast<int *>(ws_rr_buffer_ptr) + ZCOPY_NOTIFY_NVL_METADATA_OFFSET_INTS);
+    auto nvl_channel_prefix_start = AsymBuffer<int>(ws_rr_buffer_ptr, kNumRDMARanks, NUM_MAX_NVL_PEERS, channel_id, num_channels);
+    auto nvl_channel_prefix_end = AsymBuffer<int>(ws_rr_buffer_ptr, kNumRDMARanks, NUM_MAX_NVL_PEERS, channel_id, num_channels);
+    auto nvl_channel_finish_signal = AsymBuffer<int>(ws_rr_buffer_ptr, 1, NUM_MAX_NVL_PEERS, channel_id, num_channels);
+
+    // RDMA sender warp synchronization
+    __shared__ volatile int rdma_send_channel_next_tail[kNumRDMARanks];
+    auto sync_rdma_sender_smem = []() { asm volatile("barrier.sync 0, %0;" :: "r"((kNumDispatchRDMASenderWarps) * 32)); };
+
+    // Forward warp synchronization
+    __shared__ volatile int forward_channel_head[NUM_MAX_NVL_PEERS][kNumRDMARanks];
+    __shared__ volatile bool forward_channel_retired[NUM_MAX_NVL_PEERS];
+    auto sync_forwarder_smem = []() { asm volatile("barrier.sync 1, %0;" :: "r"((NUM_MAX_NVL_PEERS + 1) * 32)); };
+
+    // RDMA multi-sge list
+    __shared__ __align__(16) ibgda_sge_t sge_list_buf[kNumDispatchRDMASenderWarps * NUM_MAX_SGE_PER_WQE];
+    ibgda_sge_t *sge_list = sge_list_buf + warp_id * NUM_MAX_SGE_PER_WQE;
+
+    if (warp_role == WarpRole::kRDMASender) {
+        // NOTES: in case of splitting the issued put at the end of the buffer
+        EP_DEVICE_ASSERT(num_max_rdma_chunked_recv_tokens % num_max_rdma_chunked_send_tokens == 0);
+
+        // Get tasks
+        int token_start_idx, token_end_idx;
+        get_channel_task_range(num_tokens, num_channels, channel_id, token_start_idx, token_end_idx);
+
+        // Clean shared memory
+        EP_STATIC_ASSERT(kNumRDMARanks <= 32, "Invalid number of RDMA ranks");
+        (warp_id == 0 and lane_id < kNumRDMARanks) ? (rdma_send_channel_next_tail[lane_id] = 0) : 0;
+
+        // Send number of tokens in this channel by `-value - 1`
+        EP_STATIC_ASSERT(NUM_MAX_NVL_PEERS * 2 + 2 <= 32, "Invalid number of NVL peers");
+
+        for (int i = warp_id; i < kNumRDMARanks; i += kNumDispatchRDMASenderWarps) {
+            int dst_rdma_rank = (i + channel_id + rdma_rank) % kNumRDMARanks;
+
+            auto dst_ptr = dst_rdma_rank == rdma_rank ? rdma_channel_meta.recv_buffer(dst_rdma_rank) : rdma_channel_meta.send_buffer(dst_rdma_rank);
+            if (lane_id < NUM_MAX_NVL_PEERS) {
+                dst_ptr[lane_id] = -(channel_id == 0 ? 0 : gbl_channel_prefix_matrix[(dst_rdma_rank * NUM_MAX_NVL_PEERS + lane_id) * num_channels + channel_id - 1]) - 1;
+            } else if (lane_id < NUM_MAX_NVL_PEERS * 2) {
+                dst_ptr[lane_id] = -gbl_channel_prefix_matrix[(dst_rdma_rank * NUM_MAX_NVL_PEERS + lane_id - NUM_MAX_NVL_PEERS) * num_channels + channel_id] - 1;
+            } else if (lane_id == NUM_MAX_NVL_PEERS * 2) {
+                dst_ptr[lane_id] = -(channel_id == 0 ? 0 : rdma_channel_prefix_matrix[dst_rdma_rank * num_channels + channel_id - 1]) - 1;
+            } else if (lane_id == NUM_MAX_NVL_PEERS * 2 + 1) {
+                dst_ptr[lane_id] = -rdma_channel_prefix_matrix[dst_rdma_rank * num_channels + channel_id] - 1;
+            }
+            __syncwarp();
+
+            // Issue RDMA for non-local ranks
+            if (dst_rdma_rank != rdma_rank) {
+                nvshmemi_ibgda_put_nbi_warp<true>(reinterpret_cast<uint64_t>(rdma_channel_meta.recv_buffer(rdma_rank)),
+                                                  reinterpret_cast<uint64_t>(rdma_channel_meta.send_buffer(dst_rdma_rank)),
+                                                  sizeof(int) * (NUM_MAX_NVL_PEERS * 2 + 2),
+                                                  translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank),
+                                                  channel_id, lane_id, 0);
+            }
+        }
+        sync_rdma_sender_smem();
+
+        // Iterate over tokens and copy into buffer
+        int64_t token_idx;
+        int num_sge_per_rdma_token = 2;
+        if (num_scales > 0) num_sge_per_rdma_token ++;
+        if (num_topk > 0) num_sge_per_rdma_token += 2;
+
+        for (int i = warp_id; i < kNumRDMARanks; i += kNumDispatchRDMASenderWarps) {
+            int dst_rdma_rank = (i + channel_id + rdma_rank) % kNumRDMARanks;
+
+            int last_issued_tail = 0;
+            int num_tokens_to_send = 0;
+            num_tokens_to_send = rdma_channel_prefix_matrix[dst_rdma_rank * num_channels + channel_id];
+            if (channel_id > 0) {
+                num_tokens_to_send -= rdma_channel_prefix_matrix[dst_rdma_rank * num_channels + channel_id - 1];
+            }
+
+            int issue_token_idx = 0;
+            int num_tokens_to_issue = min(num_tokens_to_send, num_max_rdma_chunked_send_tokens);
+            int num_sge_per_msg = num_sge_per_rdma_token * num_tokens_to_issue;
+            EP_DEVICE_ASSERT(num_sge_per_msg <= NUM_MAX_SGE_PER_WQE);
+            for (token_idx = token_start_idx; token_idx < token_end_idx; token_idx ++) {
+                // Read RDMA rank existence
+                uint64_t is_token_in_rank_uint64 = 0;
+                int cached_rdma_channel_head = 0, rdma_tail_idx = -1;
+                if (lane_id == 0) {
+                    is_token_in_rank_uint64 = *reinterpret_cast<const uint64_t*>(is_token_in_rank + token_idx * num_ranks + dst_rdma_rank * NUM_MAX_NVL_PEERS);
+                    // Acquire next tail
+                    if (is_token_in_rank_uint64 != 0) {
+                        rdma_tail_idx = rdma_send_channel_next_tail[dst_rdma_rank] ++;
+                        // Since in the zcopy case we use the SGE buffer exclusively, we do not
+                        // wait for the head here and directly proceed to fill the SGE instead,
+                        // without risk of overwriting the src buffer of an ongoing RDMA WRITE.
+                    }
+
+                    // Store RDMA head for combine
+                    if (not kCachedMode)
+                        send_rdma_head[token_idx * kNumRDMARanks + dst_rdma_rank] = rdma_tail_idx;
+                }
+                __syncwarp();
+
+                auto recv_is_token_in_rank_uint64 = broadcast(is_token_in_rank_uint64, 0);
+                if (recv_is_token_in_rank_uint64 == 0) {
+                    continue;
+                }
+
+                auto token_x = x + token_idx * hidden_int4;
+                auto token_x_scales = x_scales + token_idx * num_scales;
+                auto token_topk_idx = topk_idx + token_idx * num_topk;
+                auto token_topk_weights = topk_weights + token_idx * num_topk;
+                auto token_source_meta_rdma_buf = rdma_channel_src_meta.buffer(dst_rdma_rank) + rdma_tail_idx;
+
+                SourceMeta src_meta;
+                // Construct source meta
+                if (lane_id == 0) {
+                    auto recv_is_token_in_rank_values = reinterpret_cast<const bool*>(&is_token_in_rank_uint64);
+                    src_meta = SourceMeta(rdma_rank, recv_is_token_in_rank_values, token_idx);
+                    st_na_global(token_source_meta_rdma_buf, src_meta);
+                }
+                __syncwarp();
+
+                // Prepare SGE
+                if (dst_rdma_rank != rdma_rank) {
+                    int sge_idx = 0;
+                    if (lane_id == 0) {
+                        sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].addr = reinterpret_cast<uint64_t>(token_x);
+                        sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].length = hidden_bytes;
+                        sge_idx++;
+                        sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].addr = reinterpret_cast<uint64_t>(token_source_meta_rdma_buf);
+                        sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].length = sizeof(SourceMeta);
+                        sge_idx++;
+                        if (num_scales > 0) {
+                            sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].addr = reinterpret_cast<uint64_t>(token_x_scales);
+                            sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].length = num_scales * sizeof(float);
+                            sge_idx++;
+                        }
+                        if (num_topk > 0) {
+                            sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].addr = reinterpret_cast<uint64_t>(token_topk_idx);
+                            sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].length = num_topk * sizeof(topk_idx_t);
+                            sge_idx++;
+                            sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].addr = reinterpret_cast<uint64_t>(token_topk_weights);
+                            sge_list[issue_token_idx * num_sge_per_rdma_token + sge_idx].length = num_topk * sizeof(float);
+                            sge_idx++;
+                        }
+                    }
+                    __syncwarp();
+                }
+
+                issue_token_idx ++;
+                if (issue_token_idx < num_tokens_to_issue) {
+                    continue;
+                }
+
+                // Actually wait for the tail now
+                auto start_time = clock64();
+                while (rdma_tail_idx - cached_rdma_channel_head >= num_max_rdma_chunked_recv_tokens) {
+                    cached_rdma_channel_head = static_cast<int>(ld_volatile_global(rdma_channel_head.buffer(dst_rdma_rank)));
+
+                    // Timeout check
+                    if (clock64() - start_time >= NUM_TIMEOUT_CYCLES) {
+                        printf("DeepEP dispatch RDMA sender timeout, channel: %d, RDMA: %d, nvl: %d, dst RDMA lane: %d, head: %d, tail: %d, num_max_rdma_chunked_recv_tokens: %d \n",
+                        channel_id, rdma_rank, nvl_rank, lane_id, cached_rdma_channel_head, rdma_tail_idx, num_max_rdma_chunked_recv_tokens);
+                        trap();
+                    }
+                }
+
+                // Issue the WRITE operation
+                if (dst_rdma_rank != rdma_rank) {
+                    size_t num_bytes_per_msg = num_bytes_per_rdma_token * num_tokens_to_issue;
+                    int dst_slot_idx = last_issued_tail % num_max_rdma_chunked_recv_tokens;
+                    auto dst_ptr = reinterpret_cast<uint64_t>(rdma_channel_data.buffer(rdma_rank) + dst_slot_idx * num_bytes_per_rdma_token);
+                    EP_DEVICE_ASSERT(dst_slot_idx + num_tokens_to_issue <= num_max_rdma_chunked_recv_tokens);
+                    nvshmemi_ibgda_put_nbi_warp_multi_sge_parallel<true>(sge_list, num_sge_per_msg, dst_ptr, num_bytes_per_msg,
+                                                                         translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank), channel_id, lane_id);
+                } else {
+                    // The local forwarder will fetch the SourceMeta from the SourceMeta RDMA
+                    // source buffer. Simply updating the tail suffices.
+                    memory_fence();
+                }
+
+                last_issued_tail += num_tokens_to_issue;
+                __syncwarp();
+
+                issue_token_idx = 0;
+                num_tokens_to_send -= num_tokens_to_issue;
+                if (lane_id == 0) {
+                    nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_tail.buffer(rdma_rank), num_tokens_to_issue,
+                                                    translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank), channel_id, dst_rdma_rank == rdma_rank);
+                }
+                __syncwarp();
+                num_tokens_to_issue = min(num_tokens_to_send, num_max_rdma_chunked_send_tokens);
+                num_sge_per_msg = num_sge_per_rdma_token * num_tokens_to_issue;
+            }
+        }
+        // Wait for all RDMA ranks to finish receiving
+        if (warp_id == 0 and lane_id < kNumRDMARanks) {
+            auto start_time = clock64();
+            constexpr uint64_t expected = 1;
+            while (true) {
+                auto signal = ld_volatile_global(rdma_channel_recv_finish_signal.buffer());
+                if (signal == expected) {
+                    break;
+                }
+                if (clock64() - start_time > NUM_TIMEOUT_CYCLES or signal > expected) {
+                    printf("DeepEP zcopy dispatch recv completion signal corruption or timeout, channel: %d, RDMA: %d, nvl: %d, src RDMA: %d, signal: %#lx, expected: %#lx\n",
+                        channel_id, rdma_rank, nvl_rank, lane_id, signal, expected);
+                    trap();
+                }
+            }
+        }
+    } else if (warp_role == WarpRole::kRDMAAndNVLForwarder) {
+        // RDMA consumers and NVL producers
+        const auto dst_nvl_rank = target_rank;
+        const auto dst_rank = rdma_rank * NUM_MAX_NVL_PEERS + dst_nvl_rank;
+        const auto dst_rank_expert_begin = dst_rank * (num_experts / num_ranks);
+        const auto dst_rank_expert_end = dst_rank_expert_begin + (num_experts / num_ranks);
+
+        // Dynamic TMA shared memory layout
+        const size_t SMEM_LEN_PER_TARGET_NVL_PEER = 16384;
+        // TODO: Zero-copy: Maybe use existing constants?
+        constexpr uintptr_t TMA_SMEM_ALIGNMENT = 16384;
+        extern __shared__ int4 tma_smem[];
+        char *tma_smem_aligned = reinterpret_cast<char *>(align_up(reinterpret_cast<uintptr_t>(tma_smem), TMA_SMEM_ALIGNMENT));
+        __shared__ uint64_t tma_mbarrier[NUM_MAX_NVL_PEERS];
+
+        // Dedicated TMA shared memory for scales
+        const size_t SMEM_SCALES_LEN_PER_TARGET_NVL_PEER = 512;
+        __shared__ __align__(SMEM_SCALES_LEN_PER_TARGET_NVL_PEER) char tma_smem_scales[NUM_MAX_NVL_PEERS][SMEM_SCALES_LEN_PER_TARGET_NVL_PEER];
+        __shared__ uint64_t tma_mbarrier_scales[NUM_MAX_NVL_PEERS];
+
+        char *smem_ptrs[NUM_MAX_NVL_PEERS];
+        #pragma unroll
+        for (size_t i = 0; i < NUM_MAX_NVL_PEERS; ++ i) {
+            smem_ptrs[i] = tma_smem_aligned + SMEM_LEN_PER_TARGET_NVL_PEER * i;
+        }
+        EP_DEVICE_ASSERT(
+            reinterpret_cast<uintptr_t>(smem_ptrs[NUM_MAX_NVL_PEERS - 1]) + SMEM_LEN_PER_TARGET_NVL_PEER <=
+            reinterpret_cast<uintptr_t>(tma_smem) + kNvlFwdTMASMemLen);
+
+        // Wait counters to arrive
+        int num_tokens_to_recv_from_rdma = 0, num_tokens_to_recv_from_rdma_saved = 0, src_rdma_channel_prefix = 0;
+        bool finish_signaled = false;
+        auto rdma_signal_finish =
+            [&rdma_channel_recv_finish_signal, &finish_signaled, rdma_rank, nvl_rank, channel_id](int src_rdma_rank, int qp_id) {
+            nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_recv_finish_signal.buffer(rdma_rank), 1,
+                                            translate_dst_rdma_rank<kLowLatencyMode>(src_rdma_rank, nvl_rank), qp_id, src_rdma_rank == rdma_rank);
+            finish_signaled = true;
+        };
+        EP_DEVICE_ASSERT(kNumRDMARanks <= 32);
+        auto start_time = clock64();
+        int start_sum = -1, end_sum = -1;
+        if (lane_id < kNumRDMARanks) {
+            while (true) {
+                auto meta_0 = ld_volatile_global(rdma_channel_meta.recv_buffer(lane_id) + dst_nvl_rank);
+                auto meta_1 = ld_volatile_global(rdma_channel_meta.recv_buffer(lane_id) + NUM_MAX_NVL_PEERS + dst_nvl_rank);
+                auto meta_2 = ld_volatile_global(rdma_channel_meta.recv_buffer(lane_id) + NUM_MAX_NVL_PEERS * 2);
+                auto meta_3 = ld_volatile_global(rdma_channel_meta.recv_buffer(lane_id) + NUM_MAX_NVL_PEERS * 2 + 1);
+                if (meta_0 < 0 and meta_1 < 0 and meta_2 < 0 and meta_3 < 0) {
+                    // Notify NVL ranks
+                    start_sum = -meta_0 - 1, end_sum = -meta_1 - 1;
+                    EP_DEVICE_ASSERT(start_sum >= 0 and end_sum >= 0 and end_sum >= start_sum);
+                    st_relaxed_sys_global(nvl_channel_prefix_start.buffer() + nvl_rank * kNumRDMARanks + lane_id, -start_sum - 1);
+                    st_relaxed_sys_global(nvl_channel_prefix_end.buffer() + nvl_rank * kNumRDMARanks + lane_id, -end_sum - 1);
+
+                    // Save RDMA channel received token count
+                    src_rdma_channel_prefix = -meta_2 - 1;
+                    auto src_rdma_channel_prefix_1 = -meta_3 - 1;
+                    num_tokens_to_recv_from_rdma = num_tokens_to_recv_from_rdma_saved = src_rdma_channel_prefix_1 - src_rdma_channel_prefix;
+                    if (not kCachedMode)
+                        recv_rdma_channel_prefix_matrix[lane_id * num_channels + channel_id] = src_rdma_channel_prefix_1;
+                    src_rdma_channel_prefix += lane_id == 0 ? 0 : recv_rdma_rank_prefix_sum[lane_id - 1];
+                    EP_DEVICE_ASSERT(num_tokens_to_recv_from_rdma >= 0);
+                    // TODO: We can check if the recv count is 0 on the sender side instead
+                    if (num_tokens_to_recv_from_rdma == 0 and dst_nvl_rank == lane_id % NUM_MAX_NVL_PEERS) {
+                        // Need to immediately send finish signal here, as we won't receive any
+                        // tokens and thus will not trigger the logic upon token reception.
+                        // As of the second condition, see comments on the other atomic add
+                        rdma_signal_finish(lane_id, channel_id);
+                    }
+                    break;
+                }
+
+                // Timeout check
+                if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                    printf("DeepEP zcopy dispatch forwarder timeout (RDMA meta), channel: %d, RDMA: %d, nvl: %d, src RDMA lane: %d, dst NVL: %d, meta: %d, %d, %d, %d\n",
+                           channel_id, rdma_rank, nvl_rank, lane_id, dst_nvl_rank, meta_0, meta_1, meta_2, meta_3);
+                    trap();
+                }
+            }
+        }
+        __syncwarp();
+
+        // Shift cached head
+        send_nvl_head += src_rdma_channel_prefix * NUM_MAX_NVL_PEERS + dst_nvl_rank;
+
+        // Wait shared memory to be cleaned
+        sync_forwarder_smem();
+
+        // Forward tokens from RDMA buffer
+        // NOTES: always start from the local rank
+        int src_rdma_rank = sm_id % kNumRDMARanks;
+        int cached_rdma_channel_head = 0, cached_rdma_channel_tail = 0;
+        while (__any_sync(0xffffffff, num_tokens_to_recv_from_rdma > 0)) {
+            // Find next source RDMA rank (round-robin)
+            start_time = clock64();
+            while (true) {
+                src_rdma_rank = (src_rdma_rank + 1) % kNumRDMARanks;
+                if (__shfl_sync(0xffffffff, num_tokens_to_recv_from_rdma, src_rdma_rank) > 0) {
+                    if (lane_id == src_rdma_rank and cached_rdma_channel_head == cached_rdma_channel_tail)
+                        cached_rdma_channel_tail = static_cast<int>(ld_acquire_sys_global(rdma_channel_tail.buffer(src_rdma_rank)));
+                    if (__shfl_sync(0xffffffff, cached_rdma_channel_tail > cached_rdma_channel_head, src_rdma_rank))
+                        break;
+                }
+
+                // Timeout check
+                if (clock64() - start_time > NUM_TIMEOUT_CYCLES and lane_id < kNumRDMARanks) {
+                    printf("DeepEP zcopy dispatch forwarder timeout (RDMA check), channel: %d, RDMA: %d, nvl: %d, dst NVL: %d, src RDMA lane: %d, head: %d, tail: %d, expected: %d\n",
+                           channel_id, rdma_rank, nvl_rank, dst_nvl_rank, lane_id, cached_rdma_channel_head, cached_rdma_channel_tail, num_tokens_to_recv_from_rdma);
+                    trap();
+                }
+            }
+            auto src_rdma_head = __shfl_sync(0xffffffff, cached_rdma_channel_head, src_rdma_rank);
+            auto src_rdma_tail = __shfl_sync(0xffffffff, cached_rdma_channel_tail, src_rdma_rank);
+
+            int total_offset = 0;
+            if (src_rdma_rank * NUM_MAX_NVL_PEERS + nvl_rank > 0) {
+                total_offset = recv_gbl_rank_prefix_sum_fwd[dst_nvl_rank * num_ranks + src_rdma_rank * NUM_MAX_NVL_PEERS + nvl_rank - 1];
+            }
+
+            int num_recv_tokens = recv_gbl_rank_prefix_sum_fwd[dst_nvl_rank * num_ranks + num_ranks - 1];
+            auto target_nvl_rank_x_bytes = num_recv_tokens * hidden_bytes;
+            auto target_nvl_rank_topk_idx_bytes = num_recv_tokens * num_topk * sizeof(topk_idx_t);
+            auto target_nvl_rank_topk_weights_bytes = num_recv_tokens * num_topk * sizeof(float);
+            auto target_nvl_rank_x_scales_bytes = num_recv_tokens * num_scales * sizeof(float);
+
+            auto target_nvl_rank_x = ws_rr_fused_buffer_ptr;
+            auto target_nvl_rank_topk_idx = reinterpret_cast<topk_idx_t*>(reinterpret_cast<uint8_t*>(ws_rr_fused_buffer_ptr) + target_nvl_rank_x_bytes);
+            auto target_nvl_rank_topk_weights = reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(ws_rr_fused_buffer_ptr) + target_nvl_rank_x_bytes + target_nvl_rank_topk_idx_bytes);
+            auto target_nvl_rank_x_scales = reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(ws_rr_fused_buffer_ptr) + target_nvl_rank_x_bytes + target_nvl_rank_topk_idx_bytes + target_nvl_rank_topk_weights_bytes);
+            auto target_nvl_rank_src_meta = reinterpret_cast<SourceMeta*>(reinterpret_cast<uint8_t*>(ws_rr_fused_buffer_ptr) + target_nvl_rank_x_bytes + target_nvl_rank_topk_idx_bytes + target_nvl_rank_topk_weights_bytes + target_nvl_rank_x_scales_bytes);
+
+            int start_offset = __shfl_sync(0xffffffff, start_sum, src_rdma_rank);
+            int end_offset = __shfl_sync(0xffffffff, end_sum, src_rdma_rank);
+            total_offset += start_offset;
+
+            if (lane_id == src_rdma_rank and not finish_signaled) {
+                // There will be NUM_MAX_NVL_PEERS threads in this <channel, rank> that learn
+                // about the first condition, each belonging to a different forwarder warp. The
+                // second condition guarantees only 1 warp (and thus 1 thread) will issue the
+                // atomic add.
+                if (src_rdma_tail == num_tokens_to_recv_from_rdma_saved and dst_nvl_rank == src_rdma_rank % NUM_MAX_NVL_PEERS) {
+                    // Send RDMA recv finish signal
+                    rdma_signal_finish(lane_id, channel_id);
+                }
+            }
+
+            // Iterate over every token from the RDMA buffer
+            for (int i = src_rdma_head, num_tokens_sent = 0; i < src_rdma_tail; ++ i) {
+                // Wait for previous TMA transfers to finish, if any
+                memcpy_tma_warp_finalize();
+
+                const bool is_local_token = src_rdma_rank == rdma_rank;
+                void *shifted;
+                if (is_local_token) {
+                    shifted = rdma_channel_src_meta.buffer(src_rdma_rank) + i;
+                } else {
+                    auto rdma_slot_idx = i % num_max_rdma_chunked_recv_tokens;
+                    shifted = rdma_channel_data.buffer(src_rdma_rank) + rdma_slot_idx * num_bytes_per_rdma_token;
+                }
+                auto src_meta = ld_nc_global(reinterpret_cast<SourceMeta*>(reinterpret_cast<int8_t*>(shifted) +
+                    (is_local_token ? 0 : hidden_bytes)));
+                __syncwarp();
+                bool is_in_dst_nvl_rank = src_meta.is_token_in_nvl_rank(dst_nvl_rank);
+                if (lane_id == src_rdma_rank) {
+                    --num_tokens_to_recv_from_rdma;
+                    auto cached_head = is_in_dst_nvl_rank ? total_offset : -1;
+                    if (not kCachedMode) {
+                        send_nvl_head[i * NUM_MAX_NVL_PEERS] = cached_head;
+                    }
+                    if (src_meta.src_rdma_rank != src_rdma_rank or src_meta.is_token_in_nvl_rank_bits == 0 or src_meta.is_token_in_nvl_rank_bits >= (1<<NUM_MAX_NVL_PEERS)) {
+                        printf("DeepEP zcopy dispatch bad source meta: rank %d, i = %d, src_rdma_rank = %d, dst_nvl_rank = %d, meta = (%d, %#x)\n", rank, i, src_rdma_rank, dst_nvl_rank, src_meta.src_rdma_rank, src_meta.is_token_in_nvl_rank_bits);
+                        trap();
+                    }
+                }
+                __syncwarp();
+                if (not is_in_dst_nvl_rank)
+                    continue;
+
+                const void *src_x, *src_scales, *src_topk_idx, *src_topk_weights;
+                if (is_local_token) {
+                    src_x = x + src_meta.token_idx * hidden_int4;
+                    src_scales = x_scales + src_meta.token_idx * num_scales;
+                    src_topk_idx = topk_idx + src_meta.token_idx * num_topk;
+                    src_topk_weights = topk_weights + src_meta.token_idx * num_topk;
+                } else {
+                    src_x = shifted;
+                    shifted = shift_ptr(shifted, hidden_bytes);
+                    shifted = shift_ptr(shifted, sizeof(SourceMeta));
+                    src_scales = shifted;
+                    shifted = shift_ptr(shifted, num_scales * sizeof(float));
+                    src_topk_idx = shifted;
+                    shifted = shift_ptr(shifted, sizeof(topk_idx_t) * num_topk);
+                    src_topk_weights = shifted;
+                    shifted = shift_ptr(shifted, sizeof(float) * num_topk);
+                }
+
+                (lane_id == src_rdma_rank) ? (start_sum += 1) : 0;
+
+                if (lane_id == 0) {
+                    // Load hidden into shared memory
+                    memcpy_tma_lane_launch_load(
+                        src_x,
+                        hidden_bytes,
+                        smem_ptrs[target_rank],
+                        tma_mbarrier[target_rank]
+                    );
+                    // Load scales into shared memory
+                    memcpy_tma_lane_launch_load(
+                        src_scales,
+                        num_scales * sizeof(float),
+                        tma_smem_scales[target_rank],
+                        tma_mbarrier_scales[target_rank]
+                    );
+                }
+
+                // Copy source meta
+                if (lane_id == 0 and not kCachedMode)
+                    st_na_global(target_nvl_rank_src_meta + total_offset, src_meta);
+
+                // Copy `topk_idx` and `topk_weights`
+                if (lane_id < num_topk) {
+                    // Read
+                    auto idx_value = ld_nc_global(reinterpret_cast<const topk_idx_t *>(src_topk_idx) + lane_id);
+                    auto weight_value = ld_nc_global(reinterpret_cast<const float *>(src_topk_weights) + lane_id);
+
+                    // Transform and write
+                    idx_value = (idx_value >= dst_rank_expert_begin and idx_value < dst_rank_expert_end) ? idx_value - dst_rank_expert_begin : -1;
+                    st_na_global(target_nvl_rank_topk_idx + total_offset * num_topk + lane_id, idx_value);
+                    weight_value = idx_value >= 0 ? weight_value : 0.0f;
+                    st_na_global(target_nvl_rank_topk_weights + total_offset * num_topk + lane_id, weight_value);
+                }
+
+                if (lane_id == 0) {
+                    // Store scales into target
+                    memcpy_tma_lane_launch_store(
+                        reinterpret_cast<void *>(target_nvl_rank_x_scales + total_offset * num_scales),
+                        num_scales * sizeof(float),
+                        tma_smem_scales[target_rank],
+                        tma_mbarrier_scales[target_rank]
+                    );
+                    // Store hidden into target
+                    memcpy_tma_lane_launch_store(
+                        shift_ptr(target_nvl_rank_x, total_offset * hidden_bytes),
+                        hidden_bytes,
+                        smem_ptrs[target_rank],
+                        tma_mbarrier[target_rank]
+                    );
+                }
+
+                total_offset++;
+
+                // In case of insufficient NVL buffers, early stopping
+                if ((++ num_tokens_sent) == num_max_nvl_chunked_send_tokens)
+                    src_rdma_tail = i + 1;
+            }
+
+            // Sync head index
+            // With the token data landed in SMEM, RDMA recv buffer can be safely overwritten without waiting for TMA store
+            if (lane_id == src_rdma_rank)
+                forward_channel_head[dst_nvl_rank][src_rdma_rank] = (cached_rdma_channel_head = src_rdma_tail);
+            memcpy_tma_warp_finalize();
+            __syncwarp();
+        }
+
+        // Retired
+        __syncwarp();
+        if (lane_id == 0) {
+            st_relaxed_sys_global(nvl_channel_finish_signal.buffer() + nvl_rank, 1);
+            forward_channel_retired[dst_nvl_rank] = true;
+        };
+    } else if (warp_role == WarpRole::kForwarderCoordinator) {
+        EP_STATIC_ASSERT(kNumRDMARanks <= 32, "Invalid number of RDMA peers");
+
+        // Clean shared memory
+        EP_STATIC_ASSERT(NUM_MAX_NVL_PEERS <= 32, "Invalid number of NVL peers");
+        #pragma unroll
+        for (int i = lane_id; i < kNumRDMARanks * NUM_MAX_NVL_PEERS; i += 32)
+            forward_channel_head[i % NUM_MAX_NVL_PEERS][i / NUM_MAX_NVL_PEERS] = 0;
+        if (lane_id < NUM_MAX_NVL_PEERS)
+            forward_channel_retired[lane_id] = false;
+        sync_forwarder_smem();
+
+        int last_head = 0, target_rdma = lane_id < kNumRDMARanks ? lane_id : 0;
+        while (true) {
+            // Find minimum head
+            int min_head = std::numeric_limits<int>::max();
+            #pragma unroll
+            for (int i = 0; i < NUM_MAX_NVL_PEERS; ++ i) if (not forward_channel_retired[i])
+                min_head = min(min_head, forward_channel_head[i][target_rdma]);
+            if (__all_sync(0xffffffff, min_head == std::numeric_limits<int>::max()))
+                break;
+
+            // Update remote head
+            if (min_head != std::numeric_limits<int>::max() and min_head >= last_head + num_max_rdma_chunked_send_tokens and lane_id < kNumRDMARanks) {
+                nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_head.buffer(rdma_rank), min_head - last_head,
+                                                translate_dst_rdma_rank<kLowLatencyMode>(lane_id, nvl_rank), channel_id, lane_id == rdma_rank);
+                last_head = min_head;
+            }
+
+            // Nanosleep and let other warps work
+            __nanosleep(NUM_WAIT_NANOSECONDS);
+        }
+    } else {
+        // NVL consumers
+        // Retrieve rank offset from barrier results (each lane's register stores an RDMA rank)
+
+        for (int i = 0; i < NUM_MAX_NVL_PEERS; i++) {
+            int src_nvl_rank = (i + channel_id) % NUM_MAX_NVL_PEERS;
+            int total_offset = 0;
+            EP_STATIC_ASSERT(kNumRDMARanks <= 32, "Invalid number of RDMA peers");
+            if (lane_id < kNumRDMARanks and lane_id * NUM_MAX_NVL_PEERS + src_nvl_rank > 0)
+                total_offset = recv_gbl_rank_prefix_sum[lane_id * NUM_MAX_NVL_PEERS + src_nvl_rank - 1];
+
+            // Receive channel offsets
+            int start_offset = 0, end_offset = 0;
+            auto start_time = clock64();
+            while (lane_id < kNumRDMARanks) {
+                start_offset = ld_volatile_global(nvl_channel_prefix_start.buffer() + src_nvl_rank * kNumRDMARanks + lane_id);
+                end_offset = ld_volatile_global(nvl_channel_prefix_end.buffer() + src_nvl_rank * kNumRDMARanks + lane_id);
+                if (start_offset < 0 and end_offset < 0) {
+                    start_offset = -start_offset - 1, end_offset = -end_offset - 1;
+                    total_offset += start_offset;
+                    break;
+                }
+
+                // Timeout check
+                if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                    printf("DeepEP zcopy dispatch NVL receiver timeout, channel: %d, RDMA: %d, nvl: %d, src RDMA: %d, src nvl: %d, start: %d, end: %d\n",
+                        channel_id, rdma_rank, nvl_rank, lane_id, src_nvl_rank, start_offset, end_offset);
+                    trap();
+                }
+            }
+
+            // Save for combine usage
+            if (lane_id < kNumRDMARanks and not kCachedMode)
+                recv_gbl_channel_prefix_matrix[(lane_id * NUM_MAX_NVL_PEERS + src_nvl_rank) * num_channels + channel_id] = total_offset;
+            __syncwarp();
+        }
+
+        // Wait for all local ranks to finish forwarding
+        for (int i = lane_id; i < NUM_MAX_NVL_PEERS; i += 32) {
+            auto start_time = clock64();
+            while (not ld_volatile_global(nvl_channel_finish_signal.buffer() + i)) {
+                if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                    printf("DeepEP zcopy dispatch forwarding wait timeout, channel: %d, RDMA: %d, nvl: %d, src NVL: %d\n",
+                        channel_id, rdma_rank, nvl_rank, i);
+                    trap();
+                }
+            }
+        }
+    }
+}
+
+void dispatch(void* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, float* recv_topk_weights, void* recv_src_meta,
+              const void* x, const float* x_scales, const topk_idx_t* topk_idx, const float* topk_weights,
+              int* send_rdma_head, int* send_nvl_head,
+              int* recv_rdma_channel_prefix_matrix, int* recv_gbl_channel_prefix_matrix,
+              const int* rdma_channel_prefix_matrix, const int* recv_rdma_rank_prefix_sum,
+              const int* gbl_channel_prefix_matrix, const int* recv_gbl_rank_prefix_sum,
+              const int* recv_gbl_rank_prefix_sum_fwd,
+              const bool* is_token_in_rank,
+              int num_tokens, int hidden_int4, int num_scales, int num_topk, int num_experts,
+              void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
+              void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
+              int rank, int num_ranks, bool is_cached_dispatch,
+              cudaStream_t stream, int num_channels, bool low_latency_mode) {
+    constexpr int smem_size = 16384 * (NUM_MAX_NVL_PEERS + 1); // +1 to account for alignment
+#define DISPATCH_LAUNCH_CASE(num_rdma_ranks) { \
+    const int kNumDispatchRDMASenderWarps = num_rdma_ranks; \
+    SETUP_LAUNCH_CONFIG(num_channels, (kNumDispatchRDMASenderWarps + 2 + NUM_MAX_NVL_PEERS) * 32, stream); \
+    auto dispatch_func = low_latency_mode ? \
+        (is_cached_dispatch ? dispatch<true, num_rdma_ranks, true, smem_size, kNumDispatchRDMASenderWarps> : dispatch<true, num_rdma_ranks, false, smem_size, kNumDispatchRDMASenderWarps>) : \
+        (is_cached_dispatch ? dispatch<false, num_rdma_ranks, true, smem_size, kNumDispatchRDMASenderWarps> : dispatch<false, num_rdma_ranks, false, smem_size, kNumDispatchRDMASenderWarps>); \
+    SET_SHARED_MEMORY_FOR_TMA(dispatch_func); \
+    LAUNCH_KERNEL(&cfg, dispatch_func, \
+                  reinterpret_cast<int4*>(recv_x), recv_x_scales, recv_topk_idx, recv_topk_weights, reinterpret_cast<SourceMeta*>(recv_src_meta), \
+                  reinterpret_cast<const int4*>(x), x_scales, topk_idx, topk_weights, \
+                  send_rdma_head, send_nvl_head, \
+                  recv_rdma_channel_prefix_matrix, recv_gbl_channel_prefix_matrix, \
+                  rdma_channel_prefix_matrix, recv_rdma_rank_prefix_sum, \
+                  gbl_channel_prefix_matrix, recv_gbl_rank_prefix_sum, \
+                  recv_gbl_rank_prefix_sum_fwd, \
+                  is_token_in_rank, \
+                  num_tokens, hidden_int4, num_scales, num_topk, num_experts, \
+                  rdma_buffer_ptr, num_max_rdma_chunked_send_tokens, num_max_rdma_chunked_recv_tokens, \
+                  buffer_fused_ptrs, buffer_ptrs, num_max_nvl_chunked_send_tokens, num_max_nvl_chunked_recv_tokens, \
+                  rank, num_ranks); } break
+
+    EP_HOST_ASSERT((topk_idx == nullptr)  == (topk_weights == nullptr));
+    EP_HOST_ASSERT((recv_topk_idx == nullptr) == (recv_topk_weights == nullptr));
+
+    SWITCH_RDMA_RANKS(DISPATCH_LAUNCH_CASE);
+#undef DISPATCH_LAUNCH_CASE
+}
+
+template <int kNumRanks, typename dtype_t, int kMaxNumRanks, typename ReceiveFn, typename ReceiveTWFn>
+__device__ int combine_token(bool is_token_in_rank, int head_idx,
+                             int lane_id, int hidden_int4, int num_topk,
+                             int4* combined_row, float* combined_topk_weights,
+                             int num_max_recv_tokens, const ReceiveFn& recv_fn, const ReceiveTWFn& recv_tw_fn) {
+    constexpr auto kDtypePerInt4 = sizeof(int4) / sizeof(dtype_t);
+
+    // Broadcast current heads
+    // Lane `i` holds the head of rank `i` and `is_token_in_rank`
+    EP_STATIC_ASSERT(kMaxNumRanks <= 32, "Too many ranks");
+    int num_topk_ranks = 0, topk_ranks[kMaxNumRanks], slot_indices[kMaxNumRanks];
+    #pragma unroll
+    for (int i = 0; i < kNumRanks; ++ i) if (__shfl_sync(0xffffffff, is_token_in_rank, i)) {
+        slot_indices[num_topk_ranks] = __shfl_sync(0xffffffff, head_idx, i) % num_max_recv_tokens;
+        topk_ranks[num_topk_ranks ++] = i;
+    }
+    EP_DEVICE_ASSERT(num_topk_ranks <= kMaxNumRanks);
+
+    // Reduce data
+    #pragma unroll
+    for (int i = lane_id; i < hidden_int4; i += 32) {
+        // Read buffers
+        // TODO: maybe too many registers here
+        int4 recv_value_int4[kMaxNumRanks];
+        #pragma unroll
+        for (int j = 0; j < num_topk_ranks; ++ j)
+            recv_value_int4[j] = recv_fn(topk_ranks[j], slot_indices[j], i);
+
+        // Reduce all-to-all results
+        float values[kDtypePerInt4] = {0};
+        #pragma unroll
+        for (int j = 0; j < num_topk_ranks; ++ j) {
+            auto recv_value_dtypes = reinterpret_cast<const dtype_t*>(&recv_value_int4[j]);
+            #pragma unroll
+            for (int k = 0; k < kDtypePerInt4; ++ k)
+                values[k] += static_cast<float>(recv_value_dtypes[k]);
+        }
+
+        // Cast back to `dtype_t` and write
+        int4 out_int4;
+        auto out_dtypes = reinterpret_cast<dtype_t*>(&out_int4);
+        #pragma unroll
+        for (int j = 0; j < kDtypePerInt4; ++ j)
+            out_dtypes[j] = static_cast<dtype_t>(values[j]);
+        st_na_global(combined_row + i, out_int4);
+    }
+
+    // Reduce `topk_weights`
+    if (lane_id < num_topk) {
+        float value = 0;
+        #pragma unroll
+        for (int i = 0; i < num_topk_ranks; ++ i)
+            value += recv_tw_fn(topk_ranks[i], slot_indices[i], lane_id);
+        st_na_global(combined_topk_weights + lane_id, value);
+    }
+
+    // Return the minimum top-k rank
+    return topk_ranks[0];
+}
+
+template<bool kLowLatencyMode,
+         int kNumRDMARanks, typename dtype_t,
+         int kNumCombineForwarderWarps,
+         int kNumRDMAReceivers,
+         int kNumTopkRDMARanks = get_num_topk_rdma_ranks(kNumRDMARanks),
+         int kNumWarpsPerForwarder = (kNumCombineForwarderWarps / kNumRDMARanks > 0) ? kNumCombineForwarderWarps / kNumRDMARanks : 1,
+         int kNumForwarders = kNumRDMARanks * kNumWarpsPerForwarder>
+__global__ void __launch_bounds__((1 + kNumForwarders + kNumRDMAReceivers + 1) * 32, 1)
+combine(int4* combined_x, float* combined_topk_weights,
+        const bool* is_combined_token_in_rank,
+        const int4* x, const float* topk_weights,
+        const int* combined_rdma_head, const int* combined_nvl_head,
+        const SourceMeta* src_meta, const int* rdma_channel_prefix_matrix, const int* rdma_rank_prefix_sum, const int* gbl_channel_prefix_matrix,
+        const int* recv_gbl_rank_prefix_sum_fwd,
+        int num_tokens, int num_combined_tokens, int hidden, int num_topk,
+        void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
+        void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
+        int rank, int num_ranks) {
+    enum class WarpRole {
+        kNVLSender,
+        kNVLAndRDMAForwarder,
+        kRDMAReceiver,
+        KCoordinator
+    };
+
+    const auto sm_id = static_cast<int>(blockIdx.x);
+    const auto num_threads = static_cast<int>(blockDim.x), num_warps = num_threads / 32;
+    const auto thread_id = static_cast<int>(threadIdx.x), lane_id = get_lane_id();
+    const auto num_channels = static_cast<int>(gridDim.x), channel_id = sm_id;
+
+    EP_DEVICE_ASSERT(num_topk <= 32);
+    EP_DEVICE_ASSERT(hidden % (sizeof(int4) / sizeof(dtype_t)) == 0);
+    const auto hidden_int4 = hidden / (sizeof(int4) / sizeof(dtype_t));
+
+    const auto rdma_rank = rank / NUM_MAX_NVL_PEERS, nvl_rank = rank % NUM_MAX_NVL_PEERS;
+    auto role_meta = [=]() -> std::pair<WarpRole, int> {
+        auto warp_id = thread_id / 32;
+        if (warp_id == 0) {
+            return {WarpRole::kNVLSender, 0};
+        } else if (warp_id < 1 + kNumForwarders) {
+            auto shuffled_warp_id = warp_id - 1;
+            return {WarpRole::kNVLAndRDMAForwarder, shuffled_warp_id};
+        } else if (warp_id < 1 + kNumForwarders + kNumRDMAReceivers) {
+            auto shuffled_warp_id = warp_id - 1 - kNumForwarders;
+            return {WarpRole::kRDMAReceiver, shuffled_warp_id};
+        } else {
+            return {WarpRole::KCoordinator, 0};
+        }
+    }();
+    auto warp_role = role_meta.first;
+    auto warp_id = role_meta.second;
+
+    EP_DEVICE_ASSERT(num_warps == 1 + kNumForwarders + kNumRDMAReceivers + 1);
+
+    if (warp_role == WarpRole::kNVLSender) {
+        // NVL layouts
+        void *rs_wr_buffer_ptr = buffer_ptrs[nvl_rank];
+        auto nvl_channel_finish_signal = AsymBuffer<int>(rs_wr_buffer_ptr, 1, NUM_MAX_NVL_PEERS, channel_id, num_channels);
+
+        // Wait for all local ranks to finish forwarding
+        if (lane_id < NUM_MAX_NVL_PEERS) {
+            auto start_time = clock64();
+            while (not ld_volatile_global(nvl_channel_finish_signal.buffer() + lane_id)) {
+                if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                    printf("DeepEP zcopy combine forwarding wait timeout, channel: %d, RDMA: %d, nvl: %d, dst NVL: %d\n",
+                        channel_id, rdma_rank, nvl_rank, lane_id);
+                    trap();
+                }
+            }
+        }
+    } else {
+        // Combiners and coordinators
+        // RDMA symmetric layout
+        auto hidden_bytes = hidden_int4 * sizeof(int4);
+        auto num_bytes_per_rdma_token = get_num_bytes_per_token(hidden_int4, 0, 0, num_topk);
+        auto rdma_channel_data = SymBuffer<int8_t>(rdma_buffer_ptr, num_max_rdma_chunked_recv_tokens * num_bytes_per_rdma_token, kNumRDMARanks, channel_id, num_channels);
+        auto rdma_channel_head = SymBuffer<uint64_t, false>(rdma_buffer_ptr, 1, kNumRDMARanks, channel_id, num_channels);
+        auto rdma_channel_tail = SymBuffer<uint64_t, false>(rdma_buffer_ptr, 1, kNumRDMARanks, channel_id, num_channels);
+
+        // NVL layouts
+        void* ws_rr_fused_buffer_ptr[NUM_MAX_NVL_PEERS], *rs_wr_buffer_ptr[NUM_MAX_NVL_PEERS];
+        #pragma unroll
+        for (int i = 0; i < NUM_MAX_NVL_PEERS; ++ i) {
+            ws_rr_fused_buffer_ptr[i] = buffer_fused_ptrs[i];
+            rs_wr_buffer_ptr[i] = buffer_ptrs[i];
+        }
+        auto nvl_channel_finish_signal = AsymBuffer<int, NUM_MAX_NVL_PEERS>(rs_wr_buffer_ptr, 1, NUM_MAX_NVL_PEERS, channel_id, num_channels);
+
+        // Combiner warp synchronization
+        __shared__ volatile int rdma_receiver_rdma_head[kNumRDMAReceivers][kNumRDMARanks];
+        __shared__ volatile bool rdma_receiver_retired[kNumRDMAReceivers];
+        auto sync_forwarder_smem = [=]() { asm volatile("barrier.sync 1, %0;" :: "r"((kNumForwarders) * 32)); };
+        auto sync_rdma_receiver_and_coordinator_smem = [=]() { asm volatile("barrier.sync 2, %0;" :: "r"((kNumRDMAReceivers + 1) * 32)); };
+
+        if (warp_role == WarpRole::kNVLAndRDMAForwarder) {
+            // Dynamic TMA shared memory layout
+            const size_t SMEM_LEN_PER_WARP = 14 * 1024;
+            extern __shared__ int4 tma_smem[];
+            char *tma_smem_aligned = reinterpret_cast<char *>(tma_smem);
+            __shared__ uint64_t tma_mbarrier[kNumForwarders];
+
+            char *smem_ptrs[kNumForwarders];
+            for (size_t i = 0; i < kNumForwarders; ++ i) {
+                smem_ptrs[i] = tma_smem_aligned + SMEM_LEN_PER_WARP * i;
+            }
+
+            // Receive from NVL ranks and forward to RDMA ranks
+            // NOTES: this part is using "large warps" for each RDMA ranks
+            const auto dst_rdma_rank = warp_id / kNumWarpsPerForwarder;
+            const auto sub_warp_id = warp_id % kNumWarpsPerForwarder;
+            auto send_buffer = dst_rdma_rank == rdma_rank ? rdma_channel_data.recv_buffer(dst_rdma_rank) : rdma_channel_data.send_buffer(dst_rdma_rank);
+            auto sync_large_warp = [=]() {
+                if (kNumWarpsPerForwarder == 1) {
+                    __syncwarp();
+                } else {
+                    asm volatile("barrier.sync %0, %1;" :: "r"(dst_rdma_rank + 3), "r"(kNumWarpsPerForwarder * 32));
+                }
+            };
+            EP_STATIC_ASSERT(kNumWarpsPerForwarder == 1 or kNumRDMARanks + 2 <= 16, "Barriers are not enough");
+
+            // Get count and cached head
+            int num_tokens_to_combine = rdma_channel_prefix_matrix[dst_rdma_rank * num_channels + channel_id];
+            int num_tokens_prefix = channel_id == 0 ? 0 : rdma_channel_prefix_matrix[dst_rdma_rank * num_channels + channel_id - 1];
+            num_tokens_to_combine -= num_tokens_prefix;
+            num_tokens_prefix += dst_rdma_rank == 0 ? 0 : rdma_rank_prefix_sum[dst_rdma_rank - 1];
+            combined_nvl_head += num_tokens_prefix * NUM_MAX_NVL_PEERS;
+
+            // Iterate over all tokens and combine by chunks
+            for (int token_start_idx = 0; token_start_idx < num_tokens_to_combine; token_start_idx += num_max_rdma_chunked_send_tokens) {
+                // Check destination queue emptiness, or wait a buffer to be released
+                auto token_end_idx = min(token_start_idx + num_max_rdma_chunked_send_tokens, num_tokens_to_combine);
+                auto num_chunked_tokens = token_end_idx - token_start_idx;
+                auto start_time = clock64();
+                while (sub_warp_id == 0 and lane_id == 0) {
+                    // Inequality: `num_max_rdma_chunked_recv_tokens - (tail - head) >= num_chunked_tokens`
+                    // Here, `token_start_idx` is the actual tail
+                    int num_used_slots = token_start_idx - ld_volatile_global(rdma_channel_head.buffer(dst_rdma_rank));
+                    if (num_max_rdma_chunked_recv_tokens - num_used_slots >= num_chunked_tokens)
+                        break;
+
+                    // Timeout check
+                    if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                        printf("DeepEP zcopy combine forwarder (RDMA check) timeout, channel: %d, RDMA: %d, nvl: %d, dst RDMA: %d, head: %ld, tail: %d, chunked: %d\n",
+                               channel_id, rdma_rank, nvl_rank, dst_rdma_rank, ld_volatile_global(rdma_channel_head.buffer(dst_rdma_rank)), token_start_idx, num_chunked_tokens);
+                        trap();
+                    }
+                }
+                sync_large_warp();
+
+                // Combine and write to the RDMA buffer
+                for (int token_idx = token_start_idx + sub_warp_id; token_idx < token_end_idx; token_idx += kNumWarpsPerForwarder) {
+                    // Read expected head
+                    EP_STATIC_ASSERT(kNumRDMARanks <= 32, "Invalid number of RDMA peers");
+                    int expected_head = -1;
+                    if (lane_id < NUM_MAX_NVL_PEERS)
+                        expected_head = ld_nc_global(combined_nvl_head + token_idx * NUM_MAX_NVL_PEERS + lane_id);
+
+                    // Combine current token
+                    auto rdma_slot_idx = token_idx % num_max_rdma_chunked_recv_tokens;
+                    void* shifted = send_buffer + rdma_slot_idx * num_bytes_per_rdma_token;
+
+                    EP_STATIC_ASSERT(NUM_MAX_NVL_PEERS <= 32, "Too many ranks");
+                    int num_topk_ranks = 0, slot_idx;
+                    void* src_ptr[NUM_MAX_NVL_PEERS];
+                    void* src_tw_ptr[NUM_MAX_NVL_PEERS];
+                    bool is_token_in_rank = expected_head >= 0;
+
+                    #pragma unroll
+                    for (int i = 0; i < NUM_MAX_NVL_PEERS; ++ i) {
+                        if (__shfl_sync(0xffffffff, is_token_in_rank, i)) {
+                            slot_idx = __shfl_sync(0xffffffff, expected_head, i);
+                            int num_dispatch_tokens = recv_gbl_rank_prefix_sum_fwd[i * num_ranks + num_ranks - 1];
+                            EP_DEVICE_ASSERT(slot_idx < num_dispatch_tokens);
+                            int src_nvl_rank_x_bytes = num_dispatch_tokens * hidden_bytes;
+                            auto src_nvl_rank_x = reinterpret_cast<int4*>(ws_rr_fused_buffer_ptr[i]);
+                            auto src_nvl_rank_topk_weight = reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(ws_rr_fused_buffer_ptr[i]) + src_nvl_rank_x_bytes);
+
+                            src_ptr[num_topk_ranks] = src_nvl_rank_x + slot_idx * hidden_int4;
+                            src_tw_ptr[num_topk_ranks] = src_nvl_rank_topk_weight + slot_idx * num_topk;
+                            num_topk_ranks++;
+                        }
+                    }
+                    EP_DEVICE_ASSERT(num_topk_ranks <= NUM_MAX_NVL_PEERS);
+                    EP_DEVICE_ASSERT(warp_id < kNumForwarders);
+
+                    // Reduce `hidden` and `topk_weights`
+                    reduce_add_tma_warp(
+                        shifted,
+                        (void*)(reinterpret_cast<int8_t*>(shifted) + hidden_bytes + sizeof(SourceMeta)),
+                        (void**)src_ptr,
+                        (void**)src_tw_ptr,
+                        num_topk_ranks,
+                        num_topk,
+                        hidden_bytes,
+                        lane_id,
+                        smem_ptrs[warp_id],
+                        hidden_bytes,
+                        tma_mbarrier[warp_id]
+                    );
+                }
+                sync_large_warp();
+
+                // Issue RDMA send
+                if (sub_warp_id == kNumWarpsPerForwarder - 1) {
+                    if (dst_rdma_rank != rdma_rank) {
+                        auto rdma_slot_idx = token_start_idx % num_max_rdma_chunked_recv_tokens;
+                        const size_t num_bytes_per_msg = num_chunked_tokens * num_bytes_per_rdma_token;
+                        const auto dst_ptr = reinterpret_cast<uint64_t>(rdma_channel_data.recv_buffer(rdma_rank) + rdma_slot_idx * num_bytes_per_rdma_token);
+                        const auto src_ptr = reinterpret_cast<uint64_t>(rdma_channel_data.send_buffer(dst_rdma_rank) + rdma_slot_idx * num_bytes_per_rdma_token);
+                        nvshmemi_ibgda_put_nbi_warp<true>(dst_ptr, src_ptr, num_bytes_per_msg,
+                                                          translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank), channel_id, lane_id, 0);
+                    } else {
+                        memory_fence();
+                    }
+
+                    // Write new RDMA tail
+                    __syncwarp();
+                    if (lane_id == 0) {
+                        nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_tail.buffer(rdma_rank), num_chunked_tokens,
+                                                        translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank), channel_id, dst_rdma_rank == rdma_rank);
+                    }
+                }
+            }
+
+            sync_forwarder_smem();
+            if (warp_id == 0 and lane_id < NUM_MAX_NVL_PEERS) {
+                st_relaxed_sys_global(nvl_channel_finish_signal.buffer_by(lane_id) + nvl_rank, 1);
+            }
+            __syncwarp();
+        } else if (warp_role == WarpRole::kRDMAReceiver) {
+            // RDMA Consumer
+            // Receive from RDMA ranks and write to the output tensor
+            // Clean shared memory and sync
+            EP_DEVICE_ASSERT(kNumRDMARanks <= 32);
+            lane_id < kNumRDMARanks ? (rdma_receiver_rdma_head[warp_id][lane_id] = 0) : 0;
+            lane_id == 0 ? (rdma_receiver_retired[warp_id] = false) : 0;
+            sync_rdma_receiver_and_coordinator_smem();
+
+            // The same tokens as the dispatch process
+            int token_start_idx, token_end_idx;
+            get_channel_task_range(num_combined_tokens, num_channels, channel_id, token_start_idx, token_end_idx);
+
+            // Iterate over all tokens and combine
+            int cached_channel_tail_idx = 0;
+            for (int64_t token_idx = token_start_idx + warp_id; token_idx < token_end_idx; token_idx += kNumRDMAReceivers) {
+                // Read expected head
+                EP_STATIC_ASSERT(kNumRDMARanks <= 32, "Invalid number of RDMA peers");
+                int expected_head = -1;
+                if (lane_id < kNumRDMARanks) {
+                    expected_head = ld_nc_global(combined_rdma_head + token_idx * kNumRDMARanks + lane_id);
+                    (expected_head < 0) ? (rdma_receiver_rdma_head[warp_id][lane_id] = -expected_head - 1) : (rdma_receiver_rdma_head[warp_id][lane_id] = expected_head);
+                }
+
+                // Wait lanes to be ready
+                auto start_time = clock64();
+                while (cached_channel_tail_idx <= expected_head) {
+                    cached_channel_tail_idx = static_cast<int>(ld_acquire_sys_global(rdma_channel_tail.buffer(lane_id)));
+
+                    // Timeout check
+                    if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                        printf("DeepEP zcopy combine RDMA receiver timeout, channel: %d, RDMA: %d, nvl: %d, src RDMA: %d, tail: %d, waiting: %ld, expect: %d\n",
+                               channel_id, rdma_rank, nvl_rank, lane_id, cached_channel_tail_idx, token_idx, expected_head);
+                        trap();
+                    }
+                }
+                __syncwarp();
+
+                // Combine current token
+                auto recv_fn = [&](int src_rdma_rank, int slot_idx, int hidden_int4_idx) -> int4 { return ld_nc_global(reinterpret_cast<const int4*>(rdma_channel_data.recv_buffer(src_rdma_rank) + slot_idx * num_bytes_per_rdma_token) + hidden_int4_idx);};
+                auto recv_tw_fn = [&](int src_rdma_rank, int slot_idx, int topk_idx) -> float { return ld_nc_global(reinterpret_cast<const float*>(rdma_channel_data.recv_buffer(src_rdma_rank) + slot_idx * num_bytes_per_rdma_token + hidden_bytes + sizeof(SourceMeta)) + topk_idx);};
+                combine_token<kNumRDMARanks, dtype_t, kNumTopkRDMARanks>(expected_head >= 0,
+                                                                         expected_head, lane_id,
+                                                                         hidden_int4, num_topk,
+                                                                         combined_x + token_idx * hidden_int4,
+                                                                         combined_topk_weights + token_idx * num_topk,
+                                                                         num_max_rdma_chunked_recv_tokens, recv_fn, recv_tw_fn);
+            }
+            // Retired
+            __syncwarp();
+            if (lane_id == 0)
+                rdma_receiver_retired[warp_id] = true;
+        } else {
+            // Coordinator
+            // Sync shared memory status
+            sync_rdma_receiver_and_coordinator_smem();
+
+            int last_rdma_head = 0;
+            int dst_rdma_rank = lane_id < kNumRDMARanks ? lane_id : 0;
+            EP_STATIC_ASSERT(kNumCombineForwarderWarps <= 32, "Invalid number of forwarder warps");
+            while (true) {
+                // Retired
+                if (__all_sync(0xffffffff, lane_id >= kNumRDMAReceivers or rdma_receiver_retired[lane_id]))
+                    break;
+
+                // Find minimum head for RDMA ranks
+                int min_head = std::numeric_limits<int>::max();
+                #pragma unroll
+                for (int i = 0; i < kNumRDMAReceivers; ++ i) if (not rdma_receiver_retired[i])
+                    min_head = min(min_head, rdma_receiver_rdma_head[i][dst_rdma_rank]);
+                if (min_head != std::numeric_limits<int>::max() and min_head >= last_rdma_head + num_max_rdma_chunked_send_tokens and lane_id < kNumRDMARanks) {
+                    nvshmemi_ibgda_amo_nonfetch_add(rdma_channel_head.buffer(rdma_rank), min_head - last_rdma_head,
+                                                    translate_dst_rdma_rank<kLowLatencyMode>(dst_rdma_rank, nvl_rank), channel_id, dst_rdma_rank == rdma_rank);
+                    last_rdma_head = min_head;
+                }
+
+                // Nanosleep and let other warps work
+                __nanosleep(NUM_WAIT_NANOSECONDS);
+            }
+        }
+    }
+}
+
+void combine(cudaDataType_t type,
+             void* combined_x, float* combined_topk_weights,
+             const bool* is_combined_token_in_rank,
+             const void* x, const float* topk_weights,
+             const void* bias_0, const void* bias_1,
+             const int* combined_rdma_head, const int* combined_nvl_head,
+             const void* src_meta, const int* rdma_channel_prefix_matrix, const int* rdma_rank_prefix_sum, const int* gbl_channel_prefix_matrix,
+             const int* recv_gbl_rank_prefix_sum_fwd,
+             int num_tokens, int num_combined_tokens, int hidden, int num_topk,
+             void* rdma_buffer_ptr, int num_max_rdma_chunked_send_tokens, int num_max_rdma_chunked_recv_tokens,
+             void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
+             int rank, int num_ranks, cudaStream_t stream, int num_channels, bool low_latency_mode) {
+    // TODO: Zero-copy: Add support for bias
+    EP_HOST_ASSERT(bias_0 == nullptr and bias_1 == nullptr);
+
+    constexpr int kNumCombineForwarderWarps = 14;
+    constexpr int kNumRDMAReceivers = 32 - (1 + kNumCombineForwarderWarps + 1);
+    constexpr int smem_size = 14 * 1024 * kNumCombineForwarderWarps;
+
+#define COMBINE_LAUNCH_CASE(num_rdma_ranks) { \
+    auto combine_func = low_latency_mode ? \
+        combine<true, num_rdma_ranks, nv_bfloat16, kNumCombineForwarderWarps, kNumRDMAReceivers> : combine<false, num_rdma_ranks, nv_bfloat16, kNumCombineForwarderWarps, kNumRDMAReceivers>; \
+    SET_SHARED_MEMORY_FOR_TMA(combine_func) \
+    LAUNCH_KERNEL(&cfg, combine_func, \
+                  reinterpret_cast<int4*>(combined_x), combined_topk_weights, is_combined_token_in_rank, \
+                  reinterpret_cast<const int4*>(x), topk_weights, \
+                  combined_rdma_head, combined_nvl_head, \
+                  reinterpret_cast<const SourceMeta*>(src_meta), rdma_channel_prefix_matrix, rdma_rank_prefix_sum, gbl_channel_prefix_matrix, \
+                  recv_gbl_rank_prefix_sum_fwd, \
+                  num_tokens, num_combined_tokens, hidden, num_topk, \
+                  rdma_buffer_ptr, num_max_rdma_chunked_send_tokens, num_max_rdma_chunked_recv_tokens, \
+                  buffer_fused_ptrs, buffer_ptrs, num_max_nvl_chunked_send_tokens, num_max_nvl_chunked_recv_tokens, \
+                  rank, num_ranks); } break
+
+    int num_rdma_ranks = num_ranks / NUM_MAX_NVL_PEERS;
+    auto num_warps_per_forwarder = kNumCombineForwarderWarps / num_rdma_ranks;
+    int num_forwarder_warps = num_rdma_ranks * num_warps_per_forwarder;
+    EP_HOST_ASSERT(kNumCombineForwarderWarps / num_rdma_ranks >= 1);
+    EP_HOST_ASSERT(num_forwarder_warps > 0 and num_forwarder_warps % num_rdma_ranks == 0);
+    EP_HOST_ASSERT(num_max_nvl_chunked_recv_tokens % num_rdma_ranks == 0);
+    EP_HOST_ASSERT(num_max_nvl_chunked_recv_tokens / num_rdma_ranks > std::max(num_max_rdma_chunked_send_tokens, num_max_nvl_chunked_send_tokens));
+    EP_HOST_ASSERT(type == CUDA_R_16BF);
+
+    SETUP_LAUNCH_CONFIG(num_channels, (1 + num_forwarder_warps + kNumRDMAReceivers + 1) * 32, stream);
+    SWITCH_RDMA_RANKS(COMBINE_LAUNCH_CASE);
+#undef COMBINE_LAUNCH_CASE
+}
+
+} // namespace internode_zcopy
+
+} // namespace deep_ep

--- a/csrc/kernels/internode_zcopy.cu
+++ b/csrc/kernels/internode_zcopy.cu
@@ -730,7 +730,7 @@ void dispatch(void* recv_x, float* recv_x_scales, topk_idx_t* recv_topk_idx, flo
               void** buffer_fused_ptrs, void** buffer_ptrs, int num_max_nvl_chunked_send_tokens, int num_max_nvl_chunked_recv_tokens,
               int rank, int num_ranks, bool is_cached_dispatch,
               cudaStream_t stream, int num_channels, bool low_latency_mode) {
-    constexpr int smem_size = 16384 * (NUM_MAX_NVL_PEERS + 1); // +1 to account for alignment
+    constexpr int smem_size = 16384 * NUM_MAX_NVL_PEERS + ZCOPY_TMA_SMEM_ALIGNMENT;
 #define DISPATCH_LAUNCH_CASE(num_rdma_ranks) { \
     const int kNumDispatchRDMASenderWarps = num_rdma_ranks; \
     SETUP_LAUNCH_CONFIG(num_channels, (kNumDispatchRDMASenderWarps + 2 + NUM_MAX_NVL_PEERS) * 32, stream); \

--- a/csrc/kernels/internode_zcopy.cu
+++ b/csrc/kernels/internode_zcopy.cu
@@ -926,7 +926,7 @@ combine(int4* combined_x, float* combined_topk_weights,
 
         if (warp_role == WarpRole::kNVLAndRDMAForwarder) {
             // Dynamic TMA shared memory layout
-            const size_t SMEM_LEN_PER_WARP = 14 * 1024;
+            const size_t SMEM_LEN_PER_WARP = 16384;
             extern __shared__ int4 tma_smem[];
             char *tma_smem_aligned = reinterpret_cast<char *>(align_up<uintptr_t>(reinterpret_cast<uintptr_t>(tma_smem), ZCOPY_TMA_SMEM_ALIGNMENT));
             __shared__ uint64_t tma_mbarrier[kNumForwarders];
@@ -1161,7 +1161,7 @@ void combine(cudaDataType_t type,
     int num_rdma_ranks = num_ranks / NUM_MAX_NVL_PEERS;
     auto num_warps_per_forwarder = kNumCombineForwarderWarps / num_rdma_ranks;
     int num_forwarder_warps = num_rdma_ranks * num_warps_per_forwarder;
-    size_t smem_size = 7168 * 2 * num_forwarder_warps + ZCOPY_TMA_SMEM_ALIGNMENT;
+    size_t smem_size = 16384 * num_forwarder_warps + ZCOPY_TMA_SMEM_ALIGNMENT;
 
 #define COMBINE_LAUNCH_CASE(num_rdma_ranks) { \
     auto combine_func = low_latency_mode ? \

--- a/csrc/kernels/utils.cuh
+++ b/csrc/kernels/utils.cuh
@@ -33,6 +33,21 @@
     } \
 }
 
+template <typename T>
+struct ConvertToCharPointer {
+    using type = typename std::conditional<
+        std::is_const<typename std::remove_pointer<T>::type>::value,
+        const char *,
+        char *
+    >::type;
+};
+
+template <typename T>
+__forceinline__ __device__ __host__ T *shift_ptr(T *ptr, size_t offset) {
+    using char_ptr_t = typename ConvertToCharPointer<T *>::type;
+    return reinterpret_cast<T *>(reinterpret_cast<char_ptr_t>(ptr) + offset);
+}
+
 namespace deep_ep {
 
 template <int kBytes>
@@ -55,6 +70,21 @@ struct PatternVisitor {
         return func(i);
     }
 };
+
+template <typename dtype_t>
+__host__ __device__ constexpr dtype_t ceil_div(dtype_t a, dtype_t b) {
+    return (a + b - 1) / b;
+}
+
+template <typename dtype_t>
+__host__ __device__ constexpr dtype_t align_up(dtype_t a, dtype_t b) {
+    return ceil_div<dtype_t>(a, b) * b;
+}
+
+template <typename dtype_t>
+__host__ __device__ constexpr dtype_t align_down(dtype_t a, dtype_t b) {
+    return a / b * b;
+}
 
 __device__ __forceinline__ void trap() {
     asm("trap;");
@@ -162,8 +192,8 @@ __device__  __forceinline__ int64_t ld_volatile_global(const int64_t *ptr) {
     return ret;
 }
 
-__device__  __forceinline__ int64_t ld_volatile_global(const uint64_t *ptr) {
-    int64_t ret;
+__device__  __forceinline__ uint64_t ld_volatile_global(const uint64_t *ptr) {
+    uint64_t ret;
     asm volatile("ld.volatile.global.u64 %0, [%1];" : "=l"(ret) : "l"(ptr));
     return ret;
 }
@@ -400,22 +430,320 @@ __device__ __forceinline__ void tma_store_wait() {
     asm volatile("cp.async.bulk.wait_group.read %0;" :: "n"(N) : "memory");
 }
 
+__forceinline__ __device__
+uint32_t cast_smem_ptr_to_uint(void const *const ptr) {
+// We prefer to use the new CVTA intrinsics if they are available, otherwise we
+// will fall back to the previous internal intrinsics if they are available.
+  uint32_t smem_ptr;
+
+  asm("{ .reg .u64 smem_ptr; cvta.to.shared.u64 smem_ptr, %1; cvt.u32.u64 "
+      "%0, smem_ptr; }\n"
+      : "=r"(smem_ptr)
+      : "l"(ptr));
+
+  return smem_ptr;
+}
+
+struct SM90_TMA_LOAD_1D {
+    __forceinline__ __device__ static void
+    copy(void const *src_gmem_ptr, void *dst_smem_ptr, int32_t const &size, uint64_t cache_hint, uint64_t *mbar_ptr) {
+      // 地址转换（兼容 Hopper 寻址模式）
+      uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(src_gmem_ptr);
+      uint32_t smem_int_mbar = cast_smem_ptr_to_uint(mbar_ptr);
+      uint32_t smem_int_ptr = cast_smem_ptr_to_uint(dst_smem_ptr);
+
+      // 新版 PTX 指令
+      asm volatile(
+          "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes.L2::cache_hint"
+          " [%0], [%1], %2, [%3], %4;"
+          :
+          : "r"(smem_int_ptr),        // dest_prt(SMEM)
+            "l"(gmem_int_desc),       // src_ptr(GMEM)
+            "r"(size),               // Size,16的整数倍
+            "r"(smem_int_mbar),      // mbarrier 地址
+            "l"(cache_hint)          // 缓存策略（例如 L2::L2_128B）
+          : "memory"
+      );
+    }
+};
+
+struct SM90_TMA_STORE_1D {
+    __forceinline__ __device__ static void
+    copy(void const *src_smem_ptr, void const *dest_gmem_prt, int32_t const &size, uint64_t cache_hint) {  // 新增缓存策略参数
+      uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(dest_gmem_prt);
+      uint32_t smem_int_ptr = cast_smem_ptr_to_uint(src_smem_ptr);
+
+      // 新指令格式：添加L2缓存策略，调整操作数顺序
+      asm volatile(
+          "cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint"
+          " [%0], [%1], %2, %3;"
+          :
+          : "l"(gmem_int_desc),       // 目标：global mem
+            "r"(smem_int_ptr),      // 源：shmem
+            "r"(size),              // 数据块大小（字节数）
+            "l"(cache_hint)         // L2缓存策略
+          : "memory"
+      );
+    }
+};
+
+struct SM90_TMA_REDUCE_ADD_BF16 {
+    __forceinline__ __device__ static void
+    reduce_add(void const *src_smem_ptr, void *dst_gmem_ptr, int32_t const &size, uint64_t cache_hint) {
+      uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(dst_gmem_ptr);
+      uint32_t smem_int_ptr = cast_smem_ptr_to_uint(src_smem_ptr);
+      // 使用cp.reduce.async.bulk指令进行reduce add操作
+      asm volatile(
+          "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.noftz.bf16"
+          " [%0], [%1], %2;"
+          :
+          : "l"(gmem_int_desc),    // 目标：global mem
+            "r"(smem_int_ptr),    // 源：shared mem
+            "r"(size)
+          : "memory"
+      );
+    }
+};
+
+struct SM90_TMA_REDUCE_ADD_F32 {
+    __forceinline__ __device__ static void
+    reduce_add(void const *src_smem_ptr, void *dst_gmem_ptr, int32_t const &size, uint64_t cache_hint) {
+      uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(dst_gmem_ptr);
+      uint32_t smem_int_ptr = cast_smem_ptr_to_uint(src_smem_ptr);
+      // 使用cp.reduce.async.bulk指令进行reduce add操作
+      asm volatile(
+          "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f32"
+          " [%0], [%1], %2;"
+          :
+          : "l"(gmem_int_desc),    // 目标：global mem
+            "r"(smem_int_ptr),    // 源：shared mem
+            "r"(size)
+          : "memory"
+      );
+    }
+};
+
+__forceinline__ __device__ void
+initialize_barrier(uint64_t& smem_barrier,                 // 64 bits user-manged barrier in smem
+                   int thread_count = 1)                   // Thread count expected to arrive/wait on this barrier
+{
+  uint32_t smem_int_ptr = cast_smem_ptr_to_uint(&smem_barrier);
+  asm volatile ("mbarrier.init.shared::cta.b64 [%0], %1;\n"
+    :: "r"(smem_int_ptr),
+       "r"(thread_count));
+}
+
+// Set the number of bytes transfered per transaction and perform an arrive operation as well
+__forceinline__ __device__ void
+set_barrier_transaction_bytes(uint64_t& smem_barrier,      // 64 bits user-manged barrier in smem
+                              uint32_t bytes)              // Number of bytes transfered by per TMA transaction
+{
+  uint32_t smem_int_ptr = cast_smem_ptr_to_uint(&smem_barrier);
+  asm volatile ("mbarrier.arrive.expect_tx.shared::cta.b64 _, [%0], %1;\n"
+    :: "r"(smem_int_ptr),
+       "r"(bytes));
+}
+
+// Barrier wait
+__forceinline__ __device__ void
+wait_barrier(uint64_t& smem_barrier,                       // 64 bits user-manged barrier in smem
+             int phase_bit)                                // Current phase bit the barrier waiting to flip
+{
+  uint32_t smem_int_ptr = cast_smem_ptr_to_uint(&smem_barrier);
+  asm volatile(
+    "{\n"
+    ".reg .pred                P1;\n"
+    "LAB_WAIT:\n"
+    "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
+    "@P1                       bra DONE;\n"
+    "bra                   LAB_WAIT;\n"
+    "DONE:\n"
+    "}\n"
+    :: "r"(smem_int_ptr),
+       "r"(phase_bit));
+}
+
+__forceinline__ __device__ static void
+tma_commit_group() {
+    asm volatile("cp.async.bulk.commit_group;");
+}
+
+// Wait until all TMA descriptor previously issued are safe to be modified after tma_desc_commit_group()
+__forceinline__ __device__ static void
+tma_wait_group() {
+    asm volatile(
+      "cp.async.bulk.wait_group %0;"
+      :
+      : "n"(0)
+      : "memory");
+}
+
+__device__ __forceinline__ void memcpy_tma_warp(
+    void *dst_ptr, 
+    const void *src_ptr,
+    size_t size, 
+    int lane_id, 
+    char* smem,
+    size_t smem_len,
+    uint64_t& tma_mbarrier
+) {
+    // TODO: Tune this value
+    int kTransactionBytes = 0;
+    if (smem_len < size) {
+        int kNumCopy = ceil_div(size, smem_len);
+        kTransactionBytes = align_up(static_cast<int>(size) / kNumCopy, 16);
+    }
+    else {
+        kTransactionBytes = size;
+    }
+
+    for (int i = 0; i < size; i += kTransactionBytes) {
+        const int chunk_size = min(kTransactionBytes, static_cast<int>(size) - i);
+        if (lane_id == 0) {
+            initialize_barrier(tma_mbarrier, 1);
+            set_barrier_transaction_bytes(tma_mbarrier, chunk_size);
+            SM90_TMA_LOAD_1D::copy((void*)(reinterpret_cast<const char *>(src_ptr) + i), smem, chunk_size, 0x0, &tma_mbarrier);
+        }
+        __syncwarp();
+        wait_barrier(tma_mbarrier, 0);
+
+        if (lane_id == 0) {
+            SM90_TMA_STORE_1D::copy(smem, (void*)(reinterpret_cast<char *>(dst_ptr) + i), chunk_size, 0x0);
+            tma_commit_group();
+        }
+        tma_wait_group();
+        __syncwarp();
+    }
+}
+
+__device__ __forceinline__ void memcpy_tma_lane_launch_load(
+    const void *src_ptr,
+    size_t size,
+    char* smem,
+    uint64_t& tma_mbarrier
+) {
+    initialize_barrier(tma_mbarrier, 1);
+    set_barrier_transaction_bytes(tma_mbarrier, size);
+    SM90_TMA_LOAD_1D::copy(src_ptr, smem, size, 0x0, &tma_mbarrier);
+}
+
+__device__ __forceinline__ void memcpy_tma_lane_launch_store(
+    void *dst_ptr,
+    size_t size,
+    char* smem,
+    uint64_t& tma_mbarrier
+) {
+    wait_barrier(tma_mbarrier, 0);
+    SM90_TMA_STORE_1D::copy(smem, dst_ptr, size, 0x0);
+    tma_commit_group();
+}
+
+__device__ __forceinline__ void memcpy_tma_warp_finalize() {
+    tma_wait_group();
+    __syncwarp();
+}
+
+__device__ __forceinline__ void reduce_add_tma_warp(
+    void *combined_row,
+    void *combined_row_topk_weights,
+    void **src_ptr,
+    void **src_tw_ptr,
+    int num_topk_ranks,
+    int num_topk,
+    size_t size,
+    int lane_id,
+    char* smem,
+    size_t smem_len,
+    uint64_t &tma_mbarrier
+) {
+    EP_DEVICE_ASSERT(size <= smem_len);
+    float topk_weight_value = 0;
+    for (int i = 0; i < num_topk_ranks; i++) {
+        if (lane_id == 0) {
+            initialize_barrier(tma_mbarrier, 1);
+            set_barrier_transaction_bytes(tma_mbarrier, smem_len);
+            SM90_TMA_LOAD_1D::copy((void*)(reinterpret_cast<char *>(src_ptr[i])), smem, smem_len, 0x0, &tma_mbarrier);
+        }
+        __syncwarp();
+
+        if (lane_id < num_topk) {
+            topk_weight_value += ld_nc_global(reinterpret_cast<float*>(src_tw_ptr[i]) + lane_id);
+        }
+
+        wait_barrier(tma_mbarrier, 0);
+
+        if (lane_id == 0) {
+            if (i == 0) {
+                SM90_TMA_STORE_1D::copy(smem, (void*)(reinterpret_cast<char *>(combined_row)), smem_len, 0x0);
+            }
+            else{
+                SM90_TMA_REDUCE_ADD_BF16::reduce_add(smem, (void*)(reinterpret_cast<char *>(combined_row)), smem_len, 0x0);
+            }
+            tma_commit_group();
+        }
+        tma_wait_group();
+        __syncwarp();
+    }
+
+    if (lane_id < num_topk) {
+        st_na_global(reinterpret_cast<float*>(combined_row_topk_weights) + lane_id, topk_weight_value);
+    }
+}
+
+
+template <typename dtype_t>
+__device__ __forceinline__ void reduce_add_regular_warp(
+    void *combined_row,
+    void *combined_row_topk_weights,
+    void **src_ptr,
+    void **src_tw_ptr,
+    int num_topk_ranks,
+    int num_topk,
+    int hidden_int4,
+    int lane_id
+) {
+    // Reduce data
+    constexpr auto kDtypePerInt4 = sizeof(int4) / sizeof(dtype_t);
+    #pragma unroll
+    for (int i = lane_id; i < hidden_int4; i += 32) {
+        // Read buffers
+        // TODO: maybe too many registers here
+        int4 recv_value_int4[NUM_MAX_NVL_PEERS];
+        #pragma unroll
+        for (int j = 0; j < num_topk_ranks; ++ j)
+            recv_value_int4[j] = ld_nc_global(reinterpret_cast<int4*>(src_ptr[j]) + i);
+
+        // Reduce all-to-all results
+        float values[kDtypePerInt4] = {0};
+        #pragma unroll
+        for (int j = 0; j < num_topk_ranks; ++ j) {
+            auto recv_value_dtypes = reinterpret_cast<const dtype_t*>(&recv_value_int4[j]);
+            #pragma unroll
+            for (int k = 0; k < kDtypePerInt4; ++ k)
+                values[k] += static_cast<float>(recv_value_dtypes[k]);
+        }
+
+        // Cast back to `dtype_t` and write
+        int4 out_int4;
+        auto out_dtypes = reinterpret_cast<dtype_t*>(&out_int4);
+        #pragma unroll
+        for (int j = 0; j < kDtypePerInt4; ++ j)
+            out_dtypes[j] = static_cast<dtype_t>(values[j]);
+        st_na_global(reinterpret_cast<int4*>(combined_row) + i, out_int4);
+    }
+
+    // Reduce `topk_weights`
+    if (lane_id < num_topk) {
+        float value = 0;
+        #pragma unroll
+        for (int i = 0; i < num_topk_ranks; ++ i)
+            value += ld_nc_global(reinterpret_cast<float*>(src_tw_ptr[i]) + lane_id);
+        st_na_global(reinterpret_cast<float*>(combined_row_topk_weights) + lane_id, value);
+    }
+    __syncwarp();
+}
+
 #endif
-
-template <typename dtype_t>
-__host__ __device__ constexpr dtype_t ceil_div(dtype_t a, dtype_t b) {
-    return (a + b - 1) / b;
-}
-
-template <typename dtype_t>
-__host__ __device__ constexpr dtype_t align_up(dtype_t a, dtype_t b) {
-    return ceil_div<dtype_t>(a, b) * b;
-}
-
-template <typename dtype_t>
-__host__ __device__ constexpr dtype_t align_down(dtype_t a, dtype_t b) {
-    return a / b * b;
-}
 
 __forceinline__ __device__ void get_channel_task_range(int num_tokens, int num_sms, int sm_id,
                                                        int& token_start_idx, int& token_end_idx) {

--- a/csrc/kernels/utils.cuh
+++ b/csrc/kernels/utils.cuh
@@ -461,11 +461,6 @@ __device__ __forceinline__ void memcpy_tma_lane_launch_store(
     tma_store_1d(smem, dst_ptr, size);
 }
 
-__device__ __forceinline__ void memcpy_tma_warp_finalize() {
-    tma_store_wait<0>();
-    __syncwarp();
-}
-
 __device__ __forceinline__ void reduce_add_tma_warp(
     void *combined_row,
     void *combined_row_topk_weights,

--- a/csrc/kernels/utils.cuh
+++ b/csrc/kernels/utils.cuh
@@ -439,18 +439,19 @@ __device__ __forceinline__ void tma_store_wait() {
     asm volatile("cp.async.bulk.wait_group.read %0;" :: "n"(N) : "memory");
 }
 
-__device__ __forceinline__ void memcpy_tma_lane_launch_load(const void* src_ptr, size_t size,
-                                                            char* smem, uint64_t& tma_mbarrier) {
-    mbarrier_init(&tma_mbarrier, 1);
-    mbarrier_arrive_and_expect_tx(&tma_mbarrier, size);
-    tma_load_1d(smem, src_ptr, &tma_mbarrier, size);
+__device__ __forceinline__ void tma_load_1d_launch(char* smem_ptr, const void* gmem_ptr,
+                                                   uint64_t* mbar_ptr, size_t num_bytes) {
+    constexpr int arrive_count = 1;
+    mbarrier_init(mbar_ptr, arrive_count);
+    mbarrier_arrive_and_expect_tx(mbar_ptr, num_bytes);
+    tma_load_1d(smem_ptr, gmem_ptr, mbar_ptr, num_bytes);
 }
 
-__device__ __forceinline__ void memcpy_tma_lane_launch_store(void* dst_ptr, size_t size,
-                                                             const char* smem, uint64_t& tma_mbarrier) {
+__device__ __forceinline__ void tma_store_1d_launch(const char* smem_ptr, void* gmem_ptr,
+                                                    uint64_t* mbar_ptr, size_t num_bytes) {
     uint32_t tma_phase = 0;
-    mbarrier_wait(&tma_mbarrier, tma_phase);
-    tma_store_1d(smem, dst_ptr, size);
+    mbarrier_wait(mbar_ptr, tma_phase);
+    tma_store_1d(smem_ptr, gmem_ptr, num_bytes);
 }
 
 #endif

--- a/deep_ep/buffer.py
+++ b/deep_ep/buffer.py
@@ -123,7 +123,7 @@ class Buffer:
             # Disable NVLink SHArP
             os.environ['NVSHMEM_DISABLE_NVLS'] = '1'
             # NOTES: NVSHMEM initialization requires at least 256 MiB
-            os.environ['NVSHMEM_CUMEM_GRANULARITY'] = f'{2 ** 31}' if enable_zcopy else f'{2 ** 29}'
+            os.environ['NVSHMEM_CUMEM_GRANULARITY'] = f'{2 ** 29}'
 
             if not allow_mnnvl:
                 # Disable multi-node NVLink detection

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
         cxx_flags.append('-DDISABLE_NVSHMEM')
         nvcc_flags.append('-DDISABLE_NVSHMEM')
     else:
-        sources.extend(['csrc/kernels/internode.cu', 'csrc/kernels/internode_ll.cu'])
+        sources.extend(['csrc/kernels/internode.cu', 'csrc/kernels/internode_zcopy.cu', 'csrc/kernels/internode_ll.cu'])
         include_dirs.extend([f'{nvshmem_dir}/include'])
         library_dirs.extend([f'{nvshmem_dir}/lib'])
         nvcc_dlink.extend(['-dlink', f'-L{nvshmem_dir}/lib', '-lnvshmem_device'])

--- a/tests/test_internode.py
+++ b/tests/test_internode.py
@@ -217,7 +217,7 @@ def test_main(args: argparse.Namespace, num_sms: int,
                     event.current_stream_wait() if async_mode else ()
                     check_x = (combined_x.float() if disable_bias else combined_x.float() - bias_0.float() - bias_1.float()) / is_token_in_rank.sum(dim=1).unsqueeze(1)
                     ref_x = x_pure_rand if is_rand else x
-                    assert calc_diff(check_x, ref_x) < 5e-4 if current_x is x_pure_rand_e4m3 else 5e-6 
+                    assert calc_diff(check_x, ref_x) < (5e-4 if current_x is x_pure_rand_e4m3 else 5e-6)
                     if with_topk:
                         check_topk_weights = combined_topk_weights if is_rand else (combined_topk_weights / is_token_in_rank.sum(dim=1).unsqueeze(1))
                         ref_topk_weights = topk_weights_pure_rand if is_rand else topk_weights

--- a/tests/test_internode.py
+++ b/tests/test_internode.py
@@ -62,6 +62,7 @@ def test_main(args: argparse.Namespace, num_sms: int,
 
     # RDMA dispatch counts
     rdma_idx = topk_idx // (num_experts // num_nodes)
+    rdma_idx = rdma_idx.to(torch.int64)
     rdma_idx.masked_fill_(topk_idx == -1, -1)
     inplace_unique(rdma_idx, num_nodes)
     num_rdma_token_sent = rdma_idx.ne(-1).sum().item()


### PR DESCRIPTION
The original Internode Normal Kernel suffers from high GPU SM utilization and underutilized interconnect bandwidth, which constrains prefill performance.
In our optimized version, we apply buffer fusion and TMA offloading to enable true zero-copy communication and maximize NVLink bandwidth usage.


Evaluation on H20 clusters shows significant gains:
* With EP=16, performance (dispatch(FP8) / dispatch(BF16) / combine) improved from 76.50 / 84.05 / 62.50 to 89.46 / 91.82 / 82.27.
* With EP=32, performance increased from 59.95 / 61.33 / 61.24 to 62.53 / 63.24 / 62.55.

Additionally, SM occupancy was reduced by up to 66.7%. The optimized kernel uses only 12 SMs for EP=16 and 8 SMs for EP=32, compared to 24 SMs in the original version.