### PR TITLE
Add NVSHMEM guards for low_latency mask buffer functions

### DIFF
--- a/csrc/deep_ep.cpp
+++ b/csrc/deep_ep.cpp
@@ -1823,22 +1823,34 @@ bool is_sm90_compiled() {
 }
 
 void Buffer::low_latency_update_mask_buffer(int rank_to_mask, bool mask) {
+#ifndef DISABLE_NVSHMEM
     EP_HOST_ASSERT(mask_buffer_ptr != nullptr and "Shrink mode must be enabled");
     EP_HOST_ASSERT(rank_to_mask >= 0 and rank_to_mask < num_ranks);
     internode_ll::update_mask_buffer(mask_buffer_ptr, rank_to_mask, mask, at::cuda::getCurrentCUDAStream());
+#else
+    EP_HOST_ASSERT(false and "NVSHMEM is disabled during compilation");
+#endif
 }
 
 void Buffer::low_latency_query_mask_buffer(const torch::Tensor& mask_status) {
+#ifndef DISABLE_NVSHMEM
     EP_HOST_ASSERT(mask_buffer_ptr != nullptr and "Shrink mode must be enabled");
     EP_HOST_ASSERT(mask_status.numel() == num_ranks && mask_status.scalar_type() == torch::kInt32);
 
     internode_ll::query_mask_buffer(
         mask_buffer_ptr, num_ranks, reinterpret_cast<int*>(mask_status.data_ptr()), at::cuda::getCurrentCUDAStream());
+#else
+    EP_HOST_ASSERT(false and "NVSHMEM is disabled during compilation");
+#endif
 }
 
 void Buffer::low_latency_clean_mask_buffer() {
+#ifndef DISABLE_NVSHMEM
     EP_HOST_ASSERT(mask_buffer_ptr != nullptr and "Shrink mode must be enabled");
     internode_ll::clean_mask_buffer(mask_buffer_ptr, num_ranks, at::cuda::getCurrentCUDAStream());
+#else
+    EP_HOST_ASSERT(false and "NVSHMEM is disabled during compilation");
+#endif
 }
 
 }  // namespace deep_ep


### PR DESCRIPTION
## Summary
- Add `#ifndef DISABLE_NVSHMEM` guards to mask buffer functions
- Fixes undefined symbol errors when building without NVSHMEM

## Problem
When building DeepEP with `DISABLE_NVSHMEM` (for systems without NVSHMEM like sm86 A6000 or sm80 A100 without NVLink/RDMA), importing the module fails with:

```
ImportError: undefined symbol: _ZN7deep_ep12internode_ll17query_mask_bufferE...
```

This is because the following functions reference `internode_ll::` symbols without NVSHMEM guards:
- `low_latency_update_mask_buffer()`
- `low_latency_query_mask_buffer()`
- `low_latency_clean_mask_buffer()`

## Solution
Add `#ifndef DISABLE_NVSHMEM` guards to these functions, matching the pattern used elsewhere in the codebase.

## Test plan
- [ ] Build with `DISABLE_NVSHMEM=1 TORCH_CUDA_ARCH_LIST=8.0` on sm80 system
- [ ] Verify `import deep_ep` succeeds
- [ ] Build normally with NVSHMEM and verify functionality

Fixes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)