### PR TITLE
Add UCCL-EP to Community Forks section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ This code repository is released under [the MIT License](LICENSE), except for co
 
 ## Community Forks
 
+- [uccl/uccl-ep](https://github.com/uccl-project/uccl/tree/main/ep) - Enables running DeepEP on heterogeneous GPUs (e.g., Nvidia, AMD) and NICs (e.g., EFA, Broadcom, CX7)
 - [Infrawaves/DeepEP_ibrc_dual-ports_multiQP](https://github.com/Infrawaves/DeepEP_ibrc_dual-ports_multiQP) - Adds multi-QP solution and dual-port NIC support in IBRC transport
 - [antgroup/DeepXTrace](https://github.com/antgroup/DeepXTrace) - A diagnostic analyzer for efficient and precise localization of slow ranks
 


### PR DESCRIPTION
This PR adds [UCCL-EP](https://github.com/uccl-project/uccl/tree/main/ep) to the community fork in the README. UCCL-EP allows running DeepEP-style GPU-initiated communication on **heterogeneous GPUs (e.g., Nvidia, AMD) and NICs (e.g., EFA, Broadcom, CX7)**.

UCCL-EP is API-compatible with DeepEP and supports both low-latency mode and normal mode. 

Some results (more results can be found [here](https://github.com/uccl-project/uccl/tree/main/ep#results)):

### Normal mode

4096 tokens per batch, 7168 hidden, top-8 experts, FP8 dispatch and BF16 combine

#### On B200 + EFAv4

|   Type    | Dispatch #EP | Bottleneck bandwidth & latency | Combine #EP | Bottleneck bandwidth & latency |
|:---------:|:-------------:|:--------------------:|:------------:|:--------------------:|
| Intranode | 8  | 280 GB/s (NVLink), 571 µs | 8  | 426 GB/s (NVLink), 727 µs |
| Internode | 16 | 53 GB/s (RDMA), 1141 µs | 16 | 60 GB/s (RDMA), 1965 µs    |
| Internode | 24 | 53 GB/s (RDMA), 1637 µs | 24 | 59 GB/s (RDMA), 2887 µs    |
| Internode | 32 | 53 GB/s (RDMA), 2072 µs | 32 | 57 GB/s (RDMA), 3724 µs    |

#### On AMD MI300X with CX7 InfiniBand

|   Type    | FP8 Dispatch #EP | Bottleneck bandwidth| BF16 Dispatch #EP |Bottleneck bandwidth | Combine #EP | Bottleneck bandwidth |
|:---------:|:------------:|:--------------------:|:-----------:|:--------------------:|:--------------------:|:--------------------:|
| Internode |      16      |    71 GB/s (RDMA)    |     16      |    81 GB/s (RDMA)    | 16      |    54 GB/s (RDMA)    |
| Internode |      32      |    57 GB/s (RDMA)    |     32      |    60 GB/s (RDMA)    |  32      |    57 GB/s (RDMA)    |

#### On AMD MI300X with Broadcom Thor2

|   Type    | FP8 Dispatch #EP | Bottleneck bandwidth| BF16 Dispatch #EP |Bottleneck bandwidth | Combine #EP | Bottleneck bandwidth |
|:---------:|:------------:|:--------------------:|:-----------:|:--------------------:|:--------------------:|:--------------------:|
| Internode |      16      |    71 GB/s (RDMA)    |     16      |    81 GB/s (RDMA)    | 16      |    45 GB/s (RDMA)    |
| Internode |      32      |    49 GB/s (RDMA)    |     32      |    55 GB/s (RDMA)    |  32      |    50 GB/s (RDMA)    |

### Low-latency mode

128 tokens per batch, 7168 hidden, top-8 experts, FP8 dispatch and BF16 combine

#### AMD MI300X with CX7 InfiniBand

| Dispatch #EP | Latency | RDMA bandwidth | Combine #EP | Latency | RDMA bandwidth |
|:------------:|:-------:|:--------------:|:-----------:|:-------:|:--------------:|
|      8       |   65 us  |    114 GB/s     |      8      |  92 us  |    157 GB/s    |
|      16      | 136 us  |    55 GB/s     |     16      | 207 us  |    70 GB/s     |
|      32      | 224 us  |    30 GB/s     |     32      | 341 us  |    42 GB/s     |

#### On B200 + EFAv4

| Dispatch #EP | Latency | RDMA bandwidth | Combine #EP | Latency | RDMA bandwidth |
|:-------------:|:--------:|:---------------:|:------------:|:--------:|:---------------:|
| 16 | 228 µs | 33 GB/s | 16 | 318 µs | 46 GB/s |
| 24 | 448 µs | 17 GB/s | 24 | 566 µs | 26 GB/s |
| 32 | 406 µs | 19 GB/s | 32 | 617 µs | 24 GB/s |

