### PR TITLE
Add printf buffer flush delay to EP_DEVICE_ASSERT

### DIFF
--- a/csrc/kernels/exception.cuh
+++ b/csrc/kernels/exception.cuh
@@ -57,6 +57,10 @@ public:
     do {                                                                                   \
         if (not(cond)) {                                                                   \
             printf("Assertion failed: %s:%d, condition: %s\n", __FILE__, __LINE__, #cond); \
+            /* Delay before trap to allow printf buffer flush (see issue #480) */         \
+            for (int _i = 0; _i < NUM_TRAP_FLUSH_ITERATIONS; ++_i) {                       \
+                __nanosleep(NUM_WAIT_NANOSECONDS);                                         \
+            }                                                                              \
             asm("trap;");                                                                  \
         }                                                                                  \
     } while (0)


### PR DESCRIPTION
## Summary
- Adds the same printf buffer flush delay to `EP_DEVICE_ASSERT` as was added to `trap()` in PR #539
- Ensures device assertion failure messages are not lost when kernel aborts

## Problem
While PR #539 fixed the `trap()` function to delay before aborting, `EP_DEVICE_ASSERT` was still using raw `asm("trap;")` without any delay. This meant assertion failures in device code could still lose their printf output.

## Solution
Added the same delay loop using `NUM_TRAP_FLUSH_ITERATIONS` and `__nanosleep(NUM_WAIT_NANOSECONDS)` before the trap instruction in `EP_DEVICE_ASSERT`.

## Changes
- `csrc/kernels/exception.cuh` - Added flush delay to `EP_DEVICE_ASSERT` macro

## Test plan
- [ ] Trigger a device assertion and verify the message is printed
- [ ] Verify no performance impact on normal execution (delay only on error path)

Related to #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)