### PR TITLE
Fix nvshmem_host_lib name in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ if __name__ == '__main__':
             disable_nvshmem = True
     else:
         disable_nvshmem = False
+        # Get the actual versioned library name when NVSHMEM_DIR is provided
+        nvshmem_host_lib = get_nvshmem_host_lib_name(nvshmem_dir)
 
     if not disable_nvshmem:
         assert os.path.exists(nvshmem_dir), f'The specified NVSHMEM directory does not exist: {nvshmem_dir}'


### PR DESCRIPTION
When installing nvshmem 3.3.20 via pip, the name of the file is `libnvshmem_host.so.3` instead of `libnvshmem_host.so`, so I guess it's more robust to use `get_nvshmem_host_lib_name`
<img width="562" height="151" alt="image" src="https://github.com/user-attachments/assets/c0d57eb8-4d46-40ca-90d5-25e6504f991a" />
