### PR TITLE
Try to detect 802.3ad LACP bonding slaves and multiply by slave count

### DIFF
--- a/deep_ep/utils/envs.py
+++ b/deep_ep/utils/envs.py
@@ -262,6 +262,14 @@ def get_rdma_gbs(nic_name: str = _DEFAULT_NIC_NAME) -> float:
         match = re.search(pattern, output, re.DOTALL)
         assert match
         rate = int(match.group(1))
+
+        # Try to detect 802.3ad LACP bonding slaves and multiply by slave count
+        result = subprocess.run(f'cat /sys/class/infiniband/{nic_name}/device/net/*/upper_*/bonding/slaves',
+                                shell=True, capture_output=True, text=True)
+        slave_count = len(result.stdout.strip().split())
+        if slave_count >= 2:
+            rate *= slave_count
+
         return rate / 8
     except Exception as e:
         print(f'Failed to get RDMA connection speed: {e}')


### PR DESCRIPTION
We found the get_rdma_gbs() function in #605 deep_ep/utils/envs.py:246 uses ibstat to detect the RDMA NIC bandwidth, which is then used to calculate the number of SMs.

However, in LACP bonding environments, ibstat reports only half of the actual bandwidth, leading to incorrect SM calculation.

This change is for detecting 802.3ad LACP bonding slaves and multiplying rdma rate by slave count.

refer: #614 