### PR TITLE
fix benchmark error when slow

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -208,7 +208,7 @@ def bench_kineto(fn,
         prof.export_chrome_trace(trace_path)
 
     # Return average kernel durations
-    units = {'ms': 1e3, 'us': 1e6}
+    units = {'ms': 1e3, 'us': 1e6, 's': 1}
     kernel_durations = []
     for name in kernel_names:
         for line in prof_lines:


### PR DESCRIPTION
when kernel time is greater than 1s, it will failt with bellow erro:

```
  File "/workspace/DeepEP/tests/test_internode.py", line 205, in test_main
    t, notify_t = bench_kineto(lambda: buffer.dispatch(**tune_args), ('dispatch', 'notify'), suppress_kineto_output=True)
    ^^^^^^^^^^^
ValueError: not enough values to unpack (expected 2, got 1)
```