### PR TITLE
Add guards for scales when the type is bf16

### DIFF
--- a/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
+++ b/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
@@ -204,15 +204,15 @@ struct dispatch_kernel_param_t{
   // Input buffers. These buffers are local buffers.
   const TOKEN_DATA_TYPE* attn_input_token;
   const float* attn_input_prob; // Needed by expert layer, so only valid in forward dispatch.
-  const float* attn_input_token_scaling_factor; // If input token is FP8 dtype, we need scaling factor for tokens.
+  const float* attn_input_token_scaling_factor = nullptr; // If input token is FP8 dtype, we need scaling factor for tokens.
   // Output buffers. These buffers are both local and remote buffers.
   TOKEN_DATA_TYPE* expert_output_token[MAX_NUM_OF_RANKS_PER_NODE];
   float* expert_output_prob[MAX_NUM_OF_RANKS_PER_NODE]; // Only valid in forward dispatch.
-  float* expert_output_scaling_factor[MAX_NUM_OF_RANKS_PER_NODE]; // Only valid for FP8 token type.
+  float* expert_output_scaling_factor[MAX_NUM_OF_RANKS_PER_NODE] = {}; // Only valid for FP8 token type.
   // Internal temp buffers. These buffers are local buffers.
   const TOKEN_DATA_TYPE* rdma_inter_node_group_token;
   const float* rdma_inter_node_group_prob; // Only valid in forward dispatch.
-  const float* rdma_inter_node_group_scaling_factor; // Only valid for FP8 token type.
+  const float* rdma_inter_node_group_scaling_factor = nullptr; // Only valid for FP8 token type.
   uint64_t* rdma_inter_node_group_flags; // For RDMA Atomic flags.
   uint32_t* intra_node_write_completion_flags; // For intra-node S2G write completion notification.
   // Metadata buffers. These buffers are local buffers.

--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -72,16 +72,21 @@ void Executor::dispatch_core(HybridEpConfigInstance config, DispatchBuffers& dis
       param.expert_output_token[i] = reinterpret_cast<DType*>(
           dispatch_buffers.expert_output_token_all_ranks[i]);
       param.expert_output_prob[i] = dispatch_buffers.expert_output_prob_all_ranks[i];
-      param.expert_output_scaling_factor[i] = 
-          dispatch_buffers.expert_output_scaling_factor_all_ranks[i];
+      if (config.token_data_type == TOKEN_DATA_TYPE::UINT8) {
+          param.expert_output_scaling_factor[i] = 
+              dispatch_buffers.expert_output_scaling_factor_all_ranks[i];
+      }
     }
     
     // Setup local buffer pointers
     param.rdma_inter_node_group_token = reinterpret_cast<DType*>(
         dispatch_buffers.rdma_inter_node_group_token);
     param.rdma_inter_node_group_prob = dispatch_buffers.rdma_inter_node_group_prob;
-    param.rdma_inter_node_group_scaling_factor = 
-        dispatch_buffers.rdma_inter_node_group_scaling_factor;
+    if (config.token_data_type == TOKEN_DATA_TYPE::UINT8) {
+        param.rdma_inter_node_group_scaling_factor = 
+            dispatch_buffers.rdma_inter_node_group_scaling_factor;
+    }
+
     param.rdma_inter_node_group_flags = dispatch_buffers.rdma_inter_node_group_flags;
     param.intra_node_write_completion_flags = 
         dispatch_buffers.intra_node_write_completion_flags;

--- a/csrc/hybrid_ep/utils.cuh
+++ b/csrc/hybrid_ep/utils.cuh
@@ -42,12 +42,12 @@ struct DispatchBuffers {
   void **expert_output_token_all_ranks;
   float *expert_output_prob;
   float **expert_output_prob_all_ranks;
-  float *expert_output_scaling_factor;
-  float **expert_output_scaling_factor_all_ranks;
+  float *expert_output_scaling_factor = nullptr;
+  float **expert_output_scaling_factor_all_ranks = nullptr;
   // Local temp buffer for dispatch kernel.
   void *rdma_inter_node_group_token;
   float *rdma_inter_node_group_prob;
-  float *rdma_inter_node_group_scaling_factor;
+  float *rdma_inter_node_group_scaling_factor = nullptr;
   uint64_t *rdma_inter_node_group_flags;
   // Misc flags
   uint32_t *intra_node_write_completion_flags;


### PR DESCRIPTION
I'm working on integrating the DeepEP hybrid kernels with vLLM and ran into problems when running with bf16 tokens.  I added some checks to allow for null scales for bf16 and it fixed the crashes I was running into.

cc @jershi425 , @Autumn1998 