### PR TITLE
Fix EP128 nvl_buffer_size configuration in test_internode.py

### DIFF
--- a/tests/test_internode.py
+++ b/tests/test_internode.py
@@ -99,7 +99,7 @@ def test_main(args: argparse.Namespace,
     time.sleep(1)
 
     # Config
-    rdma_buffer_size, nvl_buffer_size = 128, (720 if num_ranks in (24, 48, 96, 144, 160) else 512)
+    rdma_buffer_size, nvl_buffer_size = 128, (720 if num_ranks in (24, 48, 96, 128, 144, 160) else 512)
     config = deep_ep.Config(num_sms, 8, nvl_buffer_size, 16, rdma_buffer_size)
 
     # Test dispatch


### PR DESCRIPTION
## Summary
- Add 128 to the num_ranks tuple for nvl_buffer_size=720 configuration
- Fixes assertion error when running test_internode.py with EP128

## Test plan
- [ ] Run `python tests/test_internode.py` with EP128 configuration
- [ ] Verify no assertion errors occur

Fixes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)