### PR TITLE
Add internode Support  for the SM80 architecture

### DIFF
--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -51,12 +51,35 @@
 #ifndef DISABLE_SM90_FEATURES
 #include <cuda_fp8.h>
 #else
-// Ampere does not support FP8 features
+// Define minimal FP8 types to avoid compilation errors in CUDA standard library
+typedef uint8_t __nv_fp8_storage_t;
+typedef uint32_t __nv_fp8x2_storage_t;
+
+struct __nv_fp8_e4m3 {
+    __nv_fp8_storage_t __x;
+    __nv_fp8_e4m3() = default;
+    __device__ __nv_fp8_e4m3(__nv_fp8_storage_t x) : __x(x) {}
+};
+
+struct __nv_fp8_e5m2 {
+    __nv_fp8_storage_t __x;
+    __nv_fp8_e5m2() = default;
+    __device__ __nv_fp8_e5m2(__nv_fp8_storage_t x) : __x(x) {}
+};
+
+// Define minimal FP8 constants and functions as stubs
 #define __NV_E4M3 0
 #define __NV_E5M2 1
-typedef int __nv_fp8_interpretation_t;
-typedef int __nv_fp8x4_e4m3;
-typedef uint8_t __nv_fp8_storage_t;
+#define __NV_SATFINITE 0
+
+// Stub FP8 conversion function
+__device__ static inline __nv_fp8x2_storage_t __nv_cvt_float2_to_fp8x2(float2, int, int) {
+    return 0;  // Return dummy value
+}
+
+// Prevent cuda_fp8.h from being included when SM90 features are disabled
+#define CUDA_FP8_H
+#define __CUDA_FP8_H__
 #endif
 
 namespace deep_ep {

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,8 @@ if __name__ == '__main__':
         cxx_flags.append('-DDISABLE_SM90_FEATURES')
         nvcc_flags.append('-DDISABLE_SM90_FEATURES')
 
-        # Disable internode and low-latency kernels
-        assert disable_nvshmem
+        # CUDA 12 flags
+        nvcc_flags.extend(['-rdc=true', '--ptxas-options=--register-usage-level=10'])
     else:
         # Prefer H800 series
         os.environ['TORCH_CUDA_ARCH_LIST'] = os.getenv('TORCH_CUDA_ARCH_LIST', '9.0')


### PR DESCRIPTION
### Background: 
1). The A800 DeepEP only supports intra-machine communication; inter-machine communication is not supported; 
2). We require multi-machine communication via DeepEP on our A800 systems.

### Modifications
1). Supports compilation in internode mode under the SM80 architecture using:
```
export TORCH_CUDA_ARCH_LIST="8.0"
export DISABLE_SM90_FEATURES=1
```
2). Modified PTX instructions unsupported on the SM80 architecture, 
e.g. `atom.acquire.cta.shared::cta.cas.b32`
3). Modified launch method to support cg::this_grid().sync() under SM80.
4). Employed the macro DISABLE_SM90_FEATURES to differentiate between SM90 and SM80 data copying approaches.

### Performance testing
NVLINK bandwidth: 25GB/s * 8
NET: 100Gb/s * 8
Use the test script's default parameters directly, noting that the --disable-sm90-features parameter must be added. For normal mode, additionally include --test-ll-compatibility (omitting this on A800 will limit usage to only 4 network cards).

<meta charset="UTF-8"><div class="mp-paragraph-wrapper hxj" data-morpho-type="paragraph" style="padding-left:0px;--indent-pixels:0px" data-slate-node="element" data-morpho-padding="0"><span data-morpho-text="Normal">Normal</span><div class="mp-paragraph-block-selection"></div></div><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
Type | Dispatch #EP | Bottleneck bandwidth | Combine #EP | Bottleneck bandwidth
-- | -- | -- | -- | --
Intranode | 8 | 170.96 GB/s (NVLink) | 8 | 166.52 GB/s (NVLink)
Internode | 16 | 21.22 GB/s (RDMA) | 16 | 20.59 GB/s (RDMA)
Internode | 32 | 14.59 GB/s (RDMA) | 32 | 14.34 GB/s (RDMA)

</div><div class="mp-table-serialize-flag"><br/></div></div></div><span data-morpho-doc-data='{"token":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiYXBwSWQiOjEsInVpZCI6IkxfcWM3dVFiT3oiLCJkb2NJZCI6IktOcWI4OEwyMV9fQS03In0..5dw15Di2MHYAAPJu.0zKEpS2fnNxhEACvv4p-jfLjv5VobT-hRTUTkxBTgsry7WdWIV9jVqOuFneC8E1QjqgX04RTLMIjc3kM3hRjSwvFkmYHMEQr2nibqIQNFAwN6GceV8vPJ6_mpTQxBByApOg1t5YquR8saACWYKfJXDddIA69Lcp9qIUPB8ekJKNfZ53bFQRXdSLT4VHkjjsy0eEzpf7FbK1dOATQiY1QUww6iw.LgrwKrEQszimFypWOtiAGA","appId":"1"}' class='mp-morpho-clipboard-doc-data' ></span>

<meta charset="UTF-8"><div class="mp-paragraph-wrapper hxj" data-morpho-type="paragraph" style="padding-left:0px;--indent-pixels:0px" data-slate-node="element" data-morpho-padding="0"><span data-morpho-text="Low-latency">Low-latency</span><div class="mp-paragraph-block-selection"></div></div><div class="mp-table-align"><div class="mp-table-wrapper"><div data-slate-node="element" style="padding-left:0px" class="mp-table-container">
Dispatch #EP | Latency | RDMA bandwidth | Combine #EP | Latency | RDMA bandwidth
-- | -- | -- | -- | -- | --
16 | 410.02 us | 18.32 GB/s | 16 | 728.45 us | 19.96 GB/s
32 | 672.17 us | 12.55 GB/s | 32 | 1174.00 us | 12.67 GB/s

</div><div class="mp-table-serialize-flag"><br/></div></div></div><span data-morpho-doc-data='{"token":"eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIiwiYXBwSWQiOjEsInVpZCI6IkxfcWM3dVFiT3oiLCJkb2NJZCI6IktOcWI4OEwyMV9fQS03In0..5dw15Di2MHYAAPJu.0zKEpS2fnNxhEACvv4p-jfLjv5VobT-hRTUTkxBTgsry7WdWIV9jVqOuFneC8E1QjqgX04RTLMIjc3kM3hRjSwvFkmYHMEQr2nibqIQNFAwN6GceV8vPJ6_mpTQxBByApOg1t5YquR8saACWYKfJXDddIA69Lcp9qIUPB8ekJKNfZ53bFQRXdSLT4VHkjjsy0eEzpf7FbK1dOATQiY1QUww6iw.LgrwKrEQszimFypWOtiAGA","appId":"1"}' class='mp-morpho-clipboard-doc-data' ></span>