### PR TITLE
Fix compatibility with torch2.10

### DIFF
--- a/csrc/deep_ep.cpp
+++ b/csrc/deep_ep.cpp
@@ -435,7 +435,7 @@ Buffer::get_dispatch_layout(
     std::optional<EventHandle> event;
     if (async) {
         event = EventHandle(comm_stream);
-        for (auto& t : {topk_idx, num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank}) {
+        for (auto& t : {num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank}) {
             t.record_stream(comm_stream);
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
@@ -721,9 +721,7 @@ Buffer::intranode_dispatch(const torch::Tensor& x,
     std::optional<EventHandle> event;
     if (async) {
         event = EventHandle(comm_stream);
-        for (auto& t : {x,
-                        is_token_in_rank,
-                        rank_prefix_matrix,
+        for (auto& t : {rank_prefix_matrix,
                         channel_prefix_matrix,
                         recv_x,
                         recv_src_idx,
@@ -733,14 +731,7 @@ Buffer::intranode_dispatch(const torch::Tensor& x,
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
         }
-        for (auto& to : {x_scales,
-                         topk_idx,
-                         topk_weights,
-                         num_tokens_per_rank,
-                         num_tokens_per_expert,
-                         cached_channel_prefix_matrix,
-                         cached_rank_prefix_matrix,
-                         recv_topk_idx,
+        for (auto& to : {recv_topk_idx,
                          recv_topk_weights,
                          recv_x_scales}) {
             to.has_value() ? to->record_stream(comm_stream) : void();
@@ -889,12 +880,12 @@ std::tuple<torch::Tensor, std::optional<torch::Tensor>, std::optional<EventHandl
     std::optional<EventHandle> event;
     if (async) {
         event = EventHandle(comm_stream);
-        for (auto& t : {x, src_idx, send_head, rank_prefix_matrix, channel_prefix_matrix, recv_x}) {
+        for (auto& t : {recv_x}) {
             t.record_stream(comm_stream);
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
         }
-        for (auto& to : {topk_weights, recv_topk_weights, bias_0, bias_1}) {
+        for (auto& to : {recv_topk_weights}) {
             to.has_value() ? to->record_stream(comm_stream) : void();
             if (allocate_on_comm_stream)
                 to.has_value() ? to->record_stream(compute_stream) : void();
@@ -1244,9 +1235,7 @@ Buffer::internode_dispatch(const torch::Tensor& x,
     std::optional<EventHandle> event;
     if (async) {
         event = EventHandle(comm_stream);
-        for (auto& t : {x,
-                        is_token_in_rank,
-                        recv_x,
+        for (auto& t : {recv_x,
                         rdma_channel_prefix_matrix,
                         recv_rdma_rank_prefix_sum,
                         gbl_channel_prefix_matrix,
@@ -1255,17 +1244,7 @@ Buffer::internode_dispatch(const torch::Tensor& x,
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
         }
-        for (auto& to : {x_scales,
-                         topk_idx,
-                         topk_weights,
-                         num_tokens_per_rank,
-                         num_tokens_per_rdma_rank,
-                         num_tokens_per_expert,
-                         cached_rdma_channel_prefix_matrix,
-                         cached_recv_rdma_rank_prefix_sum,
-                         cached_gbl_channel_prefix_matrix,
-                         cached_recv_gbl_rank_prefix_sum,
-                         recv_topk_idx,
+        for (auto& to : {recv_topk_idx,
                          recv_topk_weights,
                          recv_x_scales,
                          recv_rdma_channel_prefix_matrix,
@@ -1461,20 +1440,14 @@ std::tuple<torch::Tensor, std::optional<torch::Tensor>, std::optional<EventHandl
     std::optional<EventHandle> event;
     if (async) {
         event = EventHandle(comm_stream);
-        for (auto& t : {x,
-                        src_meta,
-                        is_combined_token_in_rank,
-                        rdma_channel_prefix_matrix,
-                        rdma_rank_prefix_sum,
-                        gbl_channel_prefix_matrix,
-                        combined_x,
+        for (auto& t : {combined_x,
                         combined_rdma_head,
                         combined_nvl_head}) {
             t.record_stream(comm_stream);
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
         }
-        for (auto& to : {topk_weights, combined_topk_weights, bias_0, bias_1}) {
+        for (auto& to : {combined_topk_weights}) {
             to.has_value() ? to->record_stream(comm_stream) : void();
             if (allocate_on_comm_stream)
                 to.has_value() ? to->record_stream(compute_stream) : void();


### PR DESCRIPTION
PyTorch 2.10 introduced stricter validation on tensor metadata operations. Specifically, when `tensor.record_stream()` is called, PyTorch 2.10+ internally calls `set_stride()` or similar metadata operations. If that tensor was created from `.detach()` upstream, PyTorch now strictly forbids these metadata modifications.

So only call `record_stream()` on tensors it creates and owns, not on input tensors passed by the caller