### PR TITLE
Fix NVLink domain over-count on MNNVL systems in `detect_accessible_ranks`

### DIFF
--- a/csrc/hybrid_ep/allocator/allocator.cu
+++ b/csrc/hybrid_ep/allocator/allocator.cu
@@ -161,6 +161,7 @@ void ExtendedMemoryAllocator::close_handle(void* ptr) {
 
 bool ExtendedMemoryAllocator::is_accessible(MemHandle* mem_handle) {
   bool accessible = false;
+  bool same_host = strncmp(mem_handle->src_hostname, hostname_, sizeof(hostname_)) == 0;
   if (support_fabric_) {
     CUmemGenericAllocationHandle handle;
     auto ret = cuMemImportFromShareableHandle(&handle, &mem_handle->inner.cu_mem_fabric_handle, CU_MEM_HANDLE_TYPE_FABRIC);
@@ -168,9 +169,10 @@ bool ExtendedMemoryAllocator::is_accessible(MemHandle* mem_handle) {
     if (accessible) {
       cuMemRelease(handle);
     }
+    // MNNVL makes fabric handles importable across nodes; restrict to same host.
+    accessible = accessible && same_host;
   } else {
-    // Check if the source hostname is the same as the current hostname
-    accessible = strncmp(mem_handle->src_hostname, hostname_, sizeof(hostname_)) == 0;
+    accessible = same_host;
   }
   return accessible;
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/deepseek-ai/DeepEP/issues/596

On GB200 NVL72 (MNNVL) systems, `detect_accessible_ranks()` returns the full EP group size instead of the physical per-node GPU count because `cuMemImportFromShareableHandle` succeeds for cross-node peers via the MNNVL fabric. This causes `device_sync_kernel` to deadlock waiting for atomic increments that never arrive.

The non-fabric path of `is_accessible()` already guards on hostname; this patch applies the same check to the fabric path so the NVLink domain is correctly bounded to the physical node.

## Test plan

- [ ] Multi-node MNNVL (GB200 NVL72): `detect_accessible_ranks` returns physical GPUs per node, not group size
- [ ] Single-node fabric (e.g. DGX H100): no behavior change
- [ ] `NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN` env var override still works and warns on mismatch
- [ ] Multi-node dispatch/combine complete without deadlock