### PR TITLE
Fix DOCA build/path regressions from NIXL integration (#606)

### DIFF
--- a/csrc/hybrid_ep/buffer/internode_doca.cuh
+++ b/csrc/hybrid_ep/buffer/internode_doca.cuh
@@ -4,6 +4,14 @@
 
 #ifndef USE_NIXL
 
+#include <unordered_map>
+#include <cstdint>
+#include <pybind11/pybind11.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/util/Optional.h>
+#include <torch/torch.h>
+#include <iostream>
+#include <dlfcn.h>
 #include "doca_gpunetio_host.h"
 #include "doca_gpunetio_device.h"
 #include "infiniband/verbs.h"

--- a/docs/README_Hybrid-EP.md
+++ b/docs/README_Hybrid-EP.md
@@ -285,14 +285,7 @@ export USE_NIXL=1
 pip install .
 ```
 
-If `USE_NIXL` is not propagated (e.g. with pip build isolation), create a marker file before building:
-
-```bash
-touch .use_nixl
-HYBRID_EP_MULTINODE=1 pip install .
-```
-
-During build, you should see `Multinode enabled: use_nixl=True` and `-> NIXL path: skipping NCCL/DOCA build`. If you see `-> DOCA path` instead, `USE_NIXL` is not being passed (try the `.use_nixl` file).
+During build, you should see `Multinode enabled: use_nixl=True` and `-> NIXL path: skipping NCCL/DOCA build`. If you see `-> DOCA path` instead, `USE_NIXL` is not being passed; ensure the variable is exported in the same shell that invokes the build (some pip front-ends with build isolation strip env vars - in that case use `pip install --no-build-isolation .` or pass the variable through your build configuration).
 
 ### Quick Start
 

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,8 @@ def to_nvcc_gencode(s: str) -> str:
 def get_extension_hybrid_ep_cpp():
     current_dir = os.path.dirname(os.path.abspath(__file__))
     enable_multinode = os.getenv("HYBRID_EP_MULTINODE", "0").strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+    # NIXL is opt-in and disabled by default; the DOCA/NCCL path is the default when multinode is enabled.
     use_nixl = os.getenv("USE_NIXL", "0").strip().lower() in {"1", "true", "t", "yes", "y", "on"}
-    # Fallback when env may not propagate (e.g. pip build isolation): .use_nixl in project root
-    if enable_multinode and not use_nixl and os.path.isfile(os.path.join(current_dir, ".use_nixl")):
-        use_nixl = True
-        print("Using NIXL (found .use_nixl; DOCA/NCCL build unavailable)")
 
     # Default to Blackwell series
     os.environ['TORCH_CUDA_ARCH_LIST'] = os.getenv('TORCH_CUDA_ARCH_LIST', '10.0')
@@ -146,16 +143,11 @@ def get_extension_hybrid_ep_cpp():
             extra_link_args.append(f"-l:libnvidia-ml.so.1")
 
             subprocess.run(["git", "submodule", "update", "--init", "--recursive"], cwd=current_dir)
-            nccl_make = subprocess.run(
+            subprocess.run(
                 ["make", "-j", "src.build", f"NVCC_GENCODE={to_nvcc_gencode(os.environ['TORCH_CUDA_ARCH_LIST'])}"],
                 cwd=nccl_dir,
+                check=True,
             )
-            if nccl_make.returncode != 0:
-                raise SystemExit(
-                    "NCCL/DOCA build failed (missing doca_gpunetio_device.h or DOCA SDK).\n"
-                    "Use NIXL instead: export USE_NIXL=1 HYBRID_EP_MULTINODE=1 && pip install .\n"
-                    "Or create .use_nixl in the project root and rebuild."
-                )
             include_dirs.append(os.path.join(nccl_dir, "src/transport/net_ib/gdaki/doca-gpunetio/include"))
             include_dirs.append(os.path.join(rdma_core_dir, "include"))
             library_dirs.append(os.path.join(rdma_core_dir, "lib"))


### PR DESCRIPTION
The NIXL integration commit (1b8f467) broke DOCA-only builds in two ways:

1. internode_doca.cuh lost the torch / pybind11 / standard headers that the original internode.cuh provided. Building with HYBRID_EP_MULTINODE=1 and USE_NIXL=0 (the documented DOCA path) failed with 9 nvcc errors on the torch::Tensor / py::list / memcpy expressions inside RDMACoordinator::exchange_remote_rdma_info.

2. A committed empty .use_nixl marker file plus a setup.py fallback forced use_nixl=True on every build, regardless of the USE_NIXL env var. This silently disabled the DOCA path even when the user explicitly opted out.

This change:

- Restores the missing system / torch / pybind11 includes in internode_doca.cuh (relocated from the original internode.cuh; guarded by #ifndef USE_NIXL so they cannot leak into the NIXL build).
- Removes the .use_nixl marker file and the corresponding fallback branch in setup.py, making USE_NIXL=0 the actual default again.
- Restores the DOCA branch in setup.py to the pre-NIXL behavior: subprocess.run(make src.build, ..., check=True) with no NIXL-suggesting SystemExit message.
- Updates docs/README_Hybrid-EP.md to drop the .use_nixl workaround and point users at pip install --no-build-isolation when env vars are stripped by build isolation.

DOCA build configuration (sources, includes, libs, extra_objects, link args, NVCC flags) is now byte-for-byte identical to the pre-1b8f467 state. NIXL paths are unchanged and remain opt-in via USE_NIXL=1.

Fixes deepseek-ai/DeepEP#606