### PR TITLE
Add delay before trap() to allow printf buffer flush

### DIFF
--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -8,6 +8,7 @@
 
 #define FINISHED_SUM_TAG 1024
 #define NUM_WAIT_NANOSECONDS 500
+#define NUM_TRAP_FLUSH_ITERATIONS 1000  // Delay iterations before trap to allow printf buffer flush
 
 #ifndef ENABLE_FAST_DEBUG
 #define NUM_CPU_TIMEOUT_SECS 100

--- a/csrc/kernels/utils.cuh
+++ b/csrc/kernels/utils.cuh
@@ -62,6 +62,13 @@ struct PatternVisitor {
 };
 
 __device__ __forceinline__ void trap() {
+    // Delay before trap to allow printf buffers from other warps to flush
+    // Without this delay, error logs may be lost when one warp traps before
+    // others can output their diagnostic messages (see issue #480)
+    #pragma unroll 1
+    for (int i = 0; i < NUM_TRAP_FLUSH_ITERATIONS; ++i) {
+        __nanosleep(NUM_WAIT_NANOSECONDS);
+    }
     asm("trap;");
 }
 


### PR DESCRIPTION
## Summary
- Adds a configurable delay before `trap()` to allow printf buffers to flush
- Prevents loss of critical error logs when one warp times out before others

## Problem
When `trap()` is called by one warp during timeout, the kernel execution aborts immediately. Other warps may still have unflushed printf buffers, causing their diagnostic messages (from Forwarder, Sender, Coordinator roles) to be lost.

## Solution
- Added `NUM_TRAP_FLUSH_ITERATIONS` constant (1000 iterations)
- Modified `trap()` to delay ~500μs (1000 × 500ns) before executing the trap instruction
- Uses `#pragma unroll 1` to prevent compiler optimization from removing the delay loop

## Changes
- `csrc/kernels/configs.cuh` - Added `NUM_TRAP_FLUSH_ITERATIONS` constant
- `csrc/kernels/utils.cuh` - Modified `trap()` function with delay loop

## Test plan
- [ ] Trigger a timeout condition and verify all warp roles output their diagnostic messages
- [ ] Verify the delay doesn't significantly impact normal operation (only affects error paths)

Fixes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)