### PR TITLE
Fix typo: NVHSMEM -> NVSHMEM in installation docs

### DIFF
--- a/third-party/README.md
+++ b/third-party/README.md
@@ -23,7 +23,7 @@ Software requirements:
 
 NVSHMEM 3.3.9 binaries are available in several formats:
    - Tarballs for  [x86_64](https://developer.download.nvidia.com/compute/nvshmem/redist/libnvshmem/linux-x86_64/libnvshmem-linux-x86_64-3.3.9_cuda12-archive.tar.xz) and [aarch64](https://developer.download.nvidia.com/compute/nvshmem/redist/libnvshmem/linux-sbsa/libnvshmem-linux-sbsa-3.3.9_cuda12-archive.tar.xz)
-   - RPM and deb packages: instructions can be found on the [NVHSMEM installer page](https://developer.nvidia.com/nvshmem-downloads?target_os=Linux)
+   - RPM and deb packages: instructions can be found on the [NVSHMEM installer page](https://developer.nvidia.com/nvshmem-downloads?target_os=Linux)
    - Conda packages through conda-forge
    - pip wheels through PyPI: `pip install nvidia-nvshmem-cu12`
 DeepEP is compatible with upstream NVSHMEM 3.3.9 and later.


### PR DESCRIPTION
## Summary
Fixed a typo in `third-party/README.md` where "NVHSMEM" was written instead of "NVSHMEM".

## Changes
- `third-party/README.md` line 26: "NVHSMEM installer page" → "NVSHMEM installer page"