### PR TITLE
feat: add __version__ and __all__ exports to package

### DIFF
--- a/deep_ep/__init__.py
+++ b/deep_ep/__init__.py
@@ -5,3 +5,18 @@ from .buffer import Buffer
 
 # noinspection PyUnresolvedReferences
 from deep_ep_cpp import Config, topk_idx_t
+
+# Package version - matches setup.py
+__version__ = "1.2.1"
+
+# Public API exports
+__all__ = [
+    # Core classes
+    "Buffer",
+    "EventOverlap",
+    "Config",
+    # Types
+    "topk_idx_t",
+    # Version
+    "__version__",
+]


### PR DESCRIPTION
## Summary

This PR improves the DeepEP package interface by adding standard Python package attributes.

### Changes

**1. Added `__version__` attribute:**
```python
>>> import deep_ep
>>> deep_ep.__version__
'1.2.1'
```
- Allows programmatic version checking
- Matches the version in `setup.py`
- Useful for debugging and compatibility checks

**2. Added `__all__` list:**
```python
__all__ = [
    "Buffer",
    "EventOverlap", 
    "Config",
    "topk_idx_t",
    "__version__",
]
```
- Explicitly defines the public API
- Enables proper `from deep_ep import *` behavior
- Documents which symbols are considered public

### Benefits

- Better IDE autocompletion and type hints
- Clearer public API documentation
- Standard Python packaging practice (PEP 8)
- Easier version checking in user code:
  ```python
  import deep_ep
  if deep_ep.__version__ < "1.2.0":
      print("Please upgrade DeepEP")
  ```

## Test plan

- [x] Python syntax validation passes
- [x] No changes to existing functionality
- [ ] Import test: `python -c "from deep_ep import __version__, __all__; print(__version__, __all__)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)