### PR TITLE
Fix check_nvlink_connections called with None group

### DIFF
--- a/deep_ep/buffer.py
+++ b/deep_ep/buffer.py
@@ -63,10 +63,9 @@ class Buffer:
                 Note: Releasing resources in the destructor may cause Python's exception handling process to hang.
             comm: the `mpi4py.MPI.Comm` communicator to use in case the group parameter is absent.
         """
-        check_nvlink_connections(group)
-
         # Initialize the CPP runtime
         if group is not None:
+            check_nvlink_connections(group)
             self.rank = group.rank()
             self.group = group
             self.group_size = group.size()


### PR DESCRIPTION
## Summary
- Fixed a bug where `check_nvlink_connections(group)` was called before validating that `group` is not `None`
- This caused an `AttributeError` when users used the `comm` (mpi4py) parameter instead of `group`

## Problem
```python
# In Buffer.__init__:
check_nvlink_connections(group)  # Called here, but group can be None!

if group is not None:
    # ... handle group
elif comm is not None:
    # ... handle comm
```

When `group=None` and `comm` is provided, `check_nvlink_connections` would fail trying to call `group.size()`.

## Solution
Moved `check_nvlink_connections(group)` inside the `if group is not None:` block.

## Changes
- `deep_ep/buffer.py` - Moved NVLink check after None validation

## Test plan
- [ ] Create Buffer with `group=None, comm=<mpi4py comm>` and verify no AttributeError
- [ ] Create Buffer with valid `group` and verify NVLink check still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)