### PR TITLE
Improve .gitignore with common Python entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,30 @@
+# Build outputs
 compile_commands.json
-.idea
-.DS_Store
-*.pyc
 build/
-.cache/
+dist/
+*.egg-info/
+*.egg
+*.so
+
+# IDE
+.idea/
 .vscode/
 */cmake-build-*/
+
+# OS
+.DS_Store
+
+# Python
+*.pyc
+__pycache__/
+.cache/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Coverage
+.coverage
+htmlcov/
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- Reorganize .gitignore into logical sections with comments
- Add common Python/CUDA development patterns to prevent accidental commits

## Changes
Added organized sections:
- **Build outputs**: `dist/`, `*.egg-info/`, `*.egg`, `*.so`
- **IDE**: Existing `.idea/`, `.vscode/` entries
- **OS**: `.DS_Store`
- **Python cache**: `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`
- **Coverage**: `.coverage`, `htmlcov/`
- **Logs**: `*.log`

## Test plan
- [x] Verify existing ignored files still work
- [x] No new untracked files appear after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)