### PR TITLE
docs(architecture): add bilingual DeepEP deep-dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For a source-driven learning path that breaks the system down from architecture 
 
 - [Documentation index](docs/README.md)
 - [English docs](docs/en/README.md)
+- [中文文档](docs/zh/README.md)
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ For latency-sensitive inference decoding, DeepEP includes a set of low-latency k
 
 Notice: the implementation in this library may have some slight differences from the [DeepSeek-V3](https://github.com/deepseek-ai/DeepSeek-V3) paper.
 
+
+## Documentation
+
+For a source-driven learning path that breaks the system down from architecture to tuning, see:
+
+- [Documentation index](docs/README.md)
+- [English docs](docs/en/README.md)
+
 ## Performance
 
 ### Normal kernels with NVLink and RDMA forwarding

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,7 @@ flowchart LR
 ## Choose your language
 
 - [English documentation](en/README.md)
-
-Chinese documentation will be added in a follow-up commit on the same `doc-260401` branch.
+- [中文文档](zh/README.md)
 
 ## What is covered
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+# DeepEP Documentation
+
+This `docs/` tree is a source-driven learning path for the DeepEP repository. It is written from the code outward: the Python API in `deep_ep/`, the C++ runtime in `csrc/deep_ep.*`, the CUDA kernels in `csrc/kernels/`, and the validation logic in `tests/`.
+
+```mermaid
+flowchart LR
+    A[Overview] --> B[Quick Start]
+    B --> C[Normal Kernels]
+    B --> D[Low-Latency Kernels]
+    C --> E[Math and Mental Models]
+    D --> E
+    E --> F[Performance and Tuning]
+```
+
+## Choose your language
+
+- [English documentation](en/README.md)
+
+Chinese documentation will be added in a follow-up commit on the same `doc-260401` branch.
+
+## What is covered
+
+- What problem DeepEP solves for MoE expert parallelism.
+- How `Buffer` maps onto the underlying CUDA/NVLink/RDMA runtime.
+- Why the repository has two distinct kernel families: normal throughput kernels and low-latency kernels.
+- How dispatch layout, buffer sizing, FP8 scaling, and low-latency double buffering work.
+- How to tune the library on a real cluster and how to reason about the trade-offs.
+
+## Suggested reading order
+
+1. Start with the language index in `en/README.md` or `zh/README.md`.
+2. Read `quick-start.md` to understand the setup and execution skeleton.
+3. Read `architecture.md` for the bird's-eye view.
+4. Read `normal-kernels.md` and `low-latency.md` depending on your workload.
+5. Use `math-theory.md` and `performance-tuning.md` as the deeper reference layer.
+
+## Source map behind these docs
+
+The explanations in this directory are grounded mainly in:
+
+- `README.md`
+- `deep_ep/buffer.py`
+- `deep_ep/utils.py`
+- `csrc/deep_ep.hpp`
+- `csrc/deep_ep.cpp`
+- `csrc/config.hpp`
+- `csrc/kernels/configs.cuh`
+- `csrc/kernels/layout.cu`
+- `csrc/kernels/intranode.cu`
+- `csrc/kernels/internode.cu`
+- `csrc/kernels/internode_ll.cu`
+- `tests/test_intranode.py`
+- `tests/test_internode.py`
+- `tests/test_low_latency.py`

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -1,0 +1,48 @@
+# DeepEP Documentation (English)
+
+DeepEP is a communication engine for MoE expert parallelism. In one sentence: **the gate decides where each token should go, and DeepEP turns that routing plan into fast NVLink and RDMA traffic.**
+
+```mermaid
+flowchart TB
+    X[Hidden states] --> G[top-k gating]
+    G --> L[get_dispatch_layout]
+    L --> D[Dispatch across NVLink / RDMA]
+    D --> E[Local expert compute]
+    E --> C[Combine back to source ranks]
+    C --> Y[Original token order restored]
+```
+
+## Reading map
+
+- [Quick Start](quick-start.md): environment, installation, minimal usage, and sanity checks.
+- [Architecture](architecture.md): the system layers, data plane, and source-code map.
+- [Normal Kernels](normal-kernels.md): the training and prefilling path built around `get_dispatch_layout`, `dispatch`, and `combine`.
+- [Low-Latency Kernels](low-latency.md): the decode-time path with IBGDA, hooks, and double buffering.
+- [Math and Mental Models](math-theory.md): indicator matrices, prefix sums, FP8 scales, and buffer-size formulas explained from first principles.
+- [Performance and Tuning](performance-tuning.md): topology assumptions, tuning knobs, and troubleshooting.
+
+## If you only have 20 minutes
+
+1. Read the first two sections of [Architecture](architecture.md).
+2. Read the API skeleton in [Quick Start](quick-start.md).
+3. Pick either [Normal Kernels](normal-kernels.md) or [Low-Latency Kernels](low-latency.md) based on your workload.
+
+## If you are integrating DeepEP into a framework
+
+Focus first on these repository surfaces:
+
+- `deep_ep/buffer.py`: the public Python control plane.
+- `deep_ep/utils.py`: event overlap and topology checks.
+- `csrc/deep_ep.cpp`: the runtime boundary between Python and CUDA.
+- `csrc/kernels/`: the actual transport and packing logic.
+- `tests/`: concrete usage patterns and tuning harnesses.
+
+## Why these docs are split this way
+
+DeepEP is easiest to learn if you peel it layer by layer:
+
+- business goal first: sparse MoE all-to-all is the real problem,
+- then system shape: NVLink domain + RDMA domain,
+- then API skeleton,
+- then kernel families,
+- and only then the math and tuning knobs.

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -1,0 +1,183 @@
+# DeepEP Architecture
+
+## 1. DeepEP in plain English
+
+Think of an MoE model as a city full of specialized repair shops:
+
+- the **gate** decides which shops should see each package,
+- the **experts** do the actual work,
+- and **DeepEP** is the delivery network that moves packages between neighborhoods and cities.
+
+Inside one node, the fast roads are **NVLink**. Across nodes, the long-haul highway is **RDMA**. DeepEP exists because MoE routing is sparse, irregular, and brutally bandwidth-hungry: every step turns into a structured all-to-all exchange.
+
+## 2. The core problem DeepEP solves
+
+A dense model keeps activations local. An MoE model does not.
+
+For every token, the gate picks several experts. Those experts may live:
+
+- on the same GPU,
+- on another GPU in the same node,
+- or on a GPU in another node.
+
+That immediately creates three hard systems problems:
+
+1. **Routing is sparse but dynamic.** Every batch produces a new token-to-expert pattern.
+2. **The physical topology is asymmetric.** NVLink is much faster than RDMA, but RDMA is the only path across nodes.
+3. **Training/prefill and decoding want different things.** Training wants throughput. Decoding wants tail latency.
+
+DeepEP answers this by offering two kernel families:
+
+| Kernel family | Primary goal | Fabric pattern | Best fit |
+| --- | --- | --- | --- |
+| Normal kernels | Maximize throughput | NVLink inside a node, RDMA forwarding across nodes | Training and inference prefilling |
+| Low-latency kernels | Minimize latency | Pure RDMA with IBGDA, optional hook-based overlap | Inference decoding |
+
+## 3. The layered architecture
+
+```mermaid
+flowchart TB
+    subgraph Framework Layer
+        Gate[MoE gate\nselect experts]
+        API[Python API\nBuffer / EventOverlap]
+    end
+
+    subgraph Runtime Layer
+        Layout[Layout kernel\ncounts + bitmaps]
+        Handle[Communication handle\nprefix sums + source metadata]
+        Stream[Dedicated comm stream]
+    end
+
+    subgraph Data Plane
+        NVL[NVLink path\nintranode]
+        RDMA[RDMA + NVSHMEM + IBGDA\ninternode]
+        LL[Low-latency double buffer\ndecode path]
+    end
+
+    subgraph Compute Layer
+        Experts[Local expert GEMMs]
+        Combine[Combine / reduce]
+    end
+
+    Gate --> API --> Layout --> Handle --> Stream
+    Stream --> NVL --> Experts --> Combine
+    Stream --> RDMA --> Experts
+    Stream --> LL --> Experts
+```
+
+### What each layer is responsible for
+
+- **Python layer (`deep_ep/buffer.py`, `deep_ep/utils.py`)**
+  - user-facing API,
+  - setup logic,
+  - layout calls,
+  - dispatch/combine orchestration,
+  - event overlap helpers.
+- **C++ runtime (`csrc/deep_ep.hpp`, `csrc/deep_ep.cpp`)**
+  - owns the communication buffers,
+  - exchanges IPC and NVSHMEM state,
+  - exposes a dedicated communication stream,
+  - chooses the correct CUDA kernel path.
+- **CUDA kernels (`csrc/kernels/*.cu*`)**
+  - count where tokens should go,
+  - build prefix sums and queue metadata,
+  - move payloads over NVLink and RDMA,
+  - reassemble or reduce results on the way back.
+
+## 4. The initialization pipeline
+
+The constructor of `Buffer` does much more than “allocate memory”. It turns the process group into a topology-aware runtime.
+
+```mermaid
+sequenceDiagram
+    participant Py as Python Buffer(...)
+    participant PG as Process group / MPI
+    participant CPP as C++ Buffer runtime
+    participant SHM as IPC / local shared memory
+    participant NS as NVSHMEM
+
+    Py->>CPP: create runtime object
+    Py->>PG: all_gather(local device ids)
+    Py->>PG: all_gather(local IPC handles)
+    alt RDMA or low-latency enabled
+        Py->>NS: set IBGDA and QP environment variables
+        Py->>PG: exchange NVSHMEM unique id
+        CPP->>NS: initialize NVSHMEM runtime
+        CPP->>NS: allocate symmetric RDMA buffer
+    end
+    CPP->>SHM: open peer IPC handles inside the node
+    CPP-->>Py: runtime becomes available
+```
+
+The most important pieces are:
+
+- `check_nvlink_connections(...)` in `deep_ep/utils.py` rejects unsupported intranode topologies.
+- `Buffer.__init__` in `deep_ep/buffer.py` gathers device IDs, IPC handles, and NVSHMEM IDs.
+- `Buffer::sync` in `csrc/deep_ep.cpp` opens peer memory handles, allocates RDMA buffers, and marks the runtime as available.
+
+## 5. The control plane vs. the data plane
+
+A useful way to read DeepEP is to separate **planning** from **movement**.
+
+### Control plane: deciding what should happen
+
+This is the job of:
+
+- `get_dispatch_layout(...)`
+- prefix matrices
+- source metadata
+- communication handles
+
+The output of the control plane is a precise answer to questions like:
+
+- how many tokens does each rank receive?
+- how many tokens does each local expert receive?
+- which tokens must be sent to each rank?
+- where should each sender write in the queue?
+
+### Data plane: actually moving bytes
+
+This is the job of:
+
+- intranode NVLink queues,
+- internode RDMA chunking and forwarding,
+- low-latency IBGDA send/recv phases,
+- combine-side reductions.
+
+The control plane is why DeepEP can be dynamic. The data plane is why it can still be fast.
+
+## 6. The source-code map
+
+| File | Why it matters |
+| --- | --- |
+| `deep_ep/__init__.py` | Python import surface: `Buffer`, `EventOverlap`, `Config`, `topk_idx_t` |
+| `deep_ep/buffer.py` | Main public API and mode selection logic |
+| `deep_ep/utils.py` | Event wrapper and topology validation |
+| `csrc/deep_ep.hpp` | Runtime interface and exposed operations |
+| `csrc/deep_ep.cpp` | Pybind bridge, buffer ownership, stream orchestration |
+| `csrc/config.hpp` | Hard constants such as `NUM_MAX_NVL_PEERS = 8` |
+| `csrc/kernels/configs.cuh` | Config object and buffer size formulas |
+| `csrc/kernels/layout.cu` | Layout kernel for per-rank and per-expert counts |
+| `csrc/kernels/intranode.cu` | NVLink dispatch/combine implementation |
+| `csrc/kernels/internode.cu` | RDMA forwarding path for normal kernels |
+| `csrc/kernels/internode_ll.cu` | Decode-time low-latency protocol |
+| `tests/*.py` | Usage examples, validation logic, and tuning loops |
+
+## 7. Why handles are a first-class concept
+
+DeepEP returns a **handle** from dispatch because the return path needs more than raw tensors. It needs the routing proof:
+
+- prefix sums,
+- source indices,
+- channel offsets,
+- RDMA-level metadata,
+- and sometimes global rank prefix sums.
+
+That handle is the bridge between “we scattered tokens out” and “we know exactly how to combine them back”.
+
+## 8. What to read next
+
+- If you want to run code quickly, go to [Quick Start](quick-start.md).
+- If your workload is training or prefilling, go to [Normal Kernels](normal-kernels.md).
+- If your workload is decode-time serving, go to [Low-Latency Kernels](low-latency.md).
+- If you want the formulas behind the API, go to [Math and Mental Models](math-theory.md).

--- a/docs/en/low-latency.md
+++ b/docs/en/low-latency.md
@@ -1,0 +1,184 @@
+# Low-Latency Kernels: Decode-Time Path
+
+The low-latency path exists for one reason: **serving cares about microseconds, not just aggregate bandwidth**.
+
+Normal kernels are built to move a lot of data efficiently. Decode-time serving often wants something different:
+
+- small batches,
+- tight tail-latency budgets,
+- and overlap between communication and compute without burning extra SMs.
+
+That is exactly what the low-latency kernels in `csrc/kernels/internode_ll.cu` are built for.
+
+## 1. When to use this path
+
+Choose the low-latency mode when all of the following are true:
+
+- you are in inference decoding,
+- all participating ranks are reachable through RDMA,
+- you care more about request latency than peak throughput,
+- you can afford a larger persistent RDMA buffer.
+
+## 2. The core idea
+
+```mermaid
+sequenceDiagram
+    participant B as Current batch
+    participant GPU as Local GPU
+    participant NIC as RDMA fabric
+    participant H as recv hook
+
+    B->>GPU: low_latency_dispatch(..., return_recv_hook=True)
+    GPU->>NIC: post sends / receives only
+    Note over GPU: no SM spent waiting for payload arrival
+    GPU->>GPU: run other compute
+    GPU->>H: hook()
+    H->>NIC: harvest received payload
+    GPU->>GPU: local expert GEMMs
+    GPU->>GPU: low_latency_combine(...)
+```
+
+The key trick is that DeepEP can separate:
+
+- **issuing the network work**, and
+- **actually receiving / materializing the payload**.
+
+That is why the API can return a hook.
+
+## 3. The RDMA buffer is double-buffered on purpose
+
+The low-latency layout in `csrc/kernels/configs.cuh` creates two symmetric slots. Think of them as **even** and **odd** lanes.
+
+```mermaid
+flowchart TB
+    subgraph RDMA buffer
+        subgraph Slot 0
+            S0[send buffer]
+            R0[recv buffer]
+            F0[signal / count buffer]
+        end
+        subgraph Slot 1
+            S1[send buffer]
+            R1[recv buffer]
+            F1[signal / count buffer]
+        end
+    end
+
+    Slot0[slot 0 in use] <--> Slot1[slot 1 in use]
+```
+
+This is why the Python docs warn you not to hold more than **two** low-latency result tensors at once: the buffers are intentionally recycled.
+
+## 4. API walkthrough
+
+### `low_latency_dispatch(...)`
+
+Inputs:
+
+- BF16 hidden states,
+- `topk_idx`,
+- `num_max_dispatch_tokens_per_rank`,
+- `num_experts`.
+
+Outputs:
+
+- packed received tensor(s),
+- per-local-expert receive counts,
+- a handle for combine,
+- an optional event,
+- an optional receive hook.
+
+The handle contains:
+
+- `src_info`,
+- `layout_range`,
+- `num_max_dispatch_tokens_per_rank`,
+- `hidden`,
+- `num_experts`.
+
+That is enough information for `low_latency_combine(...)` to know how to put the results back.
+
+### `low_latency_combine(...)`
+
+Inputs:
+
+- local expert outputs,
+- original `topk_idx`,
+- original `topk_weights`,
+- the handle returned by dispatch.
+
+Important options:
+
+- `use_logfmt`: use the internal compressed format on the combine path,
+- `zero_copy`: skip a copy when the next combine buffer is already populated,
+- `out`: provide an explicit destination tensor,
+- `return_recv_hook`: decouple network progress from receive materialization.
+
+## 5. FP8, UE8M0, and why scales exist
+
+Low-latency dispatch can optionally cast BF16 activations into FP8.
+
+The important consequence is that the receive tensor may be returned as a tuple:
+
+- FP8 payload tensor,
+- scale tensor.
+
+DeepEP stores scales per 128 hidden channels. That is the same mental model used by the helper conversion code in `tests/utils.py`.
+
+If `round_scale=True`, the scales are rounded into powers of two. If `use_ue8m0=True`, the scale storage format becomes even more compact.
+
+## 6. Hook-based overlap without extra SM usage
+
+This is one of the nicest ideas in DeepEP.
+
+Normally, “overlap communication with compute” means some compute resources are still spent polling or progressing the communication. DeepEP's low-latency design instead allows the network requests to sit in the background while the SMs do other work.
+
+A good mental model is:
+
+- **dispatch call**: mail the package and keep the tracking number,
+- **other compute**: do useful work while the truck is on the road,
+- **hook call**: open the door exactly when the delivery arrives.
+
+## 7. Clean-up and shrink-mode controls
+
+Low-latency mode exposes extra APIs because it is closer to production serving behavior.
+
+### `clean_low_latency_buffer(...)`
+
+Use this when the low-latency buffer might be dirty, especially after mixing normal and low-latency flows. Parts of the protocol assume zero-initialized regions.
+
+### Mask buffer APIs
+
+- `low_latency_update_mask_buffer(...)`
+- `low_latency_query_mask_buffer(...)`
+- `low_latency_clean_mask_buffer()`
+
+These are tied to the timeout and failure-handling logic exercised in `tests/test_low_latency.py`.
+
+The idea is simple: if a rank becomes unhealthy or times out, the protocol can mark it as masked so the rest of the system can keep moving.
+
+## 8. Why low-latency mode uses more memory
+
+The low-latency buffer is big because it must keep enough space for:
+
+- send messages,
+- receive messages,
+- signaling state,
+- and double buffering.
+
+It is essentially pre-paying memory in order to buy down control-flow latency later.
+
+## 9. Practical checklist before you enable it
+
+- Make sure RDMA is visible from every participating rank.
+- Set `num_qps_per_rank` equal to the number of local experts for best performance.
+- Keep `num_max_dispatch_tokens_per_rank` realistic; the README suggests staying below 256 for decoding engines.
+- Remember that the persistent RDMA buffer must be large enough for the worst expected decode-time shape.
+- If you mix normal and low-latency kernels, clean the low-latency buffer before reusing it.
+
+## 10. Source files worth reading together
+
+- `deep_ep/buffer.py` for the public API and returned tuple shapes,
+- `csrc/kernels/configs.cuh` for the low-latency memory layout,
+- `csrc/kernels/internode_ll.cu` for send/recv phases, masking, and statistics,
+- `tests/test_low_latency.py` for real usage patterns and failure simulation.

--- a/docs/en/math-theory.md
+++ b/docs/en/math-theory.md
@@ -1,0 +1,246 @@
+# Math and Mental Models
+
+This page translates DeepEP's formulas into everyday intuition. The goal is not to impress you with symbols. The goal is to make the symbols feel obvious.
+
+## 1. The two questions every transport must answer
+
+Before DeepEP can move a single byte, it must answer:
+
+1. **Where should each token go?**
+2. **How much buffer space should each route get?**
+
+Everything else in the code is a highly optimized answer to those two questions.
+
+## 2. Dispatch layout as a set problem
+
+Let:
+
+- `T` be the number of tokens,
+- `K` be the top-k count,
+- `E` be the number of experts,
+- `R` be the number of ranks,
+- `E_local = E / R` be the number of experts per rank.
+
+If token `t` selects expert `e_{t, j}`, then the owner rank is:
+
+$$
+\operatorname{rank}(e_{t,j}) = \left\lfloor \frac{e_{t,j}}{E_{local}} \right\rfloor.
+$$
+
+DeepEP then forms the **destination set** of token `t`:
+
+$$
+D_t = \{\operatorname{rank}(e_{t,j}) \mid e_{t,j} \neq -1\}.
+$$
+
+Notice the word **set**. If a token picks two experts on the same rank, that rank appears only once.
+
+Now define the indicator:
+
+$$
+I_{t,r} = \mathbf{1}[r \in D_t].
+$$
+
+Then the layout kernel computes:
+
+$$
+N_r = \sum_{t=0}^{T-1} I_{t,r}
+$$
+
+for the number of tokens sent to rank `r`, and
+
+$$
+M_e = \sum_{t=0}^{T-1} \sum_{j=0}^{K-1} \mathbf{1}[e_{t,j} = e]
+$$
+
+for the number of times expert `e` is selected.
+
+### Super-simple market analogy
+
+Imagine 4 shoppers and 4 vegetable stalls run by 4 vendors.
+
+- A shopper may want tomatoes and potatoes.
+- If both vegetables are sold by the same vendor, the shopper only walks to that vendor once.
+- `I_{t,r}` just means “shopper `t` needs vendor `r`”.
+- `N_r` means “how many shoppers will line up at vendor `r`”.
+
+That is all the layout kernel is doing, just at GPU speed.
+
+## 3. Worked example with real numbers
+
+Suppose:
+
+- 8 experts,
+- 4 ranks,
+- 2 experts per rank,
+- top-k = 2.
+
+Let the expert selections be:
+
+| Token | Experts | Destination set |
+| --- | --- | --- |
+| `t0` | `[1, 6]` | `{0, 3}` |
+| `t1` | `[0, 2]` | `{0, 1}` |
+| `t2` | `[3, 7]` | `{1, 3}` |
+| `t3` | `[4, -1]` | `{2}` |
+
+Then the indicator matrix is:
+
+| Token \ Rank | 0 | 1 | 2 | 3 |
+| --- | ---: | ---: | ---: | ---: |
+| `t0` | 1 | 0 | 0 | 1 |
+| `t1` | 1 | 1 | 0 | 0 |
+| `t2` | 0 | 1 | 0 | 1 |
+| `t3` | 0 | 0 | 1 | 0 |
+
+So:
+
+$$
+(N_0, N_1, N_2, N_3) = (2, 2, 1, 2).
+$$
+
+That vector is exactly the kind of tensor returned by `get_dispatch_layout(...)`.
+
+## 4. Prefix sums are just seat numbers
+
+Counts tell you **how many** passengers board each bus. Prefix sums tell you **where each passenger should sit**.
+
+If one destination rank receives counts `[1, 2, 0, 1]` from four senders, the prefix sum is:
+
+$$
+(1, 3, 3, 4).
+$$
+
+That means:
+
+- sender 0 occupies slots `[0, 1)`,
+- sender 1 occupies slots `[1, 3)`,
+- sender 2 occupies slots `[3, 3)`,
+- sender 3 occupies slots `[3, 4)`.
+
+DeepEP's prefix matrices are just that idea generalized across ranks, channels, and RDMA levels.
+
+```mermaid
+flowchart LR
+    Count[Per-sender counts] --> Prefix[Prefix sums]
+    Prefix --> Slots[Deterministic buffer slots]
+    Slots --> Transport[Writers and readers agree without conflict]
+```
+
+## 5. Combine is weighted reduction
+
+Let `h_{t,j}` be the output produced for token `t` by its `j`-th selected expert, and let `w_{t,j}` be the corresponding gate weight.
+
+Then the ideal combine result is:
+
+$$
+y_t = \sum_{j=0}^{K-1} w_{t,j} h_{t,j}.
+$$
+
+If DeepEP is also asked to add optional bias tensors `b_t^{(0)}` and `b_t^{(1)}`, the final value becomes:
+
+$$
+\hat{y}_t = y_t + b_t^{(0)} + b_t^{(1)}.
+$$
+
+So the transport graph is doing more than a gather; it is returning values to the original token order **and** applying the MoE reduction semantics.
+
+## 6. FP8 scaling in plain language
+
+DeepEP often handles payloads in blocks of 128 hidden channels.
+
+For one such block, define:
+
+$$
+\alpha = \max_i |x_i|.
+$$
+
+Then the scale is approximately:
+
+$$
+s = \frac{\alpha}{448}.
+$$
+
+The FP8 value is then a clipped, quantized version of:
+
+$$
+q_i \approx \frac{x_i}{s}, \qquad x_i \approx q_i s.
+$$
+
+### Tiny numeric example
+
+Suppose a 128-channel block has its largest magnitude equal to `4.48`.
+
+Then:
+
+$$
+s = \frac{4.48}{448} = 0.01.
+$$
+
+So values like:
+
+- `1.12` become about `112`,
+- `-2.24` become about `-224`,
+- `4.48` become about `448`.
+
+Later, DeepEP multiplies the FP8 payload by the stored scale to recover a BF16 approximation.
+
+That is why the low-latency API may return **two** tensors: payload and scales.
+
+## 7. Why low-latency buffer sizes grow so fast
+
+The formulas in `csrc/kernels/configs.cuh` are easier to understand if you separate them into payload and metadata.
+
+For normal kernels, the NVLink-side buffer is roughly:
+
+$$
+B_{NVL} \approx C \cdot R_{NVL} \cdot (\text{metadata} + T_{recv} \cdot \text{hidden bytes} + T_{recv} \cdot \text{auxiliary fields}),
+$$
+
+where `C = num_sms / 2` is the number of channels.
+
+For low-latency mode, one dispatch message is sized as:
+
+$$
+\text{bytes}_{dispatch} = 16 + \max(2H, H + 4H/128),
+$$
+
+where:
+
+- `16` is the `int4` control header,
+- `2H` is the BF16 path,
+- `H + 4H/128` is the FP8 payload plus scales.
+
+And one combine message is sized as:
+
+$$
+\text{bytes}_{combine} = 2H + 4H/128.
+$$
+
+### Example with `H = 7168`
+
+- `num_scales = 7168 / 128 = 56`
+- BF16 payload = `2H = 14336` bytes
+- FP8 payload + scales = `7168 + 56 * 4 = 7392` bytes
+- dispatch message = `16 + max(14336, 7392) = 14352` bytes
+- combine message = `14336 + 224 = 14560` bytes
+
+This is why the README warns that low-latency mode is memory-hungry: the layout is deliberately provisioned for the hard case.
+
+## 8. Source metadata as a bitfield
+
+`csrc/kernels/internode.cu` defines a `SourceMeta` structure that stores:
+
+- the source RDMA rank,
+- an 8-bit mask telling which NVLink peers inside that source node own the token.
+
+If the bit mask is `10110010`, it means those specific local NVLink positions were selected. The exact bit positions are not magic. They are just a compact way to carry “who inside the source node cares about this token?”
+
+## 9. The two guiding intuitions
+
+If you remember only two things, remember these:
+
+1. **Layout is a set-and-prefix-sum problem.**
+2. **Transport is a queue-filling problem over real hardware fabrics.**
+
+The symbols in the code become much less scary once you recognize those two patterns.

--- a/docs/en/normal-kernels.md
+++ b/docs/en/normal-kernels.md
@@ -1,0 +1,229 @@
+# Normal Kernels: Training and Prefill Path
+
+DeepEP calls the throughput-oriented path the **normal kernels**. They are the right default for:
+
+- training,
+- forward-only prefilling,
+- and any workload where overall bandwidth matters more than raw decode latency.
+
+## 1. The big picture
+
+```mermaid
+sequenceDiagram
+    participant U as User stream
+    participant C as Comm stream
+    participant L as Layout kernel
+    participant N as Notify kernel
+    participant D as Dispatch kernels
+    participant G as Local expert GEMMs
+    participant B as Combine kernels
+
+    U->>C: optional previous_event
+    C->>L: get_dispatch_layout(topk_idx, num_experts)
+    C->>N: notify counts / build prefix sums
+    C->>D: dispatch payloads and metadata
+    C-->>U: handle + optional EventOverlap
+    U->>G: compute on received expert batches
+    U->>C: combine(expert_outputs, handle)
+    C->>B: reduce back to source tokens
+    C-->>U: combined output
+```
+
+The separation between `get_dispatch_layout(...)`, `dispatch(...)`, and `combine(...)` is not accidental. It mirrors the real work:
+
+1. count the destinations,
+2. move the payloads,
+3. reduce the results back.
+
+## 2. Why layout is a separate step
+
+The gate tells you the **experts**. The transport needs the **ranks** and **counts**.
+
+For each token, DeepEP first asks:
+
+- which ranks does this token need to visit?
+- how many tokens are going to each rank?
+- how many tokens will each expert receive?
+
+The layout kernel in `csrc/kernels/layout.cu` computes exactly those answers and returns:
+
+- `num_tokens_per_rank`,
+- `num_tokens_per_rdma_rank` for internode mode,
+- `num_tokens_per_expert`,
+- `is_token_in_rank`.
+
+### The subtle point many readers miss
+
+`is_token_in_rank[t, r]` is a **boolean**, not a count.
+
+That means if one token chooses two experts that both live on the same rank, DeepEP still sends that token to that rank only **once**. This is why the layout stage is not just bookkeeping: it removes redundant traffic before the real transport begins.
+
+## 3. A tiny concrete example
+
+Assume:
+
+- 8 experts total,
+- 4 ranks,
+- 2 experts per rank.
+
+So the expert-to-rank mapping is:
+
+- rank 0 owns experts 0 and 1,
+- rank 1 owns experts 2 and 3,
+- rank 2 owns experts 4 and 5,
+- rank 3 owns experts 6 and 7.
+
+Now suppose the gate outputs:
+
+| Token | Selected experts | Destination ranks | `is_token_in_rank` row |
+| --- | --- | --- | --- |
+| `t0` | `[1, 6]` | `[0, 3]` | `[1, 0, 0, 1]` |
+| `t1` | `[0, 2]` | `[0, 1]` | `[1, 1, 0, 0]` |
+| `t2` | `[3, 7]` | `[1, 3]` | `[0, 1, 0, 1]` |
+| `t3` | `[4, -1]` | `[2]` | `[0, 0, 1, 0]` |
+
+Then:
+
+- `num_tokens_per_rank = [2, 2, 1, 2]`
+- `num_tokens_per_expert` is counted per exact expert id.
+
+That is the shipping manifest the runtime needs.
+
+## 4. What happens inside `dispatch(...)`
+
+The Python method chooses between two implementations:
+
+- **intranode dispatch** if everything is inside the NVLink domain,
+- **internode dispatch** if RDMA ranks are involved.
+
+### Intranode path
+
+The kernel family in `csrc/kernels/intranode.cu` uses:
+
+- per-rank shared queues in NVLink-visible buffers,
+- barriers between local peers,
+- per-channel prefix sums,
+- and separate sender / receiver responsibilities.
+
+A useful mental model is: **each channel is a train car**.
+
+- The layout stage decides how many parcels each destination needs.
+- Prefix sums assign each sender a seat range inside the correct car.
+- Senders write payloads into those seat ranges.
+- Receivers read a contiguous block back out.
+
+### Internode path
+
+The kernel family in `csrc/kernels/internode.cu` adds one more level:
+
+- aggregate traffic in the NVLink domain,
+- forward across RDMA between matching GPU indices,
+- then fan back out locally.
+
+That is why the README describes it as **forwarding from the NVLink domain to the RDMA domain**.
+
+```mermaid
+flowchart LR
+    subgraph Node A
+        A0[NVLink domain]
+    end
+    subgraph RDMA fabric
+        R[RDMA forwarding]
+    end
+    subgraph Node B
+        B0[NVLink domain]
+    end
+
+    A0 --> R --> B0
+```
+
+## 5. What is inside the returned handle
+
+The normal-kernel handle is the minimum information needed to reverse the dispatch later.
+
+### Intranode handle
+
+The Python code returns a tuple containing values such as:
+
+- `rank_prefix_matrix`
+- `channel_prefix_matrix`
+- `recv_channel_prefix_matrix`
+- `recv_src_idx`
+- `is_token_in_rank`
+- `send_head`
+
+Broadly speaking:
+
+- **prefix matrices** say where each sender should write and where each receiver should read,
+- **source indices** preserve the mapping back to original token order,
+- **send heads** maintain queue progress.
+
+### Internode handle
+
+The internode handle grows to include RDMA-specific pieces, such as:
+
+- RDMA channel prefix matrices,
+- global rank prefix sums,
+- received source metadata,
+- RDMA and NVLink send heads.
+
+The extra fields exist because the transport now has to remember both the cross-node hop and the intra-node fan-out.
+
+## 6. Why `combine(...)` is not just “the reverse of dispatch”
+
+Conceptually it is the reverse, but operationally it is a **reduction**.
+
+- `dispatch(...)` copies one token to every rank that owns one of its selected experts.
+- `combine(...)` gathers those expert outputs back and reduces them into the original token order.
+
+If `topk_weights` are provided, DeepEP reduces with those weights. If `bias` is provided, DeepEP adds it after the reduction.
+
+This is why the repository examples say:
+
+- the backward of dispatch is combine,
+- and the backward of combine is dispatch.
+
+The transport graph is symmetric, but the algebra on the payload is not.
+
+## 7. Asynchrony and overlap
+
+The normal path supports two useful overlap mechanisms.
+
+### `previous_event`
+
+Pass an `EventOverlap` if the communication should wait for some previous compute.
+
+### `async_finish=True`
+
+Return as soon as the work is launched on the communication stream, then wait later only when needed.
+
+This is especially useful if you want to overlap expert GEMMs or some other stream-local work with the outstanding communication.
+
+## 8. Why there can be a CPU wait
+
+For the exact normal dispatch path, the current rank may not know the final receive count immediately. The runtime therefore waits for a GPU-side signal that says “the count is ready”.
+
+That is why the README explicitly warns that the exact path is not CUDA-graph friendly in the general case.
+
+### The escape hatch: `num_worst_tokens`
+
+If you can afford a worst-case receive buffer size, you can pass `num_worst_tokens` (intranode only). That avoids the CPU sync because the receiver no longer waits for the exact count before continuing.
+
+The trade-off is simple:
+
+- **exact count** -> less memory, possible CPU wait,
+- **worst-case count** -> more memory, graph-friendlier control flow.
+
+## 9. Where to read the code
+
+If you want to align the prose with the implementation, focus on:
+
+- `deep_ep/buffer.py` for the public API and tuple layout,
+- `csrc/deep_ep.cpp` for stream orchestration and type checks,
+- `csrc/kernels/layout.cu` for count generation,
+- `csrc/kernels/intranode.cu` for local queueing,
+- `csrc/kernels/internode.cu` for RDMA forwarding.
+
+## 10. Recommended next page
+
+If the formulas behind the layout and counts still feel abstract, continue with [Math and Mental Models](math-theory.md).

--- a/docs/en/performance-tuning.md
+++ b/docs/en/performance-tuning.md
@@ -1,0 +1,145 @@
+# Performance and Tuning
+
+This page is about turning DeepEP from “it works” into “it matches the topology and workload I actually have”.
+
+## 1. First choose the right kernel family
+
+```mermaid
+flowchart TD
+    S[Workload] -->|Training or prefilling| N[Normal kernels]
+    S -->|Decode-time serving| L[Low-latency kernels]
+    N -->|Single node, NVLink-visible| INTRA[Intranode path]
+    N -->|Multiple nodes with RDMA| INTER[Internode forwarding path]
+    L --> HOOK[Optional hook-based overlap]
+```
+
+The most common tuning mistake is trying to solve a latency problem with the throughput kernel family or vice versa.
+
+## 2. Hard topology assumptions
+
+DeepEP is fast partly because it makes strong assumptions.
+
+| Assumption | Why it matters |
+| --- | --- |
+| `NUM_MAX_NVL_PEERS = 8` | The code is structured around an 8-GPU NVLink domain |
+| NVLink visible inside the node | Required for intranode normal kernels |
+| RDMA available across nodes | Required for internode normal kernels and low-latency mode |
+| NVSHMEM available | Required for RDMA-backed features |
+| Even `num_sms` for normal kernels | The runtime uses `num_channels = num_sms / 2` |
+| QPs per rank should match local experts in low-latency mode | Best throughput/latency balance for decode path |
+
+## 3. Published knobs that really matter
+
+### Runtime knobs
+
+| Knob | Surface | Effect |
+| --- | --- | --- |
+| `Buffer.set_num_sms(...)` | Python API | Controls how many SMs normal kernels may consume |
+| `Buffer.get_dispatch_config(...)` | Python API | Recommended normal-kernel dispatch chunk sizes |
+| `Buffer.get_combine_config(...)` | Python API | Recommended normal-kernel combine chunk sizes |
+| `num_qps_per_rank` | `Buffer(...)` constructor | Controls RDMA parallelism in low-latency mode |
+| `allow_nvlink_for_low_latency_mode` | `Buffer(...)` constructor | Allows NVLink assistance in low-latency mode |
+| `enable_shrink` | `Buffer(...)` constructor | Enables dynamic masking of unhealthy ranks |
+
+### Build and deployment knobs
+
+| Knob | Effect |
+| --- | --- |
+| `NVSHMEM_DIR` | Enables NVSHMEM-backed features |
+| `TORCH_CUDA_ARCH_LIST` | Chooses target GPU architecture |
+| `DISABLE_SM90_FEATURES` | Disables Hopper-specific features |
+| `DISABLE_AGGRESSIVE_PTX_INSTRS` | Disables aggressive PTX loads/stores when compatibility is more important than speed |
+| `NVSHMEM_IB_SL` | Assigns InfiniBand virtual lanes for traffic isolation |
+
+## 4. What the tuning tests already do for you
+
+The repository tests are not just correctness checks. They are also tuning harnesses.
+
+- `tests/test_intranode.py` sweeps SM counts and NVLink chunk sizes.
+- `tests/test_internode.py` sweeps NVLink and RDMA chunk sizes for the forwarding path.
+- `tests/test_low_latency.py` measures dispatch/combine bandwidth and hook-based timing split.
+- `tests/utils.py` provides `bench(...)` and `bench_kineto(...)` helpers.
+
+That means the recommended workflow is:
+
+1. make the topology correct,
+2. run the right test for your path,
+3. record the best chunk sizes on your cluster,
+4. feed those configs back into your framework integration.
+
+## 5. Network settings that matter in production
+
+The repository README gives three practical deployment recommendations.
+
+### Traffic isolation
+
+Use InfiniBand virtual lanes to separate:
+
+- normal-kernel traffic,
+- low-latency traffic,
+- and everything else.
+
+The relevant environment variable is `NVSHMEM_IB_SL`.
+
+### Adaptive routing
+
+Use adaptive routing when the fabric is busy and static routing when the fabric is light. The trade-off is straightforward:
+
+- adaptive routing lowers congestion,
+- static routing lowers added latency.
+
+### Congestion control
+
+The README notes that congestion control is disabled in the authors' production environment because they did not see major benefit.
+
+## 6. Interpreting the knobs physically
+
+It helps to think in physical terms, not just API terms.
+
+- `num_sms`: how much compute silicon you are willing to spend on communication.
+- chunk size: how much payload each channel moves before rotating.
+- QPs per rank: how many parallel doors the NIC exposes per rank.
+- `num_max_dispatch_tokens_per_rank`: the largest decode burst the low-latency buffer must survive.
+
+If a knob feels mysterious, translate it into one of those physical interpretations.
+
+## 7. Common symptoms and likely causes
+
+| Symptom | Likely cause |
+| --- | --- |
+| Intranode path fails on some machines | GPUs are not fully NVLink-visible; check topology first |
+| Low-latency path works but uses too much memory | `num_max_dispatch_tokens_per_rank` is overprovisioned |
+| Decode overlap shows little benefit | hook split does not match your compute stages, or NVLink assistance conflicts with overlap expectations |
+| Internode throughput is disappointing | RDMA chunk sizes and SL/routing are mismatched to the cluster |
+| Wrong results on unusual platforms | disable aggressive PTX instructions and retest |
+
+## 8. The undefined-PTX note is worth taking seriously
+
+DeepEP explicitly documents an aggressive PTX trick around non-coherent loads with `.L1::no_allocate`. The README explains why it was adopted and also provides the safety switch:
+
+- if a platform behaves oddly,
+- set `DISABLE_AGGRESSIVE_PTX_INSTRS=1`,
+- and prefer correctness over the last bit of speed.
+
+That is a classic HPC trade-off: exotic instructions can buy speed, but they make portability harder.
+
+## 9. A practical tuning order
+
+If you are tuning a fresh cluster, use this order:
+
+1. Verify build flags and GPU architecture.
+2. Verify NVLink visibility locally.
+3. Verify RDMA and NVSHMEM visibility globally.
+4. Tune the normal or low-latency path, not both at once.
+5. Sweep chunk sizes before making code changes.
+6. Only after transport is healthy, revisit expert GEMM overlap.
+
+That ordering prevents a lot of wasted debugging time.
+
+## 10. Final rule of thumb
+
+DeepEP performance comes from matching the software path to the physical topology.
+
+If you remember one sentence from this page, remember this one:
+
+> **Treat NVLink, RDMA, and SM budget as separate resources, then tune DeepEP so each one is spent where it is strongest.**

--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -1,0 +1,199 @@
+# Quick Start
+
+This page is the shortest path from “I just cloned DeepEP” to “I understand the API skeleton and know what must be configured on a real cluster”.
+
+## 1. Requirements checklist
+
+From the repository `README.md` and `setup.py`, the practical requirements are:
+
+- Ampere (SM80) or Hopper (SM90) class GPUs.
+- Python 3.8+.
+- PyTorch 2.1+.
+- CUDA 11+ for SM80, CUDA 12.3+ for SM90 features.
+- NVLink for intranode kernels.
+- RDMA for internode and low-latency kernels.
+- NVSHMEM for any RDMA-backed feature.
+
+If you only care about intranode NVLink kernels, DeepEP can still build without NVSHMEM, but internode and low-latency functionality will be disabled.
+
+## 2. Build and installation
+
+### Development build
+
+```bash
+NVSHMEM_DIR=/path/to/installed/nvshmem python setup.py build
+ln -s build/lib.linux-x86_64-cpython-38/deep_ep_cpp.cpython-38-x86_64-linux-gnu.so
+```
+
+### Install into the environment
+
+```bash
+NVSHMEM_DIR=/path/to/installed/nvshmem python setup.py install
+```
+
+### Important build-time environment variables
+
+| Variable | Meaning | Where it is used |
+| --- | --- | --- |
+| `NVSHMEM_DIR` | Path to NVSHMEM installation | `setup.py`, constructor setup |
+| `DISABLE_SM90_FEATURES` | Disable Hopper-specific features | `setup.py`, `csrc/config.hpp` |
+| `TORCH_CUDA_ARCH_LIST` | Target architecture list, e.g. `9.0` | `setup.py` |
+| `DISABLE_AGGRESSIVE_PTX_INSTRS` | Disable aggressive PTX load/store tricks | `setup.py`, low-level kernels |
+| `TOPK_IDX_BITS` | Choose 32-bit or 64-bit expert indices | `setup.py`, `csrc/config.hpp` |
+| `NVSHMEM_IB_SL` | InfiniBand service level / virtual lane selection | runtime deployment |
+
+## 3. Execution skeleton
+
+```mermaid
+flowchart LR
+    A[Initialize distributed group] --> B[Choose normal or low-latency mode]
+    B --> C[Allocate buffer using size hints]
+    C --> D[Prepare top-k routing tensors]
+    D --> E[Dispatch]
+    E --> F[Run local expert compute]
+    F --> G[Combine]
+```
+
+You can learn almost the whole API from that graph.
+
+## 4. Minimal normal-kernel usage
+
+```python
+import torch
+import torch.distributed as dist
+from deep_ep import Buffer
+
+# Tune throughput kernels: even number only.
+Buffer.set_num_sms(24)
+
+group = dist.group.WORLD
+hidden_bytes = hidden * 2  # BF16 is 2 bytes per element
+
+dispatch_cfg = Buffer.get_dispatch_config(group.size())
+combine_cfg = Buffer.get_combine_config(group.size())
+num_nvl_bytes = max(
+    dispatch_cfg.get_nvl_buffer_size_hint(hidden_bytes, group.size()),
+    combine_cfg.get_nvl_buffer_size_hint(hidden_bytes, group.size()),
+)
+num_rdma_bytes = max(
+    dispatch_cfg.get_rdma_buffer_size_hint(hidden_bytes, group.size()),
+    combine_cfg.get_rdma_buffer_size_hint(hidden_bytes, group.size()),
+)
+
+buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes)
+num_tokens_per_rank, num_tokens_per_rdma_rank, num_tokens_per_expert, is_token_in_rank, layout_event = \
+    buffer.get_dispatch_layout(topk_idx, num_experts)
+
+recv_x, recv_topk_idx, recv_topk_weights, local_expert_counts, handle, event = buffer.dispatch(
+    x,
+    topk_idx=topk_idx,
+    topk_weights=topk_weights,
+    num_tokens_per_rank=num_tokens_per_rank,
+    num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+    is_token_in_rank=is_token_in_rank,
+    num_tokens_per_expert=num_tokens_per_expert,
+)
+
+# ... run local expert GEMMs on recv_x ...
+
+combined_x, combined_topk_weights, event = buffer.combine(
+    expert_outputs,
+    handle,
+    topk_weights=recv_topk_weights,
+)
+```
+
+### Mental model of the arguments
+
+- `topk_idx` says which experts each token wants.
+- `get_dispatch_layout(...)` turns that into a shipping manifest.
+- `dispatch(...)` ships the tokens.
+- `handle` is the receipt that allows `combine(...)` to undo the routing later.
+
+## 5. Minimal low-latency usage
+
+```python
+from deep_ep import Buffer
+
+num_rdma_bytes = Buffer.get_low_latency_rdma_size_hint(
+    num_max_dispatch_tokens_per_rank,
+    hidden,
+    group.size(),
+    num_experts,
+)
+
+buffer = Buffer(
+    group,
+    0,
+    num_rdma_bytes,
+    low_latency_mode=True,
+    num_qps_per_rank=num_experts // group.size(),
+)
+
+recv_x, recv_count, handle, event, hook = buffer.low_latency_dispatch(
+    hidden_states,
+    topk_idx,
+    num_max_dispatch_tokens_per_rank,
+    num_experts,
+    return_recv_hook=True,
+)
+
+# Overlap other work here if you want.
+hook()
+
+combined_x, event, hook = buffer.low_latency_combine(
+    expert_outputs,
+    topk_idx,
+    topk_weights,
+    handle,
+    return_recv_hook=True,
+)
+
+hook()
+```
+
+Low-latency mode is different in three important ways:
+
+- it needs much larger RDMA buffer space,
+- it is optimized around decode-time latency instead of peak throughput,
+- and it can split “post the traffic” from “harvest the arrival” by returning a hook.
+
+## 6. What `EventOverlap` is for
+
+`EventOverlap` is a tiny wrapper over a CUDA event. Use it when you want the communication stream and the compute stream to depend on each other without globally synchronizing the device.
+
+In practice:
+
+- `previous_event` lets DeepEP wait for some earlier compute to finish,
+- `async_finish=True` lets the call return before the communication stream is fully done,
+- `current_stream_wait()` lets your current stream wait only when you choose.
+
+## 7. Cluster and topology sanity checks
+
+Before blaming DeepEP, check the physical assumptions:
+
+- Are the local GPUs actually connected by NVLink?
+- Are you running on the correct CUDA architecture target?
+- Is NVSHMEM installed and visible?
+- Is your process group initialized with the correct world size and ranks?
+- For low-latency mode, does `num_qps_per_rank` equal the number of local experts?
+
+The helper `check_nvlink_connections(...)` in `deep_ep/utils.py` exists exactly because some GPU topologies look similar from the outside but are not valid for the intranode kernels.
+
+## 8. Tests and validation harnesses
+
+The repository already includes cluster-side validation programs:
+
+```bash
+python tests/test_intranode.py
+python tests/test_internode.py
+python tests/test_low_latency.py
+```
+
+Also note the warning in `tests/utils.py`: the `init_dist(...)` helper is intentionally simple and may need to be rewritten for your cluster launcher.
+
+## 9. Where to go next
+
+- Use [Architecture](architecture.md) if you want the system map.
+- Use [Normal Kernels](normal-kernels.md) if you are integrating training or prefilling.
+- Use [Low-Latency Kernels](low-latency.md) if you are integrating decoding.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -1,0 +1,48 @@
+# DeepEP 文档（中文）
+
+DeepEP 是一个面向 MoE 专家并行通信的底层引擎。最直白地说：**门控负责决定 token 要去哪些专家，DeepEP 负责把这张“派件单”变成足够快的 NVLink 与 RDMA 通信。**
+
+```mermaid
+flowchart TB
+    X[输入 hidden states] --> G[top-k 门控]
+    G --> L[get_dispatch_layout]
+    L --> D[跨 NVLink / RDMA 分发]
+    D --> E[本地专家计算]
+    E --> C[Combine 回原始 rank]
+    C --> Y[恢复原 token 语义]
+```
+
+## 阅读导航
+
+- [快速开始](quick-start.md)：环境、安装、最小用法、基础排障。
+- [架构总览](architecture.md)：系统分层、数据平面、源码地图。
+- [普通内核路径](normal-kernels.md)：训练 / prefill 场景下的 `get_dispatch_layout`、`dispatch`、`combine`。
+- [低延迟内核路径](low-latency.md)：解码场景下的 IBGDA、hook、双缓冲机制。
+- [数学与直觉](math-theory.md)：指标矩阵、前缀和、FP8 scale、buffer 公式的“降维打击”解释。
+- [性能与调优](performance-tuning.md)：拓扑假设、关键调参项、集群部署建议。
+
+## 如果你只想先抓主线
+
+1. 先读 [架构总览](architecture.md) 前两节。
+2. 再看 [快速开始](quick-start.md) 的 API 骨架。
+3. 根据你的工作负载选择 [普通内核路径](normal-kernels.md) 或 [低延迟内核路径](low-latency.md)。
+
+## 如果你要把 DeepEP 接进训练框架或服务框架
+
+优先盯住这几个源码面：
+
+- `deep_ep/buffer.py`：公共 Python 控制面。
+- `deep_ep/utils.py`：事件重叠与拓扑检查。
+- `csrc/deep_ep.cpp`：Python 到 CUDA 的运行时边界。
+- `csrc/kernels/`：真正执行通信与打包的内核。
+- `tests/`：现成的使用范式与调优入口。
+
+## 为什么文档要分成这几层
+
+DeepEP 最怕一上来就扎进 CUDA 细节。更好的学习顺序是：
+
+- 先明白业务问题：MoE 稀疏 all-to-all 为什么难，
+- 再看系统骨架：NVLink 域 + RDMA 域，
+- 再看 API，
+- 然后再下钻到两套 kernel 家族，
+- 最后再补数学与调优。

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -1,0 +1,182 @@
+# DeepEP 架构总览
+
+## 1. 先用人话讲清楚它到底在干什么
+
+你可以把一个 MoE 模型想象成一座城市里的“专科门诊系统”：
+
+- **门控（gate）** 决定每个 token 该去看哪几个专科医生；
+- **专家（experts）** 负责真正做计算；
+- **DeepEP** 则是那个把病人从不同街区、不同城市送到对应门诊的高效交通网络。
+
+在一台机器内部，最快的路是 **NVLink**；跨机器时，长途主干道是 **RDMA**。DeepEP 的存在意义，就是把 MoE 这种“每一步都在动态换路由”的稀疏 all-to-all 通信，做得尽量快、尽量稳。
+
+## 2. DeepEP 真正解决的痛点
+
+稠密模型里，大多数激活都留在本地。MoE 不一样。
+
+对每个 token 来说，门控会选出若干专家，这些专家可能：
+
+- 就在当前 GPU 上，
+- 在同机的另一张 GPU 上，
+- 也可能在另一台机器的 GPU 上。
+
+于是立刻出现三大系统级难题：
+
+1. **路由是稀疏的，但又是动态的。** 每个 batch 的 token-to-expert 映射都可能不同。
+2. **物理拓扑是不对称的。** NVLink 很快，RDMA 慢得多，但跨节点只能走 RDMA。
+3. **训练 / prefill 与 decoding 的诉求完全不同。** 前者要吞吐，后者要低延迟。
+
+DeepEP 的回答是：不要用一套 kernel 硬扛所有场景，而是拆成两大家族。
+
+| 内核家族 | 主要目标 | 典型通信形态 | 适用场景 |
+| --- | --- | --- | --- |
+| 普通内核 | 吞吐优先 | 节点内 NVLink，节点间 RDMA forwarding | 训练、prefill |
+| 低延迟内核 | 时延优先 | 基于 IBGDA 的纯 RDMA 路径 | decoding |
+
+## 3. 系统分层图
+
+```mermaid
+flowchart TB
+    subgraph 框架层
+        Gate[MoE gate\n选择专家]
+        API[Python API\nBuffer / EventOverlap]
+    end
+
+    subgraph 运行时层
+        Layout[布局内核\n统计计数与位图]
+        Handle[通信句柄\n前缀和 + 源信息]
+        Stream[独立通信流]
+    end
+
+    subgraph 数据平面
+        NVL[NVLink 路径\n节点内]
+        RDMA[RDMA + NVSHMEM + IBGDA\n跨节点]
+        LL[低延迟双缓冲\ndecode 路径]
+    end
+
+    subgraph 计算层
+        Experts[本地专家 GEMM]
+        Combine[回收与归并]
+    end
+
+    Gate --> API --> Layout --> Handle --> Stream
+    Stream --> NVL --> Experts --> Combine
+    Stream --> RDMA --> Experts
+    Stream --> LL --> Experts
+```
+
+### 每一层分别管什么
+
+- **Python 层（`deep_ep/buffer.py`, `deep_ep/utils.py`）**
+  - 暴露用户 API；
+  - 完成初始化；
+  - 发起 layout / dispatch / combine；
+  - 管理事件重叠。
+- **C++ 运行时层（`csrc/deep_ep.hpp`, `csrc/deep_ep.cpp`）**
+  - 持有通信 buffer；
+  - 同步 IPC 与 NVSHMEM 状态；
+  - 管理独立的 communication stream；
+  - 决定走哪条 CUDA kernel 路径。
+- **CUDA kernel 层（`csrc/kernels/*.cu*`）**
+  - 统计 token 该去哪里；
+  - 建前缀和与队列元数据；
+  - 在 NVLink / RDMA 上搬运载荷；
+  - 再把结果收拢回原始 token 语义。
+
+## 4. 初始化并不只是“分配显存”
+
+`Buffer(...)` 的构造过程，本质上是在把一个普通的 process group 变成一个“知道拓扑、知道 peer、知道 RDMA 状态”的专用通信运行时。
+
+```mermaid
+sequenceDiagram
+    participant Py as Python Buffer(...)
+    participant PG as Process group / MPI
+    participant CPP as C++ Buffer runtime
+    participant SHM as IPC / 本地共享显存
+    participant NS as NVSHMEM
+
+    Py->>CPP: 创建 runtime
+    Py->>PG: all_gather 本地 device id
+    Py->>PG: all_gather IPC handle
+    alt 启用 RDMA 或 low-latency
+        Py->>NS: 设置 IBGDA / QP 相关环境变量
+        Py->>PG: 交换 NVSHMEM unique id
+        CPP->>NS: 初始化 NVSHMEM
+        CPP->>NS: 分配对称 RDMA buffer
+    end
+    CPP->>SHM: 打开本节点 peer IPC handle
+    CPP-->>Py: runtime 就绪
+```
+
+这里最关键的几个动作是：
+
+- `check_nvlink_connections(...)` 会先否决不满足条件的节点内拓扑；
+- `Buffer.__init__` 会 gather device id、IPC handle、NVSHMEM unique id；
+- `Buffer::sync` 才是真正把 peer 映射、RDMA buffer、mask buffer 等全部接好。
+
+## 5. 把 DeepEP 分成“控制面”和“数据面”最容易看懂
+
+### 控制面：先决定“应该怎么发”
+
+控制面的核心产物包括：
+
+- `get_dispatch_layout(...)` 的返回值；
+- 前缀和矩阵；
+- source metadata；
+- handle。
+
+它回答的问题是：
+
+- 每个 rank 最后会收到多少 token？
+- 每个 expert 会收到多少 token？
+- 哪些 token 需要被发到哪个 rank？
+- 每个 sender 应该把数据写到队列的哪个位置？
+
+### 数据面：再决定“怎么把字节搬过去”
+
+这一层才是真正消耗 NVLink、RDMA、SM 资源的地方，包括：
+
+- intranode NVLink 队列；
+- internode RDMA chunk forwarding；
+- low-latency 的 send/recv phase；
+- combine 侧的 reduce。
+
+一句话：**控制面负责算路，数据面负责跑车。**
+
+## 6. 源码地图
+
+| 文件 | 作用 |
+| --- | --- |
+| `deep_ep/__init__.py` | Python 导入面：`Buffer`、`EventOverlap`、`Config`、`topk_idx_t` |
+| `deep_ep/buffer.py` | 最主要的用户 API 与模式分发逻辑 |
+| `deep_ep/utils.py` | 事件封装与 NVLink 拓扑检查 |
+| `csrc/deep_ep.hpp` | C++ 侧公开接口 |
+| `csrc/deep_ep.cpp` | pybind 绑定、buffer 生命周期、stream 协调 |
+| `csrc/config.hpp` | 核心常量，比如 `NUM_MAX_NVL_PEERS = 8` |
+| `csrc/kernels/configs.cuh` | Config 参数与 buffer 大小公式 |
+| `csrc/kernels/layout.cu` | dispatch layout 统计内核 |
+| `csrc/kernels/intranode.cu` | 节点内 NVLink dispatch / combine |
+| `csrc/kernels/internode.cu` | 普通内核下的跨节点 forwarding |
+| `csrc/kernels/internode_ll.cu` | 低延迟 decode 路径 |
+| `tests/*.py` | 用法、校验和调优范式 |
+
+## 7. 为什么 handle 是一等公民
+
+DeepEP 在 `dispatch(...)` 之后返回 handle，不是为了“显得高级”，而是因为回程 combine 真的离不开它。
+
+handle 里装的是回程所需的“证据链”：
+
+- 前缀和，
+- source index，
+- channel offset，
+- RDMA 元数据，
+- 某些场景下还有 global rank prefix sum。
+
+没有这份“快递底单”，你根本无法高效地把 expert 输出精确地拼回原始 token 顺序。
+
+## 8. 接下来该读哪一页
+
+- 想快速跑起来：看 [快速开始](quick-start.md)
+- 你的场景是训练 / prefill：看 [普通内核路径](normal-kernels.md)
+- 你的场景是 decoding 服务：看 [低延迟内核路径](low-latency.md)
+- 想把公式真正看透：看 [数学与直觉](math-theory.md)

--- a/docs/zh/low-latency.md
+++ b/docs/zh/low-latency.md
@@ -1,0 +1,188 @@
+# 低延迟内核路径：Decode 场景
+
+低延迟路径存在的唯一理由，就是一句话：**在线服务看的是微秒级尾延迟，而不是单纯总吞吐。**
+
+普通内核擅长把大量数据搬得很高效；但 decode 场景更常见的是：
+
+- batch 小；
+- latency budget 极紧；
+- 希望通信与计算重叠，但又不愿意额外吃掉太多 SM。
+
+这正是 `csrc/kernels/internode_ll.cu` 这套 low-latency kernel 被设计出来的背景。
+
+## 1. 什么时候该用这条路径
+
+当下面条件同时满足时，优先考虑 low-latency 模式：
+
+- 你在做 inference decoding；
+- 所有参与 rank 都能通过 RDMA 互通；
+- 你更在意单次请求延迟，而不是绝对吞吐；
+- 你能接受更大的持久化 RDMA buffer。
+
+## 2. 核心思想一图看懂
+
+```mermaid
+sequenceDiagram
+    participant B as 当前 micro-batch
+    participant GPU as 本地 GPU
+    participant NIC as RDMA 网络
+    participant H as recv hook
+
+    B->>GPU: low_latency_dispatch(..., return_recv_hook=True)
+    GPU->>NIC: 只发起 send / recv 请求
+    Note over GPU: 此时还没真正把 payload 收完
+    GPU->>GPU: 继续做别的计算
+    GPU->>H: hook()
+    H->>NIC: 真正收取已到达的数据
+    GPU->>GPU: 本地 expert GEMM
+    GPU->>GPU: low_latency_combine(...)
+```
+
+这套设计最厉害的地方在于，它可以把：
+
+- **网络请求的发起**，和
+- **payload 的真正收取与 materialize**
+
+拆成两个阶段。
+
+所以 API 才能返回一个 hook。
+
+## 3. 为什么 RDMA buffer 必须双缓冲
+
+`csrc/kernels/configs.cuh` 里的 `LowLatencyLayout` 明确把低延迟 buffer 设计成两套对称槽位。你可以把它想成 **奇偶两条跑道**。
+
+```mermaid
+flowchart TB
+    subgraph RDMA buffer
+        subgraph 槽位 0
+            S0[send buffer]
+            R0[recv buffer]
+            F0[signal / count buffer]
+        end
+        subgraph 槽位 1
+            S1[send buffer]
+            R1[recv buffer]
+            F1[signal / count buffer]
+        end
+    end
+
+    Slot0[当前使用槽位 0] <--> Slot1[下一次轮转到槽位 1]
+```
+
+这也就是为什么 Python 文档会提醒你：**同一时刻不要长期持有超过两个 low-latency 结果张量。** 因为底层 buffer 本来就是循环复用的。
+
+## 4. API 分解
+
+### `low_latency_dispatch(...)`
+
+输入：
+
+- BF16 hidden states；
+- `topk_idx`；
+- `num_max_dispatch_tokens_per_rank`；
+- `num_experts`。
+
+输出：
+
+- 打包后的接收张量；
+- 每个本地 expert 的接收计数；
+- combine 所需 handle；
+- 可选 event；
+- 可选 recv hook。
+
+这个 handle 里一般包含：
+
+- `src_info`
+- `layout_range`
+- `num_max_dispatch_tokens_per_rank`
+- `hidden`
+- `num_experts`
+
+足以让 combine 知道后续该如何把结果还原回去。
+
+### `low_latency_combine(...)`
+
+输入：
+
+- 本地 expert 输出；
+- 原始 `topk_idx`；
+- 原始 `topk_weights`；
+- dispatch 返回的 handle。
+
+关键选项包括：
+
+- `use_logfmt`：combine 路径启用内部压缩格式；
+- `zero_copy`：若下一次 combine buffer 已经就位，可跳过一次复制；
+- `out`：直接写入指定输出张量；
+- `return_recv_hook`：把网络发送与数据接收拆开。
+
+## 5. FP8、UE8M0 和 scale 到底是什么关系
+
+low-latency dispatch 可以把 BF16 激活按块 cast 成 FP8。
+
+于是返回值就可能不是一个 tensor，而是一对：
+
+- FP8 payload tensor；
+- scale tensor。
+
+DeepEP 的 scale 通常按每 128 个 hidden channel 存一次，这和 `tests/utils.py` 里的参考 cast / back-cast 逻辑是一致的。
+
+如果 `round_scale=True`，scale 会被量化成 2 的幂；如果 `use_ue8m0=True`，scale 的存储还会进一步压缩。
+
+## 6. hook 重叠为什么厉害
+
+这是 DeepEP 非常漂亮的一点设计。
+
+很多系统里说“通信和计算重叠”，本质上只是让 SM 在一边算一边还得分神维护通信进度。DeepEP 的低延迟路径则希望做到：**网络在后台飞，SM 尽量专心做计算。**
+
+你可以把它理解成：
+
+- `dispatch`：先把快递寄出去，拿到运单号；
+- 中间计算：趁快递还在路上，先干别的；
+- `hook()`：等真正到货时，再开门签收。
+
+## 7. 清理接口与 shrink 模式
+
+低延迟模式额外暴露了一组接口，是因为它更贴近真实在线服务环境。
+
+### `clean_low_latency_buffer(...)`
+
+当 low-latency buffer 有可能被污染时一定要清。尤其是你在普通路径和低延迟路径之间来回切时，部分协议区域默认假设自己是零初始化的。
+
+### mask buffer 相关接口
+
+- `low_latency_update_mask_buffer(...)`
+- `low_latency_query_mask_buffer(...)`
+- `low_latency_clean_mask_buffer()`
+
+这几组接口对应的是 `tests/test_low_latency.py` 里模拟 rank 故障与 shrink 的逻辑。
+
+直观地说：如果某个 rank 超时或挂了，协议可以先把它标成 masked，让剩余系统尽量继续向前跑。
+
+## 8. 为什么 low-latency 模式更吃内存
+
+因为它本质上是在用更多静态预留内存，换取更低的控制路径延迟。
+
+它要同时容纳：
+
+- send message 区；
+- recv message 区；
+- signaling 状态；
+- 双缓冲槽位。
+
+所以它不是“浪费”，而是“预付内存，换低时延”。
+
+## 9. 上低延迟模式前的实践检查表
+
+- 确认所有参与 rank 之间 RDMA 互通；
+- `num_qps_per_rank` 最好等于本地 expert 数；
+- `num_max_dispatch_tokens_per_rank` 要按真实 decode engine 的峰值来设，不要瞎放大；
+- 混用普通模式与低延迟模式时，要记得先清理 low-latency buffer；
+- 记住低延迟 buffer 是循环复用的，不适合长期囤很多结果张量。
+
+## 10. 想直接读源码，建议绑定这几处
+
+- `deep_ep/buffer.py`：公共 API 与返回张量形状；
+- `csrc/kernels/configs.cuh`：low-latency buffer layout；
+- `csrc/kernels/internode_ll.cu`：send/recv phase、masking、统计；
+- `tests/test_low_latency.py`：真实用法与故障模拟。

--- a/docs/zh/math-theory.md
+++ b/docs/zh/math-theory.md
@@ -1,0 +1,249 @@
+# 数学与直觉
+
+这一页的任务不是炫公式，而是把 DeepEP 里的那些“看起来像天书”的符号，翻译成你能一眼看懂的现实意义。
+
+## 1. 每个通信系统都必须先回答两个问题
+
+在 DeepEP 真正搬运任何一个字节之前，它必须先回答：
+
+1. **每个 token 到底要去哪里？**
+2. **每条路到底要预留多少 buffer？**
+
+你看到的大部分复杂代码，本质上都只是这两个问题的高性能实现。
+
+## 2. Dispatch layout 的本质：集合问题
+
+设：
+
+- `T`：token 数；
+- `K`：top-k 数；
+- `E`：expert 总数；
+- `R`：rank 总数；
+- `E_local = E / R`：每个 rank 持有的 expert 数。
+
+如果 token `t` 的第 `j` 个选择 expert 是 `e_{t, j}`，那么它所属的 rank 就是：
+
+$$
+\operatorname{rank}(e_{t,j}) = \left\lfloor \frac{e_{t,j}}{E_{local}} \right\rfloor.
+$$
+
+随后，DeepEP 会构造 token `t` 的目标 rank 集合：
+
+$$
+D_t = \{\operatorname{rank}(e_{t,j}) \mid e_{t,j} \neq -1\}.
+$$
+
+注意这个词是 **集合**。意思是：如果一个 token 选中了两个 expert，而这两个 expert 恰好都在同一个 rank 上，那么这个 rank 只算一次。
+
+接着定义指标量：
+
+$$
+I_{t,r} = \mathbf{1}[r \in D_t].
+$$
+
+那么 layout kernel 实际上在算：
+
+$$
+N_r = \sum_{t=0}^{T-1} I_{t,r}
+$$
+
+这就是发往 rank `r` 的 token 数。
+
+而每个 expert 被选中的次数则是：
+
+$$
+M_e = \sum_{t=0}^{T-1} \sum_{j=0}^{K-1} \mathbf{1}[e_{t,j} = e].
+$$
+
+### 菜市场级别类比
+
+想象有 4 个大妈去菜市场，4 个摊位分别卖不同菜。
+
+- 某位大妈可能想买番茄和土豆；
+- 如果这两样菜刚好都在同一个摊位卖，那她只走到这个摊位一次；
+- `I_{t,r}` 的意思就是：“第 `t` 位大妈需不需要去第 `r` 个摊位”；
+- `N_r` 的意思就是：“第 `r` 个摊位最后要接待多少位顾客”。
+
+layout kernel 干的就是这个事，只不过它在 GPU 上用极高并发算出来。
+
+## 3. 代入一个极简数字例子
+
+假设：
+
+- 8 个 expert；
+- 4 个 rank；
+- 每个 rank 2 个 expert；
+- top-k = 2。
+
+门控结果如下：
+
+| Token | 选中 expert | 目标 rank 集合 |
+| --- | --- | --- |
+| `t0` | `[1, 6]` | `{0, 3}` |
+| `t1` | `[0, 2]` | `{0, 1}` |
+| `t2` | `[3, 7]` | `{1, 3}` |
+| `t3` | `[4, -1]` | `{2}` |
+
+于是指标矩阵就是：
+
+| Token \ Rank | 0 | 1 | 2 | 3 |
+| --- | ---: | ---: | ---: | ---: |
+| `t0` | 1 | 0 | 0 | 1 |
+| `t1` | 1 | 1 | 0 | 0 |
+| `t2` | 0 | 1 | 0 | 1 |
+| `t3` | 0 | 0 | 1 | 0 |
+
+因此：
+
+$$
+(N_0, N_1, N_2, N_3) = (2, 2, 1, 2).
+$$
+
+这串数字，正是 `get_dispatch_layout(...)` 返回的核心内容之一。
+
+## 4. 前缀和根本没那么玄，它就是“排座位”
+
+计数告诉你：某辆车上有多少乘客。前缀和告诉你：**每个乘客应该坐哪一排**。
+
+如果一个目标 rank 从 4 个 sender 那里分别收到计数 `[1, 2, 0, 1]`，它的前缀和就是：
+
+$$
+(1, 3, 3, 4).
+$$
+
+含义就是：
+
+- sender 0 占区间 `[0, 1)`；
+- sender 1 占区间 `[1, 3)`；
+- sender 2 占区间 `[3, 3)`；
+- sender 3 占区间 `[3, 4)`。
+
+DeepEP 里的各种 prefix matrix，本质就是把这个“排座位”逻辑扩展到了 rank、channel、RDMA 多层级上。
+
+```mermaid
+flowchart LR
+    Count[各 sender 计数] --> Prefix[前缀和]
+    Prefix --> Slots[确定 buffer 写入区间]
+    Slots --> Transport[读写双方无冲突对齐]
+```
+
+## 5. Combine 的数学本质：带权归并
+
+设 `h_{t,j}` 表示 token `t` 在第 `j` 个 expert 上计算出的结果，`w_{t,j}` 表示对应门控权重。
+
+那么理想的 combine 输出就是：
+
+$$
+y_t = \sum_{j=0}^{K-1} w_{t,j} h_{t,j}.
+$$
+
+如果还传入了 bias `b_t^{(0)}` 和 `b_t^{(1)}`，最终输出就变成：
+
+$$
+\hat{y}_t = y_t + b_t^{(0)} + b_t^{(1)}.
+$$
+
+所以 combine 不是“把东西搬回来”这么简单，它实际上同时完成了：
+
+- 恢复原 token 语义；
+- 对多个 expert 输出做 reduce；
+- 视情况再叠加 bias。
+
+## 6. FP8 scale 用最接地气的话解释
+
+DeepEP 常按 128 个 hidden channel 为一组处理数据。
+
+对某一组，先定义：
+
+$$
+\alpha = \max_i |x_i|.
+$$
+
+然后 scale 近似设成：
+
+$$
+s = \frac{\alpha}{448}.
+$$
+
+再把数值量化成近似的 FP8 表示：
+
+$$
+q_i \approx \frac{x_i}{s}, \qquad x_i \approx q_i s.
+$$
+
+### 一组小学算术级例子
+
+假设某个 128 通道块的最大绝对值是 `4.48`，那么：
+
+$$
+s = \frac{4.48}{448} = 0.01.
+$$
+
+于是：
+
+- `1.12` 约等于 `112 × 0.01`；
+- `-2.24` 约等于 `-224 × 0.01`；
+- `4.48` 约等于 `448 × 0.01`。
+
+这就是为什么 low-latency API 往往返回两个 tensor：
+
+- 一个是 FP8 payload；
+- 一个是每 128 通道对应的 scale。
+
+## 7. 为什么 low-latency buffer 会涨得这么快
+
+`csrc/kernels/configs.cuh` 里的公式如果直接看，会让人头疼；但拆成“payload + metadata”两部分就不神秘了。
+
+对于普通内核，NVLink buffer 粗略可以写成：
+
+$$
+B_{NVL} \approx C \cdot R_{NVL} \cdot (\text{metadata} + T_{recv} \cdot \text{hidden bytes} + T_{recv} \cdot \text{auxiliary fields}),
+$$
+
+其中 `C = num_sms / 2`，代表 channel 数。
+
+对于 low-latency mode，一条 dispatch message 大致大小是：
+
+$$
+\text{bytes}_{dispatch} = 16 + \max(2H, H + 4H/128),
+$$
+
+这里：
+
+- `16` 是 `int4` 控制头；
+- `2H` 是 BF16 载荷；
+- `H + 4H/128` 是 FP8 载荷加 scale。
+
+而 combine message 大小大致是：
+
+$$
+\text{bytes}_{combine} = 2H + 4H/128.
+$$
+
+### 用 `H = 7168` 代进去
+
+- `num_scales = 7168 / 128 = 56`
+- BF16 payload = `2H = 14336` bytes
+- FP8 payload + scales = `7168 + 56 * 4 = 7392` bytes
+- dispatch message = `16 + max(14336, 7392) = 14352` bytes
+- combine message = `14336 + 224 = 14560` bytes
+
+这就是 README 为什么会提醒 low-latency 模式很吃内存：它本来就是按“艰难情况”静态预留的。
+
+## 8. SourceMeta 位域其实没那么可怕
+
+`csrc/kernels/internode.cu` 里的 `SourceMeta` 会存两类信息：
+
+- 源 RDMA rank；
+- 一个 8 bit 掩码，表示源节点内哪些 NVLink peer 跟这个 token 有关。
+
+比如 bit mask 是 `10110010`，意思就是那几个对应位上的本地 NVLink 位置被选中了。它不是玄学，只是“谁关心这个 token”被压缩存成了位图。
+
+## 9. 最后只记两条直觉就够了
+
+如果你看完这一页只想记住两句话，那就记住：
+
+1. **layout 本质上是集合 + 前缀和问题。**
+2. **通信本质上是把 payload 按真实硬件拓扑填进队列。**
+
+一旦接受这两个直觉，DeepEP 里大部分公式与 buffer 结构都会突然变得顺眼很多。

--- a/docs/zh/normal-kernels.md
+++ b/docs/zh/normal-kernels.md
@@ -1,0 +1,229 @@
+# 普通内核路径：训练与 Prefill
+
+DeepEP 把偏吞吐导向的通信路径称为 **普通内核（normal kernels）**。它是下面这些场景的首选：
+
+- 训练；
+- 仅前向的 prefilling；
+- 一切“总体带宽比单次延迟更重要”的工作负载。
+
+## 1. 一眼看懂主流程
+
+```mermaid
+sequenceDiagram
+    participant U as 用户计算流
+    participant C as 通信流
+    participant L as Layout kernel
+    participant N as Notify kernel
+    participant D as Dispatch kernels
+    participant G as 本地专家 GEMM
+    participant B as Combine kernels
+
+    U->>C: optional previous_event
+    C->>L: get_dispatch_layout(topk_idx, num_experts)
+    C->>N: 统计 count / 生成 prefix sum
+    C->>D: 分发 payload 与 metadata
+    C-->>U: 返回 handle + optional EventOverlap
+    U->>G: 对收到的 expert batch 做计算
+    U->>C: combine(expert_outputs, handle)
+    C->>B: 把结果 reduce 回原始 token
+    C-->>U: 输出 combined tensor
+```
+
+`get_dispatch_layout(...)`、`dispatch(...)`、`combine(...)` 被拆成三步，不是 API 设计上的矫情，而是因为底层工作天然就分成这三段：
+
+1. 先数清楚去哪儿；
+2. 再把 payload 真正送过去；
+3. 最后把结果按原语义收回来。
+
+## 2. 为什么 layout 必须单独做
+
+门控给的是 **expert id**，而通信真正关心的是 **rank** 和 **计数**。
+
+所以对每个 token，DeepEP 要先回答：
+
+- 它最终要去哪些 rank？
+- 每个 rank 会收到多少 token？
+- 每个 expert 会收到多少 token？
+
+`csrc/kernels/layout.cu` 的 layout kernel 就是在做这件事，最后给出：
+
+- `num_tokens_per_rank`
+- `num_tokens_per_rdma_rank`（仅 internode）
+- `num_tokens_per_expert`
+- `is_token_in_rank`
+
+### 最容易忽略的一点
+
+`is_token_in_rank[t, r]` 是一个 **布尔值**，不是次数。
+
+也就是说，如果一个 token 命中了两个 expert，而这两个 expert 恰好都在同一个 rank 上，那么这个 token 对这个 rank 只会发送 **一次**。
+
+这就是 layout 阶段真正节省带宽的地方：它先把“同 rank 重复命中”折叠掉了。
+
+## 3. 用一个极简数字例子彻底说透
+
+假设：
+
+- 总共有 8 个 expert；
+- 总共有 4 个 rank；
+- 每个 rank 持有 2 个 expert。
+
+于是 expert 到 rank 的归属关系是：
+
+- rank 0: experts 0, 1
+- rank 1: experts 2, 3
+- rank 2: experts 4, 5
+- rank 3: experts 6, 7
+
+现在门控输出是：
+
+| Token | 选中的 expert | 目标 rank | `is_token_in_rank` |
+| --- | --- | --- | --- |
+| `t0` | `[1, 6]` | `[0, 3]` | `[1, 0, 0, 1]` |
+| `t1` | `[0, 2]` | `[0, 1]` | `[1, 1, 0, 0]` |
+| `t2` | `[3, 7]` | `[1, 3]` | `[0, 1, 0, 1]` |
+| `t3` | `[4, -1]` | `[2]` | `[0, 0, 1, 0]` |
+
+那么：
+
+- `num_tokens_per_rank = [2, 2, 1, 2]`
+- `num_tokens_per_expert` 则按具体 expert id 逐个统计。
+
+这就是 dispatch 真正需要的“发货计划单”。
+
+## 4. `dispatch(...)` 内部真正发生了什么
+
+Python 层会根据当前 runtime 自动分发到两条路径：
+
+- **intranode dispatch**：所有通信都在 NVLink 域内；
+- **internode dispatch**：涉及跨节点 RDMA forwarding。
+
+### intranode 路径
+
+`csrc/kernels/intranode.cu` 里维护的是一套节点内队列系统，核心元素包括：
+
+- per-rank 的共享队列；
+- peer barrier；
+- per-channel prefix sum；
+- sender / receiver 的职责拆分。
+
+最形象的理解方式是：**每个 channel 像一节火车车厢**。
+
+- layout 阶段先决定每个目的地要几个座位；
+- prefix sum 决定每个 sender 在车厢中的座位区间；
+- sender 按区间把 token 写进去；
+- receiver 再按连续区间把它们读出来。
+
+### internode 路径
+
+`csrc/kernels/internode.cu` 又多加了一层：
+
+- 先在本节点 NVLink 域内归整；
+- 再在匹配 GPU index 的 rank 之间走 RDMA；
+- 到对端节点后再在 NVLink 域内扇出。
+
+所以 README 才会把它描述成 **从 NVLink 域 forwarding 到 RDMA 域**。
+
+```mermaid
+flowchart LR
+    subgraph 节点 A
+        A0[NVLink 域]
+    end
+    subgraph RDMA 网络
+        R[RDMA forwarding]
+    end
+    subgraph 节点 B
+        B0[NVLink 域]
+    end
+
+    A0 --> R --> B0
+```
+
+## 5. handle 里面到底装了什么
+
+普通内核返回的 handle，本质上是后续 combine 所需的“返程地图”。
+
+### intranode handle
+
+常见字段包括：
+
+- `rank_prefix_matrix`
+- `channel_prefix_matrix`
+- `recv_channel_prefix_matrix`
+- `recv_src_idx`
+- `is_token_in_rank`
+- `send_head`
+
+可以粗暴理解成：
+
+- **prefix matrix** 告诉 sender 写哪儿、receiver 读哪儿；
+- **source index** 记录 token 原始来源；
+- **send head** 维护队列推进状态。
+
+### internode handle
+
+internode handle 会更复杂，还会带上：
+
+- RDMA channel prefix matrix；
+- global rank prefix sum；
+- source metadata；
+- RDMA / NVLink send head。
+
+原因很简单：跨节点后，系统必须记住“跨节点这一跳”和“节点内再分发这一跳”的信息。
+
+## 6. `combine(...)` 为什么不只是 dispatch 的反向操作
+
+从图上看像反向，但在代数意义上它是 **归并 / reduce**。
+
+- `dispatch(...)` 是把一个 token 发到所有相关 rank；
+- `combine(...)` 是把这些专家输出再收回来，并按原 token 语义做 reduce。
+
+如果传入了 `topk_weights`，那就是带权归并；如果传入了 `bias`，则会在 reduce 之后再加 bias。
+
+这就是为什么 README 的示例里会说：
+
+- dispatch 的 backward 本质上是 combine；
+- combine 的 backward 本质上是 dispatch。
+
+通信图是对称的，但载荷上的代数操作不是简单拷贝。
+
+## 7. 异步与重叠
+
+普通路径支持两种很实用的重叠方式。
+
+### `previous_event`
+
+如果你想让这次通信先等某段前序计算结束，就把 `EventOverlap` 传进来。
+
+### `async_finish=True`
+
+让通信先在 comm stream 上飞起来，调用先返回，真正需要结果时再等待。
+
+这在专家 GEMM 与通信重叠时非常有用。
+
+## 8. 为什么会出现 CPU 等待
+
+普通 dispatch 的精确路径里，当前 rank 一开始可能不知道最终会收到多少 token，所以 runtime 需要等一个来自 GPU 的“收到计数信号”。
+
+也正因为这个 CPU wait，README 才会提醒：在一般精确路径下，它并不天然适配 CUDA graph。
+
+### `num_worst_tokens` 是什么补救手段
+
+如果你愿意提前按最坏情况留足接收空间，就可以传 `num_worst_tokens`（仅 intranode）。
+
+这样做的代价交换很清晰：
+
+- **精确计数**：省内存，但可能有 CPU wait；
+- **最坏预留**：更吃内存，但更适合 graph 化流程。
+
+## 9. 想对着源码读，重点看哪几处
+
+- `deep_ep/buffer.py`：公共 API 与 handle 结构；
+- `csrc/deep_ep.cpp`：stream 协调与参数检查；
+- `csrc/kernels/layout.cu`：layout 统计；
+- `csrc/kernels/intranode.cu`：本地 NVLink 队列；
+- `csrc/kernels/internode.cu`：跨节点 forwarding。
+
+## 10. 下一页建议
+
+如果你看完还是觉得 prefix sum、计数和 buffer 公式很抽象，直接去看 [数学与直觉](math-theory.md)。那一页就是专门把这些“天书”打回人话的。

--- a/docs/zh/performance-tuning.md
+++ b/docs/zh/performance-tuning.md
@@ -1,0 +1,152 @@
+# 性能与调优
+
+这一页讲的不是“能不能跑”，而是“怎样把 DeepEP 调到真正贴合你的拓扑与工作负载”。
+
+## 1. 第一步永远是选对 kernel 家族
+
+```mermaid
+flowchart TD
+    S[工作负载类型] -->|训练 / prefilling| N[普通内核]
+    S -->|decode 在线服务| L[低延迟内核]
+    N -->|单节点且 NVLink 可见| INTRA[Intranode 路径]
+    N -->|多节点且有 RDMA| INTER[Internode forwarding 路径]
+    L --> HOOK[可选 hook 重叠]
+```
+
+最常见的调优误区，就是拿吞吐型 kernel 去解决延迟问题，或者反过来。
+
+## 2. 先接受它的硬拓扑假设
+
+DeepEP 之所以快，很大程度上是因为它做了强假设。
+
+| 假设 | 重要原因 |
+| --- | --- |
+| `NUM_MAX_NVL_PEERS = 8` | 代码整体围绕 8 卡 NVLink 域展开 |
+| 节点内 GPU 之间 NVLink 可见 | 普通 intranode kernel 的前提 |
+| 节点间有 RDMA | 普通 internode 与 low-latency 的前提 |
+| 装了 NVSHMEM | 所有 RDMA 能力的基础 |
+| 普通内核 `num_sms` 必须是偶数 | 因为 `num_channels = num_sms / 2` |
+| low-latency 下 `num_qps_per_rank` 最好等于本地 expert 数 | decode 路径最优配置 |
+
+## 3. 真正影响性能的公开调参项
+
+### 运行时参数
+
+| 参数 | 暴露位置 | 作用 |
+| --- | --- | --- |
+| `Buffer.set_num_sms(...)` | Python API | 控制普通内核可占用多少 SM |
+| `Buffer.get_dispatch_config(...)` | Python API | 普通 dispatch 推荐 chunk 配置 |
+| `Buffer.get_combine_config(...)` | Python API | 普通 combine 推荐 chunk 配置 |
+| `num_qps_per_rank` | `Buffer(...)` 构造参数 | 控制 low-latency 模式下 RDMA 并行度 |
+| `allow_nvlink_for_low_latency_mode` | `Buffer(...)` 构造参数 | 是否允许 low-latency 使用 NVLink 辅助 |
+| `enable_shrink` | `Buffer(...)` 构造参数 | 启用动态 masking / shrink 模式 |
+
+### 构建与部署参数
+
+| 参数 | 作用 |
+| --- | --- |
+| `NVSHMEM_DIR` | 打开 NVSHMEM 相关能力 |
+| `TORCH_CUDA_ARCH_LIST` | 指定目标 GPU 架构 |
+| `DISABLE_SM90_FEATURES` | 禁用 Hopper 特性 |
+| `DISABLE_AGGRESSIVE_PTX_INSTRS` | 在兼容性优先时禁用激进 PTX 技巧 |
+| `NVSHMEM_IB_SL` | 选择 InfiniBand 虚拟 lane |
+
+## 4. 仓库里的测试本身就是调优框架
+
+别把 `tests/` 只当成 correctness check。它们本身就是调优 harness。
+
+- `tests/test_intranode.py` 会扫 SM 数与 NVLink chunk size；
+- `tests/test_internode.py` 会联合扫 NVLink / RDMA chunk size；
+- `tests/test_low_latency.py` 会测 dispatch / combine 的时延与 hook 拆分；
+- `tests/utils.py` 里有 `bench(...)` 与 `bench_kineto(...)` 工具。
+
+因此最靠谱的调优顺序是：
+
+1. 先把拓扑与构建配对正确；
+2. 运行对应路径的测试脚本；
+3. 把集群上测出来的最佳 chunk 配置记录下来；
+4. 再把这些 config 写回你的框架集成层。
+
+## 5. README 里给出的网络建议非常实战
+
+### 流量隔离
+
+建议把：
+
+- 普通内核流量；
+- 低延迟流量；
+- 其他业务流量
+
+分到不同的 InfiniBand virtual lane 上。
+
+DeepEP 侧对应的环境变量是 `NVSHMEM_IB_SL`。
+
+### 自适应路由
+
+README 的建议很朴素：
+
+- 网络负载重时开 adaptive routing；
+- 网络负载轻时走 static routing。
+
+原因很简单：
+
+- adaptive routing 更抗拥塞；
+- static routing 往往更低附加时延。
+
+### 拥塞控制
+
+仓库 README 里提到作者们在生产环境里没有明显观察到收益，所以默认不开 congestion control。
+
+## 6. 把这些调参项翻译成物理意义
+
+很多人调参时容易陷入“API 名字看不懂”的状态。其实把它翻译成硬件语言就好了：
+
+- `num_sms`：你愿意拿多少计算核心去做通信；
+- chunk size：每个 channel 一次搬多大一块数据；
+- `num_qps_per_rank`：每个 rank 在 NIC 上开多少扇并行通道；
+- `num_max_dispatch_tokens_per_rank`：decode 峰值时 buffer 必须兜住的最大 token 数。
+
+一旦这样理解，参数就不再是抽象数字，而是清楚的资源分配策略。
+
+## 7. 常见症状与高概率原因
+
+| 现象 | 常见原因 |
+| --- | --- |
+| intranode 路径报错或表现异常 | 本地 GPU 之间并非全量 NVLink 可见 |
+| low-latency 能跑但显存 / buffer 特别大 | `num_max_dispatch_tokens_per_rank` 设得太保守 |
+| hook 重叠收益不明显 | 你的计算阶段与 hook 拆分点不匹配，或 NVLink 辅助与重叠假设冲突 |
+| internode 吞吐上不去 | RDMA chunk size、service level、路由策略没有贴合集群 |
+| 某些平台上结果异常 | 先关掉 aggressive PTX，再测兼容性 |
+
+## 8. 一定要认真看待“Undefined PTX”那段说明
+
+DeepEP README 明说了：项目为了极限性能，用过比较激进的 PTX 读写技巧，比如非一致缓存相关的 load 形式。
+
+这带来的现实结论是：
+
+- 某些平台上速度会非常好；
+- 但跨平台兼容性压力会变大；
+- 如果你怀疑平台不稳，就优先把 `DISABLE_AGGRESSIVE_PTX_INSTRS=1` 打开。
+
+这是典型 HPC 风格的取舍：速度和可移植性，很多时候不能两全。
+
+## 9. 一套务实的调优顺序
+
+如果你在一套新集群上调 DeepEP，建议按下面顺序来：
+
+1. 先确认 GPU 架构与编译 flag；
+2. 再确认本地 NVLink 拓扑；
+3. 再确认全局 RDMA 与 NVSHMEM；
+4. 一次只调一条路径，不要普通和低延迟一起乱调；
+5. 优先扫 chunk size，而不是急着改代码；
+6. 等通信路径健康后，再考虑和专家 GEMM 的重叠细节。
+
+这个顺序能帮你避免大量无效 debug。
+
+## 10. 最后一句压轴经验
+
+DeepEP 的性能，本质上来自“让软件路径服从物理拓扑”。
+
+如果只记住一句话，那就是：
+
+> **把 NVLink、RDMA、SM 预算当成三种不同资源，然后让 DeepEP 在最擅长的地方消耗它们。**

--- a/docs/zh/quick-start.md
+++ b/docs/zh/quick-start.md
@@ -1,0 +1,195 @@
+# 快速开始
+
+这一页的目标很纯粹：用最短路径把你从“刚 clone 下来 DeepEP”带到“我已经明白 API 主骨架，知道真实集群里要配什么”。
+
+## 1. 先过一遍硬件与软件门槛
+
+结合仓库 `README.md` 与 `setup.py`，实际要求如下：
+
+- Ampere（SM80）或 Hopper（SM90）级别 GPU；
+- Python 3.8+；
+- PyTorch 2.1+；
+- SM80 至少 CUDA 11；SM90 建议 CUDA 12.3+；
+- 节点内普通内核依赖 NVLink；
+- 跨节点路径依赖 RDMA；
+- 所有基于 RDMA 的特性还依赖 NVSHMEM。
+
+如果你只想用单节点 NVLink 普通内核，理论上可以不装 NVSHMEM；但 internode 与 low-latency 功能都会被关闭。
+
+## 2. 构建与安装
+
+### 开发构建
+
+```bash
+NVSHMEM_DIR=/path/to/installed/nvshmem python setup.py build
+ln -s build/lib.linux-x86_64-cpython-38/deep_ep_cpp.cpython-38-x86_64-linux-gnu.so
+```
+
+### 安装到环境中
+
+```bash
+NVSHMEM_DIR=/path/to/installed/nvshmem python setup.py install
+```
+
+### 关键环境变量
+
+| 变量 | 含义 | 对应位置 |
+| --- | --- | --- |
+| `NVSHMEM_DIR` | NVSHMEM 安装目录 | `setup.py`、运行时初始化 |
+| `DISABLE_SM90_FEATURES` | 禁用 Hopper 特性 | `setup.py`、`csrc/config.hpp` |
+| `TORCH_CUDA_ARCH_LIST` | 目标架构列表，如 `9.0` | `setup.py` |
+| `DISABLE_AGGRESSIVE_PTX_INSTRS` | 关闭激进 PTX 指令技巧 | `setup.py`、底层 kernel |
+| `TOPK_IDX_BITS` | 选择 32 位或 64 位 expert index | `setup.py`、`csrc/config.hpp` |
+| `NVSHMEM_IB_SL` | InfiniBand 虚拟 lane / service level | 集群部署时使用 |
+
+## 3. 执行骨架
+
+```mermaid
+flowchart LR
+    A[初始化分布式组] --> B[选择普通模式或低延迟模式]
+    B --> C[根据 size hint 分配 buffer]
+    C --> D[准备 top-k 路由张量]
+    D --> E[Dispatch]
+    E --> F[本地专家计算]
+    F --> G[Combine]
+```
+
+如果你能把这张图吃透，DeepEP 的 API 主线就已经明白大半了。
+
+## 4. 普通内核的最小调用骨架
+
+```python
+import torch
+import torch.distributed as dist
+from deep_ep import Buffer
+
+Buffer.set_num_sms(24)  # 普通内核要求偶数
+
+group = dist.group.WORLD
+hidden_bytes = hidden * 2  # BF16 每元素 2 字节
+
+dispatch_cfg = Buffer.get_dispatch_config(group.size())
+combine_cfg = Buffer.get_combine_config(group.size())
+num_nvl_bytes = max(
+    dispatch_cfg.get_nvl_buffer_size_hint(hidden_bytes, group.size()),
+    combine_cfg.get_nvl_buffer_size_hint(hidden_bytes, group.size()),
+)
+num_rdma_bytes = max(
+    dispatch_cfg.get_rdma_buffer_size_hint(hidden_bytes, group.size()),
+    combine_cfg.get_rdma_buffer_size_hint(hidden_bytes, group.size()),
+)
+
+buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes)
+num_tokens_per_rank, num_tokens_per_rdma_rank, num_tokens_per_expert, is_token_in_rank, layout_event = \
+    buffer.get_dispatch_layout(topk_idx, num_experts)
+
+recv_x, recv_topk_idx, recv_topk_weights, local_expert_counts, handle, event = buffer.dispatch(
+    x,
+    topk_idx=topk_idx,
+    topk_weights=topk_weights,
+    num_tokens_per_rank=num_tokens_per_rank,
+    num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+    is_token_in_rank=is_token_in_rank,
+    num_tokens_per_expert=num_tokens_per_expert,
+)
+
+# ... 本地专家 GEMM ...
+
+combined_x, combined_topk_weights, event = buffer.combine(
+    expert_outputs,
+    handle,
+    topk_weights=recv_topk_weights,
+)
+```
+
+### 用最朴素的话理解这些参数
+
+- `topk_idx`：每个 token 想去哪些 expert。
+- `get_dispatch_layout(...)`：把这个愿望单翻译成“发货计划单”。
+- `dispatch(...)`：按计划把 token 发出去。
+- `handle`：回程 combine 的“底单”，没有它就很难精确拼回去。
+
+## 5. 低延迟模式的最小骨架
+
+```python
+from deep_ep import Buffer
+
+num_rdma_bytes = Buffer.get_low_latency_rdma_size_hint(
+    num_max_dispatch_tokens_per_rank,
+    hidden,
+    group.size(),
+    num_experts,
+)
+
+buffer = Buffer(
+    group,
+    0,
+    num_rdma_bytes,
+    low_latency_mode=True,
+    num_qps_per_rank=num_experts // group.size(),
+)
+
+recv_x, recv_count, handle, event, hook = buffer.low_latency_dispatch(
+    hidden_states,
+    topk_idx,
+    num_max_dispatch_tokens_per_rank,
+    num_experts,
+    return_recv_hook=True,
+)
+
+hook()  # 真正收 payload
+
+combined_x, event, hook = buffer.low_latency_combine(
+    expert_outputs,
+    topk_idx,
+    topk_weights,
+    handle,
+    return_recv_hook=True,
+)
+
+hook()
+```
+
+低延迟模式和普通模式的根本差异在于：
+
+- 它吃更多的 RDMA buffer；
+- 它优先优化 decode 延迟，而不是吞吐；
+- 它可以把“发起网络请求”和“真正收取数据”拆开。
+
+## 6. `EventOverlap` 到底是做什么的
+
+`EventOverlap` 本质上就是一个更顺手的 CUDA event 封装，用来让计算流和通信流建立依赖，而不是全设备同步。
+
+最常见的用法是：
+
+- `previous_event` 告诉 DeepEP：通信开始前要先等一段计算；
+- `async_finish=True` 让通信先在 comm stream 上飞，调用先返回；
+- `current_stream_wait()` 则让你在真正需要结果时再等。
+
+## 7. 集群排障最先看什么
+
+在怪 DeepEP 之前，先查下面这几项：
+
+- 本机 GPU 之间真的全是 NVLink 可见吗？
+- 编译时目标架构是不是配对了当前 GPU？
+- NVSHMEM 是否已正确安装与可见？
+- process group 的 world size / rank 是否正确？
+- 低延迟模式下，`num_qps_per_rank` 是否等于本地 expert 数？
+
+`deep_ep/utils.py` 里的 `check_nvlink_connections(...)` 就是专门用来挡掉那些“看起来像多卡，实际上拓扑不满足”的情况。
+
+## 8. 仓库里已有的测试入口
+
+```bash
+python tests/test_intranode.py
+python tests/test_internode.py
+python tests/test_low_latency.py
+```
+
+另外要注意 `tests/utils.py` 里的 `init_dist(...)` 很简化，作者也明说了：在你的真实集群里，通常要按自己的 launcher / 环境变量体系改写。
+
+## 9. 下一步怎么读
+
+- 想看系统全貌：去 [架构总览](architecture.md)
+- 想看训练 / prefill：去 [普通内核路径](normal-kernels.md)
+- 想看 decoding：去 [低延迟内核路径](low-latency.md)


### PR DESCRIPTION
## Summary
- add a source-driven DeepEP documentation tree under docs/ with both English and Chinese versions
- cover architecture, quick start, normal kernels, low-latency kernels, math intuition, and performance tuning
- link the repository README to the new bilingual documentation index

## Validation
- [x] bash ./format.sh
- [ ] python tests/test_intranode.py (requires an NVLink-capable multi-GPU machine)
- [ ] python tests/test_internode.py (requires an NVLink + RDMA + NVSHMEM multi-node cluster)
- [ ] python tests/test_low_latency.py (requires RDMA + NVSHMEM and the intended serving topology)

## Notes
- The repository does not include a separate CONTRIBUTING.md or PR template, so this change follows the existing README guidance and the format workflow in .github/workflows/format.yml.
- The runtime tests are hardware-gated and cannot be honestly exercised in a generic environment without the required topology.
