### PR TITLE
Improve error messages for unsupported EP rank configurations

### DIFF
--- a/deep_ep/buffer.py
+++ b/deep_ep/buffer.py
@@ -256,7 +256,8 @@ class Buffer:
             144: Config(Buffer.num_sms, 32, 720, 12, 128),
             160: Config(Buffer.num_sms, 28, 720, 12, 128),
         }
-        assert num_ranks in config_map, f'Unsupported number of EP ranks: {num_ranks}'
+        assert num_ranks in config_map, \
+            f'Unsupported number of EP ranks: {num_ranks}. Supported values: {sorted(config_map.keys())}'
         return config_map[num_ranks]
 
     @staticmethod
@@ -286,7 +287,8 @@ class Buffer:
             144: Config(Buffer.num_sms, 2, 720, 8, 128),
             160: Config(Buffer.num_sms, 2, 720, 8, 128),
         }
-        assert num_ranks in config_map, f'Unsupported number of EP ranks: {num_ranks}'
+        assert num_ranks in config_map, \
+            f'Unsupported number of EP ranks: {num_ranks}. Supported values: {sorted(config_map.keys())}'
         return config_map[num_ranks]
 
     # noinspection PyTypeChecker


### PR DESCRIPTION
## Summary
- Improved error messages in `get_dispatch_config` and `get_combine_config` to show supported rank values
- Helps users quickly identify valid configurations when they encounter an error

## Changes
- `deep_ep/buffer.py` - Enhanced assertion messages in both config functions

## Before
```
AssertionError: Unsupported number of EP ranks: 12
```

## After
```
AssertionError: Unsupported number of EP ranks: 12. Supported values: [2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 144, 160]
```

## Benefits
- Reduces debugging time for users
- Self-documenting error messages
- No performance impact (only affects error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)