### PR TITLE
Use atomicMax instead of atomicAdd for wait_recv_cost_stats

### DIFF
--- a/csrc/kernels/internode_ll.cu
+++ b/csrc/kernels/internode_ll.cu
@@ -415,7 +415,7 @@ LOW_LATENCY_DISPATCH_RECV:
             if (cumulative_local_expert_recv_stats != nullptr)
                 atomicAdd(cumulative_local_expert_recv_stats + local_expert_idx, num_recv_tokens);
             if (dispatch_wait_recv_cost_stats != nullptr)
-                atomicAdd(reinterpret_cast<unsigned long long*>(dispatch_wait_recv_cost_stats + src_rank), wait_recv_cost);
+                atomicMax(reinterpret_cast<unsigned long long*>(dispatch_wait_recv_cost_stats + src_rank), wait_recv_cost);
         }
         asm volatile("bar.sync %0, %1;" ::"r"(warp_group_id + 2), "r"(num_warps_per_group * 32));
         num_recv_tokens = shared_num_recv_tokens[warp_group_id];
@@ -970,7 +970,7 @@ LOW_LATENCY_COMBINE_RECV:
             }
 
             if (combine_wait_recv_cost_stats != nullptr) {
-                atomicAdd(reinterpret_cast<unsigned long long*>(combine_wait_recv_cost_stats + src_rank), wait_recv_cost);
+                atomicMax(reinterpret_cast<unsigned long long*>(combine_wait_recv_cost_stats + src_rank), wait_recv_cost);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Changes `atomicAdd` to `atomicMax` for `dispatch_wait_recv_cost_stats` and `combine_wait_recv_cost_stats`
- When warps wait in parallel, summing wait times produces misleading metrics
- Max captures the actual bottleneck latency for performance diagnostics

## Changes
- `csrc/kernels/internode_ll.cu:418` - dispatch stats
- `csrc/kernels/internode_ll.cu:973` - combine stats

## Rationale
As noted in #473, when multiple warps receive data from the same source rank in parallel, using `atomicAdd` to sum their wait times doesn't provide meaningful insights. Using `atomicMax` instead captures the maximum wait time observed, which:
1. Identifies the actual communication bottleneck
2. Helps diagnose slow compute ranks
3. Provides actionable latency metrics for tools like DeepXTrace

Fixes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)