### PR TITLE
mnnvl: normal mode supports mnnvl

### DIFF
--- a/csrc/deep_ep.hpp
+++ b/csrc/deep_ep.hpp
@@ -61,7 +61,7 @@ private:
 
     // NVLink Buffer
     int64_t num_nvl_bytes;
-    void* buffer_ptrs[NUM_MAX_NVL_PEERS] = {nullptr};
+    void** buffer_ptrs = nullptr;
     void** buffer_ptrs_gpu = nullptr;
 
     // NVSHMEM Buffer
@@ -70,6 +70,7 @@ private:
 
     // Shrink mode buffer
     bool enable_shrink = false;
+    bool normal_mnnvl = false;
     int* mask_buffer_ptr = nullptr;
     int* sync_buffer_ptr = nullptr;
 
@@ -78,7 +79,7 @@ private:
     int num_device_sms;
     int rank, rdma_rank, nvl_rank;
     int num_ranks, num_rdma_ranks, num_nvl_ranks;
-    shared_memory::MemHandle ipc_handles[NUM_MAX_NVL_PEERS];
+    shared_memory::MemHandle *ipc_handles = nullptr;
 
     // Stream for communication
     at::cuda::CUDAStream comm_stream;
@@ -92,7 +93,7 @@ private:
     bool destroyed = false;
 
     // Barrier signals
-    int* barrier_signal_ptrs[NUM_MAX_NVL_PEERS] = {nullptr};
+    int** barrier_signal_ptrs = nullptr;
     int** barrier_signal_ptrs_gpu = nullptr;
 
     // Workspace
@@ -120,7 +121,7 @@ public:
            bool low_latency_mode,
            bool explicitly_destroy,
            bool enable_shrink,
-           bool use_fabric);
+           bool normal_mnnvl);
 
     ~Buffer() noexcept(false);
 

--- a/csrc/kernels/launch.cuh
+++ b/csrc/kernels/launch.cuh
@@ -59,6 +59,10 @@
             case_macro(4);                                 \
         case 8:                                            \
             case_macro(8);                                 \
+        case 12:                                           \
+            case_macro(12);                                \
+        case 24:                                           \
+            case_macro(24);                                \
         default:                                           \
             EP_HOST_ASSERT(false and "Unsupported ranks"); \
     }                                                      \
@@ -97,6 +101,10 @@
             case_macro(dtype, 4);                          \
         case 8:                                            \
             case_macro(dtype, 8);                          \
+        case 12:                                           \
+            case_macro(dtype, 12);                         \
+        case 24:                                           \
+            case_macro(dtype, 24);                         \
         default:                                           \
             EP_HOST_ASSERT(false and "Unsupported ranks"); \
     }                                                      \

--- a/tests/test_intranode.py
+++ b/tests/test_intranode.py
@@ -275,9 +275,7 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                             num_rdma_bytes,
                             low_latency_mode=test_ll_compatibility,
                             num_qps_per_rank=(ll_num_experts // num_ranks if test_ll_compatibility else 1),
-                            explicitly_destroy=True,
-                            allow_mnnvl=args.allow_mnnvl,
-                            use_fabric=args.use_fabric)
+                            explicitly_destroy=True)
     torch.manual_seed(rank)
 
     for i in (24, ):
@@ -303,8 +301,6 @@ if __name__ == '__main__':
     parser.add_argument('--hidden', type=int, default=7168, help='Hidden dimension size (default: 7168)')
     parser.add_argument('--num-topk', type=int, default=8, help='Number of top-k experts (default: 8)')
     parser.add_argument('--num-experts', type=int, default=256, help='Number of experts (default: 256)')
-    parser.add_argument('--allow-mnnvl', action="store_true", help='Enable MNNVL support')
-    parser.add_argument('--use-fabric', action="store_true", help='Enable fabric mode')
     args = parser.parse_args()
 
     num_processes = args.num_processes


### PR DESCRIPTION
Allow more than 8 GPUs to work via mnnvl in normal intra mode.

Motivation:

To enable DeepEP to run on machines that support MNNVL.

For example, on these machines, each has 4 GPUs, and the GPUs can be interconnected across machines via MNNVL.

Current status:

Some work has already been completed specifically, the `use_fabric` parameter can now be used for MNNVL. However, there are several issues:

1. It currently only supports two machines (each with 4 GPUs), meaning it is still constrained by the 8-GPU limitation.

2. This behavior is controlled by an additional parameter, which is inconvenient. Higher-level frameworks typically don't know when to set it. Moreover, when MNNVL is not in use, RDMA is usually available as a fallback; thus, MNNVL should be treated more like an optimization rather than a mandatory configuration.

Implementation:

1. I introduced an environment variable `DEEP_EP_NORMAL_MNNVL` to control whether the *normal* mode should use MNNVL. To clarify: for *low-latency* mode, if the user enables the 'allow_MNNVL' option, MNNVL is already usable. This provides a smooth user experience, and frameworks like SGLang have already adopted this approach. However, for *normal* mode, deciding when to enable MNNVL is more nuanced. I believe using an environment variable is a clean and flexible solution. When this variable is set, the system enters *intra*-mode and bypasses the *inter*-node logic entirely, using MNNVL for communication across all GPUs.

2. I removed the buffer parameter `use_fabric`. This name seemed to refer to a specific handle-exchange mechanism under MNNVL, which is an implementation detail we shouldn't expose at this layer. it's not relevant to our high-level orchestration logic.

3. Previously, addresses constrained by `NUM_MAX_NVL_PEERS` now use `num_nvl_ranks` for resource allocation.

4. Finally, it's worth noting that for configurations exceeding 8 GPUs, the current implementation only supports 12 and 24 GPUs. This limitation stems from the current intra-node design: due to shared memory size constraints, we cannot set `kNumThreads` too large, and `num_ranks` must be a divisor of `kNumThreads`. As a result, only specific GPU counts (like 12 and 24) are currently feasible. To support 16 or 32 GPUs, we would likely need to decrease `kNumThreads` to 512 to satisfy both shared memory capacity and warp occupancy requirements.

By the way, I also removed the `--allow-mnnvl` flag from `test_intranode.py`, as it only affects NVSHMEM and has no practical effect in intra-node scenarios.