### PR TITLE
Fix linking error with nvidia-nvshmem-cu12 3.5.19

### DIFF
--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -74,7 +74,9 @@ typedef INT_BITS_T(TOPK_IDX_BITS) topk_idx_t;  // int32_t or int64_t
 }  // namespace deep_ep
 
 #ifndef DISABLE_NVSHMEM
+#ifdef __CUDACC__
 #include <device_host_transport/nvshmem_common_ibgda.h>
+#endif
 #include <infiniband/mlx5dv.h>
 #include <nvshmem.h>
 #include <nvshmemx.h>


### PR DESCRIPTION
## Motivation

After upgrading to NVSHMEM 3.5.19, we encountered a multiple definition linking error:

```
/usr/bin/ld: /home/windreamer/codebase/DeepEP/.venv/lib/python3.12/site-packages/nvidia/nvshmem/lib/libnvshmem_device.a(init_device.cu.o):(.bss+0x380): multiple definition of `nvshmemi_ibgda_device_state_d'; /home/windreamer/codebase/DeepEP/build/temp.linux-x86_64-cpython-312/csrc/deep_ep.o:/home/windreamer/codebase/DeepEP/.venv/lib/python3.12/site-packages/nvidia/nvshmem/include/device_host_transport/nvshmem_common_ibgda.h:351: first defined here
```

This happens because NVSHMEM 3.5.19 expects users to compile with `-rdc=true` (relocatable device code). 

```c++
#if defined(__CUDACC_RDC__) || defined(__NVSHMEM_NUMBA_SUPPORT__)
#define EXTERN_CONSTANT extern __constant__
#elif defined(__clang__)
#define EXTERN_CONSTANT extern __constant__ __attribute__((address_space(4)))
#else
#define EXTERN_CONSTANT
#endif
``` 
https://github.com/NVIDIA/nvshmem/blob/919760f413fb834e76382d129ba9c3314ce722be/src/include/device_host_transport/nvshmem_common_ibgda.h#L343-L349


However, in DeepEP's build structure:

1. **`deep_ep.cpp` is compiled by the host compiler (g++)**, not nvcc. While DeepEP enables `-rdc=true` for `.cu` files, this flag is only recognized by nvcc and has no effect on host compilation.

2. The header `device_host_transport/nvshmem_common_ibgda.h` contains a conditional definition of the global variable `nvshmemi_ibgda_device_state_d`. When included in `deep_ep.cpp`, the host compiler sees it as a **definition** rather than an `extern` declaration (since `__CUDACC_RDC__` is not defined), causing the symbol to be incorrectly emitted in `deep_ep.o`. This conflicts with the canonical definition in `libnvshmem_device.a`.

## Modification

The core issue is that `device_host_transport/nvshmem_common_ibgda.h` is a device-specific internal header that should never be included in host-compiled translation units. Instead of relying on `-rdc=true` (which doesn't affect host compilation), we restrict the inclusion of this header to only when **nvcc** is processing the file.

By guarding the inclusion with `#ifdef __CUDACC__`, we ensure that:
- Device code (`.cu` files compiled by nvcc) can still access the necessary declarations
- Host code (`.cpp` files compiled by g++) will never see this header or its problematic symbol definition

This prevents the duplicate symbol error while maintaining compatibility with NVSHMEM's device API usage in the kernel code.