### PR TITLE
Add __version__ and __all__ to package

### DIFF
--- a/deep_ep/__init__.py
+++ b/deep_ep/__init__.py
@@ -5,3 +5,6 @@ from .buffer import Buffer
 
 # noinspection PyUnresolvedReferences
 from deep_ep_cpp import Config, topk_idx_t
+
+__version__ = "1.2.1"
+__all__ = ["Buffer", "Config", "EventOverlap", "topk_idx_t"]


### PR DESCRIPTION
## Summary
- Added `__version__` attribute for programmatic version checking
- Added `__all__` to explicitly define the public API

## Changes
- `deep_ep/__init__.py` - Added version string and public API list

## Benefits
- Users can check version via `deep_ep.__version__`
- IDEs and linters get better hints about the public API
- Follows Python packaging best practices (PEP 396)

## Example usage
```python
import deep_ep
print(deep_ep.__version__)  # "1.2.1"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)