### PR TITLE
Fix combine correctness check in test_internode.py with correct eps

### DIFF
--- a/tests/test_internode.py
+++ b/tests/test_internode.py
@@ -209,7 +209,7 @@ def test_main(args: argparse.Namespace,
                     event.current_stream_wait() if async_mode else ()
                     check_x = (combined_x.float() - bias_0.float() - bias_1.float()) / is_token_in_rank.sum(dim=1).unsqueeze(1)
                     ref_x = x_pure_rand if is_rand else x
-                    assert calc_diff(check_x, ref_x) < 5e-4 if current_x is x_pure_rand_e4m3 else 5e-6
+                    assert calc_diff(check_x, ref_x) < (5e-4 if current_x is x_pure_rand_e4m3 else 5e-6)
                     if with_topk:
                         check_topk_weights = combined_topk_weights if is_rand else (combined_topk_weights /
                                                                                     is_token_in_rank.sum(dim=1).unsqueeze(1))


### PR DESCRIPTION
In `test_internode.py` the results of combine is checked against the reference. The tolerance is set as follows:

```python3
assert calc_diff(check_x, ref_x) < 5e-4 if current_x is x_pure_rand_e4m3 else 5e-6
```

However, this actually gets parsed as

```python3
assert (calc_diff(check_x, ref_x) < 5e-4) if (current_x is x_pure_rand_e4m3) else 5e-6
```

So the cases where `x is not x_pure_rand_e4m3` are not checked at all. This PR fix this problem. 