### PR TITLE
Hybrid EP：Support configurable IB Traffic Class via HYBRID_EP_IB_TC env var

### DIFF
--- a/csrc/hybrid_ep/buffer/internode_doca.cu
+++ b/csrc/hybrid_ep/buffer/internode_doca.cu
@@ -2,9 +2,27 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 // All rights reserved
 #include "buffer/internode_doca.cuh"
+#include <torch/extension.h>
 #include <sstream>
 #include <cstdlib>
 #include <unordered_map>
+#include <climits>
+
+// Get IB Traffic Class value from environment variable with range validation.
+// Traffic Class valid range is 0-255 (8-bit field in RoCE/IB).
+int get_ib_tc_value() {
+    const char* val = std::getenv("HYBRID_EP_IB_TC");
+    if (val == nullptr) {
+        return 0;  // Default value
+    }
+    int tc = std::atoi(val);
+    // Validate range: Traffic Class is an 8-bit field
+    if (tc < 0 || tc > 255) {
+        fprintf(stderr, "[Warning] HYBRID_EP_IB_TC=%d is out of valid range [0, 255]. Using default value 0.\n", tc);
+        return 0;
+    }
+    return tc;
+}
 
 // Functions realted to get RDMA context.
 ibv_device *ctx_find_dev(const char *ib_devname) {
@@ -213,7 +231,7 @@ int setup_qp_attr_for_modify(struct ibv_port_attr *port_attr, struct doca_verbs_
   assert(status == 0);
   status = doca_verbs_ah_attr_set_hop_limit(ah, DEF_HOP_LIMIT);
   assert(status == 0);
-  status = doca_verbs_ah_attr_set_traffic_class(ah, DEF_IB_TC);
+  status = doca_verbs_ah_attr_set_traffic_class(ah, get_ib_tc_value());
   assert(status == 0);
   status = doca_verbs_qp_attr_set_ah_attr(qp_attr, ah);
   assert(status == 0);

--- a/csrc/hybrid_ep/buffer/internode_doca.cuh
+++ b/csrc/hybrid_ep/buffer/internode_doca.cuh
@@ -36,7 +36,6 @@ enum memory_type {
 
 constexpr int32_t CONNECTION_TYPE = RC;
 constexpr int32_t DEF_HOP_LIMIT = 255;
-constexpr int32_t DEF_IB_TC = 0;
 constexpr int32_t DEF_RX_RDMA = 128;
 constexpr int32_t DEF_TX_BW = 512;
 constexpr int32_t EQ_NUM = 0;
@@ -102,6 +101,7 @@ struct remote_info {
 
 ibv_device *ctx_find_dev(const char *ib_devname);
 int get_gpu_handler(struct doca_gpu *handler, struct ibv_context *ib_context, int local_rank);
+int get_ib_tc_value();
 void setup_qp_init_attr(struct doca_gpu_verbs_qp_init_attr_hl *qp_init_attr,
                         struct doca_gpu *gpu_handler, struct ibv_pd *ib_pd, int tx_depth);
 int create_and_place_qps(struct gverbs_context *g_ctx,


### PR DESCRIPTION
## Summary

This PR adds support for configuring the IB Traffic Class (TC) used in RDMA QP setup via an environment variable, replacing the previously hardcoded value.

- Add `HYBRID_EP_IB_TC` for runtime configuration  
- Remove hardcoded `DEF_IB_TC = 0`  
- Introduce `get_ib_tc_value()` with range validation (0–255)  
- Fix DOCA compilation issue by adding missing headers  

This change was motivated by observed performance anomalies when using `TC=0` (e.g., ~46 GB/s in 2-node dispatch scenarios), which revealed that the TC value was hardcoded.

---

## Changes

### IB TC Configuration

**`csrc/hybrid_ep/buffer/internode_doca.cuh`**  
- Remove `DEF_IB_TC`  
- Declare `get_ib_tc_value()`  

**`csrc/hybrid_ep/buffer/internode_doca.cu`**  
- Implement `get_ib_tc_value()`:
  - Read `HYBRID_EP_IB_TC` from environment  
  - Validate range `[0, 255]`  
  - Fall back to `0` if invalid (with warning)  
- Replace all usages of `DEF_IB_TC` with `get_ib_tc_value()`  
- Add missing includes:

    #include <torch/extension.h>
    #include <climits>

---

## Usage

    # Optional: set IB Traffic Class (default = 0)
    export HYBRID_EP_IB_TC=162

    python -u tests/test_hybrid_ep.py --num-processes 8

- Values outside `[0, 255]` will:
  - Trigger a warning  
  - Fall back to `0`  

---

## Performance Impact

- Before (`TC=0`): ~46 GB/s (2-node dispatch)  
- After (e.g., `TC=162`): significantly improved throughput  

Note: exact gains depend on network configuration and topology.

---

## Notes

- Aligns with NVSHMEM-style runtime configurability  
- Helps avoid performance issues on certain platforms (e.g., B300 with TC=0)  
- Backward compatible (default remains `TC=0`)