### PR TITLE
fix(hybrid-ep): replace deprecated pynvml dependency with nvidia-ml-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
             include=['deep_ep']
         ),
         install_requires=[
-            'pynvml',
+            'nvidia-ml-py>=12.0.0',
         ],
         ext_modules=[
             get_extension_deep_ep_cpp(),


### PR DESCRIPTION
This PR replaces the deprecated `pynvml` package with `nvidia-ml-py>=12.0.0` in `setup.py`.

`pynvml` is now deprecated and can trigger a `FutureWarning` in downstream environments when `torch.cuda` is imported. Since `nvidia-ml-py` provides the official NVIDIA-maintained NVML bindings and preserves the `pynvml` module import path, switching the dependency resolves the warning without changing runtime behavior.

The `>=12.0.0` lower bound matches the compatibility floor already implied by the deprecated `pynvml` package itself.

- https://github.com/gpuopenanalytics/pynvml/blob/493a974f22ca8c8b30ee0755ae058365cd7ab76c/pyproject.toml#L15-L17