### PR TITLE
Nvshmem 3 5 runtime fixes

### DIFF
--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -29,7 +29,7 @@
 // Define __CUDACC_RDC__ to ensure proper extern declarations for NVSHMEM device symbols
 #ifndef DISABLE_NVSHMEM
 #ifndef __CUDACC_RDC__
-#define __CUDACC_RDC__     // NOLINT(*-reserved-identifier)
+#define __CUDACC_RDC__  // NOLINT(*-reserved-identifier)
 #endif
 #endif
 

--- a/csrc/kernels/ibgda_device.cuh
+++ b/csrc/kernels/ibgda_device.cuh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <type_traits>
+
 #include "configs.cuh"
 #include "exception.cuh"
 #include "utils.cuh"
@@ -82,12 +83,10 @@ __device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc_impl(
     if constexpr (std::is_same_v<StateType, nvshmemi_ibgda_device_state_v1>) {
         // v1 implementation
         return &state->globalmem
-                    .rcs[pe * num_rc_per_pe * state->num_devices_initialized +
-                         id % (num_rc_per_pe * state->num_devices_initialized)];
+                    .rcs[pe * num_rc_per_pe * state->num_devices_initialized + id % (num_rc_per_pe * state->num_devices_initialized)];
     } else {
         // v2 implementation (or any other type)
-        return &state->globalmem
-                    .rcs[pe + nvshmemi_device_state_d.npes * id];
+        return &state->globalmem.rcs[pe + nvshmemi_device_state_d.npes * id];
     }
 }
 


### PR DESCRIPTION
The addition of QPair-Specific APIs modified the way default qpairs are stored. This change allows DeepEP to work with the new version while maintaining compile-time backwards compatibility for the previous layout.

This is likely the issue encountered in issue #553 