### PR TITLE
fix build error without GPU for doca/NCCL

### DIFF
--- a/csrc/hybrid_ep/buffer/internode_doca.cu
+++ b/csrc/hybrid_ep/buffer/internode_doca.cu
@@ -2,9 +2,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 // All rights reserved
 #include "buffer/internode_doca.cuh"
+#include <torch/extension.h>
+#include <pybind11/pybind11.h>
 #include <sstream>
 #include <cstdlib>
 #include <unordered_map>
+
+namespace py = pybind11;
 
 // Functions realted to get RDMA context.
 ibv_device *ctx_find_dev(const char *ib_devname) {

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,11 @@ def get_extension_hybrid_ep_cpp():
                 os.path.join(DOCA_OBJ_PATH, "doca_gpunetio_log.o"),
             ]
 
+    linrary_path_env=os.getenv('LIBRARY_PATH', None)
+    if "stubs" in linrary_path_env:
+        for i in range(len(extra_link_args)):
+            if "libnvidia-ml.so.1" in extra_link_args[i]:
+                extra_link_args[i] = "-lnvidia-ml" # link to $CUDA_HOME/lib64/stubs/libnvidia-ml.so
 
     print(f'Build summary:')
     print(f' > Sources: {sources}')


### PR DESCRIPTION
## fix build error

build command:

```
rm -rf .use_nixl
HYBRID_EP_MULTINODE=1 LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH TORCH_CUDA_ARCH_LIST='10.0' python setup.py bdist_wheel
```

error log:

```
FAILED: /root/hybrid-ep-open-source/build/temp.linux-x86_64-cpython-312/csrc/hybrid_ep/buffer/internode_doca.o
/usr/local/cuda/bin/nvcc --generate-dependencies-with-compile --dependency-output /root/hybrid-ep-open-source/build/temp.linux-x86_64-cpython-312/csrc/hybrid_ep/buffer/internode_doca.o.d -I/root/hybrid-ep-open-source/csrc/hybrid_ep/ -I/root/hybrid-ep-open-source/csrc/hybrid_ep/backend/ -I/root/hybrid-ep-open-source/third-party/nccl/src/transport/net_ib/gdaki/doca-gpunetio/include -Iinclude -I/usr/local/lib/python3.12/dist-packages/torch/include -I/usr/local/lib/python3.12/dist-packages/torch/include/torch/csrc/api/include -I/usr/local/cuda/include -I/usr/include/python3.12 -c -c /root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu -o /root/hybrid-ep-open-source/build/temp.linux-x86_64-cpython-312/csrc/hybrid_ep/buffer/internode_doca.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options ''"'"'-fPIC'"'"'' -std=c++17 -Xcompiler -fPIC --expt-relaxed-constexpr -O3 --shared '-DSM_ARCH="10.0"' -DHYBRID_EP_BUILD_MULTINODE_ENABLE '-DRDMA_CORE_HOME=""' -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=hybrid_ep_cpp -gencode=arch=compute_100,code=sm_100
In file included from /root/hybrid-ep-open-source/third-party/nccl/src/transport/net_ib/gdaki/doca-gpunetio/include/doca_gpunetio_device.h:41,
                 from /root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cuh:8,
                 from /root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu:4:
/root/hybrid-ep-open-source/third-party/nccl/src/transport/net_ib/gdaki/doca-gpunetio/include/device/doca_gpunetio_dev_verbs_common.cuh:58:2: warning: #warning "warning: doca_gpunetio should be used with a CUDA version >= 12020." [-Wcpp]
   58 | #warning "warning: doca_gpunetio should be used with a CUDA version >= 12020."
      |  ^~~~~~~
In file included from /root/hybrid-ep-open-source/third-party/nccl/src/transport/net_ib/gdaki/doca-gpunetio/include/doca_gpunetio_device.h:41,
                 from /root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cuh:8,
                 from /root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu:4:
/root/hybrid-ep-open-source/third-party/nccl/src/transport/net_ib/gdaki/doca-gpunetio/include/device/doca_gpunetio_dev_verbs_common.cuh:58:2: warning: #warning "warning: doca_gpunetio should be used with a CUDA version >= 12020." [-Wcpp]
   58 | #warning "warning: doca_gpunetio should be used with a CUDA version >= 12020."
      |  ^~~~~~~
/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(796): error: name followed by "::" must be a class or namespace name
    torch::Tensor buffer = torch::empty({num_bytes}, at::device(at::kCPU).dtype(at::kByte));
    ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(796): error: expected a ";"
    torch::Tensor buffer = torch::empty({num_bytes}, at::device(at::kCPU).dtype(at::kByte));
                  ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(797): error: identifier "buffer" is undefined
    memcpy(buffer.data_ptr<uint8_t>(), reinterpret_cast<void *>(src), num_of_qps * sizeof(remote_info));
           ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(797): error: type name is not allowed
    memcpy(buffer.data_ptr<uint8_t>(), reinterpret_cast<void *>(src), num_of_qps * sizeof(remote_info));
                           ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(797): error: expected an expression
    memcpy(buffer.data_ptr<uint8_t>(), reinterpret_cast<void *>(src), num_of_qps * sizeof(remote_info));
                                    ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(805): error: name followed by "::" must be a class or namespace name
      output_list.append(torch::empty_like(buffer));
                         ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(812): error: name followed by "::" must be a class or namespace name
      auto tensor = output_list[i].cast<torch::Tensor>().cpu();
                                        ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(813): error: type name is not allowed
      memcpy(dst + num_of_qps * (i / buffer_config.num_of_ranks_per_node), tensor.data_ptr<uint8_t>(), num_of_qps * sizeof(remote_info));
                                                                                           ^

/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu(813): error: expected an expression
      memcpy(dst + num_of_qps * (i / buffer_config.num_of_ranks_per_node), tensor.data_ptr<uint8_t>(), num_of_qps * sizeof(remote_info));
                                                                                                    ^

9 errors detected in the compilation of "/root/hybrid-ep-open-source/csrc/hybrid_ep/buffer/internode_doca.cu".
```