### PR TITLE
Add architecture during device linking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,9 @@ if __name__ == '__main__':
         sources.extend(['csrc/kernels/internode.cu', 'csrc/kernels/internode_ll.cu'])
         include_dirs.extend([f'{nvshmem_dir}/include'])
         library_dirs.extend([f'{nvshmem_dir}/lib'])
-        nvcc_dlink.extend(['-dlink', f'-L{nvshmem_dir}/lib', '-lnvshmem_device'])
+        arch_list = os.getenv('TORCH_CUDA_ARCH_LIST', '9.0').strip()
+        arch_version = arch_list.replace('.', '')  # e.g., "9.0" -> "90"
+        nvcc_dlink.extend(['-dlink', f'-gencode=arch=compute_{arch_version},code=sm_{arch_version}', f'-L{nvshmem_dir}/lib', '-lnvshmem_device'])
         extra_link_args.extend([f'-l:{nvshmem_host_lib}', '-l:libnvshmem_device.a', f'-Wl,-rpath,{nvshmem_dir}/lib'])
 
     if int(os.getenv('DISABLE_SM90_FEATURES', 0)):


### PR DESCRIPTION
Without this fix, I see the following warnings when compiling DeepEP for a specific architecture, which leads to runtime errors with test_low_latency.py

```
nvlink warning : SM Arch ('sm_75') not found in 'DeepEP/build/temp.linux-x86_64-cpython-312/csrc/kernels/internode.o'
nvlink warning : SM Arch ('sm_75') not found in 'DeepEP/build/temp.linux-x86_64-cpython-312/csrc/kernels/internode_ll.o'
nvlink warning : SM Arch ('sm_75') not found in 'DeepEP/build/temp.linux-x86_64-cpython-312/csrc/kernels/intranode.o'
nvlink warning : SM Arch ('sm_75') not found in 'DeepEP/build/temp.linux-x86_64-cpython-312/csrc/kernels/layout.o'
nvlink warning : SM Arch ('sm_75') not found in 'DeepEP/build/temp.linux-x86_64-cpython-312/csrc/kernels/runtime.o'
```

Before this PR:
```
> cuobjdump -lelf DeepEP/build/lib.linux-x86_64-cpython-312/deep_ep_cpp.cpython-312-x86_64-linux-gnu.so 2>&1 | grep "sm_"
ELF file    1: deep_ep_cpp.cpython-312-x86_64-linux-gnu.1.sm_75.cubin
```

After this PR:
```
> cuobjdump -lelf DeepEP/build/lib.linux-x86_64-cpython-312/deep_ep_cpp.cpython-312-x86_64-linux-gnu.so 2>&1 | grep "sm_"
ELF file    1: deep_ep_cpp.cpython-312-x86_64-linux-gnu.1.sm_103.cubin
```