### PR TITLE
Nvshmem 3 5 runtime fixes (#564)

### DIFF
--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -70,5 +70,13 @@ typedef uint8_t __nv_fp8_storage_t;
 #include <nvshmemx.h>
 #include <infiniband/mlx5dv.h>
 #include <non_abi/device/threadgroup/nvshmemi_common_device_defines.cuh>
+// NVSHMEM's IBGDA header emits a *definition* of nvshmemi_ibgda_device_state_d
+// when included from host-compiled TUs (e.g., deep_ep.cpp built with g++).
+// That instantiates a private shadow copy of the device state inside
+// deep_ep_cpp.so — distinct from the one libnvshmem_device.a populates —
+// causing kernel writes (against NVSHMEM's state) and host reads (against
+// the shadow) to diverge. Only include it when compiling with NVCC.
+#if defined(__CUDACC__)
 #include <device_host_transport/nvshmem_common_ibgda.h>
+#endif
 #endif

--- a/csrc/kernels/configs.cuh
+++ b/csrc/kernels/configs.cuh
@@ -26,6 +26,13 @@
 #define __CUDACC_RDC__ // NOLINT(*-reserved-identifier)
 #endif
 
+// Define __CUDACC_RDC__ to ensure proper extern declarations for NVSHMEM device symbols
+#ifndef DISABLE_NVSHMEM
+#ifndef __CUDACC_RDC__
+#define __CUDACC_RDC__  // NOLINT(*-reserved-identifier)
+#endif
+#endif
+
 // Remove Torch restrictions
 #ifdef __CUDA_NO_HALF_CONVERSIONS__
 #undef __CUDA_NO_HALF_CONVERSIONS__

--- a/csrc/kernels/ibgda_device.cuh
+++ b/csrc/kernels/ibgda_device.cuh
@@ -92,7 +92,14 @@ __device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc_impl(
 
 __device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc(int pe, int id) {
     auto state = ibgda_get_state();
-    return ibgda_get_rc_impl(state, pe, id);
+    // PROBE: NVSHMEM 3.6.5 still typedefs nvshmemi_ibgda_device_state_t as
+    // nvshmemi_ibgda_device_state_v1, so PR #564's templated dispatch goes to
+    // the v1 (pre-3.5.21) branch. But the v1 struct's rkeys comment in 3.6.5
+    // —"rkeys[idx * npes + pe] gives rkey of chunck idx targeting peer pe"—
+    // says the post-3.5.21 (v2) layout is what's actually populated. So the
+    // v1 indexing yields wrong QPs → WQEs to wrong remote addresses →
+    // moe_recv_*_counter stays at -1 (the prenyx hang). Force v2 indexing.
+    return &state->globalmem.rcs[pe + nvshmemi_device_state_d.npes * id];
 }
 
 __device__ static __forceinline__

--- a/csrc/kernels/ibgda_device.cuh
+++ b/csrc/kernels/ibgda_device.cuh
@@ -7,6 +7,8 @@
 //  - nvshmem/src/include/non_abi/device/pt-to-pt/ibgda_device.cuh
 #pragma once
 
+#include <type_traits>
+
 #include "configs.cuh"
 #include "exception.cuh"
 #include "utils.cuh"
@@ -73,11 +75,24 @@ nvshmemi_ibgda_device_state_t* ibgda_get_state() {
     return &nvshmemi_ibgda_device_state_d;
 }
 
-__device__ static __forceinline__
-nvshmemi_ibgda_device_qp_t* ibgda_get_rc(int pe, int id) {
+// Template helper to get RC - uses compile-time type checking with if constexpr (C++17)
+template <typename StateType>
+__device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc_impl(StateType* state, int pe, int id) {
+    const auto num_rc_per_pe = state->num_rc_per_pe;
+
+    if constexpr (std::is_same_v<StateType, nvshmemi_ibgda_device_state_v1>) {
+        // v1 implementation
+        return &state->globalmem
+                    .rcs[pe * num_rc_per_pe * state->num_devices_initialized + id % (num_rc_per_pe * state->num_devices_initialized)];
+    } else {
+        // v2 implementation (or any other type)
+        return &state->globalmem.rcs[pe + nvshmemi_device_state_d.npes * id];
+    }
+}
+
+__device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc(int pe, int id) {
     auto state = ibgda_get_state();
-    const auto num_rc_per_pe = ibgda_get_state()->num_rc_per_pe;
-    return &state->globalmem.rcs[pe * num_rc_per_pe * state->num_devices_initialized + id % (num_rc_per_pe * state->num_devices_initialized)];
+    return ibgda_get_rc_impl(state, pe, id);
 }
 
 __device__ static __forceinline__

--- a/csrc/kernels/ibgda_device.cuh
+++ b/csrc/kernels/ibgda_device.cuh
@@ -92,14 +92,7 @@ __device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc_impl(
 
 __device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc(int pe, int id) {
     auto state = ibgda_get_state();
-    // PROBE: NVSHMEM 3.6.5 still typedefs nvshmemi_ibgda_device_state_t as
-    // nvshmemi_ibgda_device_state_v1, so PR #564's templated dispatch goes to
-    // the v1 (pre-3.5.21) branch. But the v1 struct's rkeys comment in 3.6.5
-    // —"rkeys[idx * npes + pe] gives rkey of chunck idx targeting peer pe"—
-    // says the post-3.5.21 (v2) layout is what's actually populated. So the
-    // v1 indexing yields wrong QPs → WQEs to wrong remote addresses →
-    // moe_recv_*_counter stays at -1 (the prenyx hang). Force v2 indexing.
-    return &state->globalmem.rcs[pe + nvshmemi_device_state_d.npes * id];
+    return ibgda_get_rc_impl(state, pe, id);
 }
 
 __device__ static __forceinline__

--- a/csrc/kernels/internode.cu
+++ b/csrc/kernels/internode.cu
@@ -106,6 +106,17 @@ notify_dispatch(const int* num_tokens_per_rank, int* moe_recv_counter_mapped, in
         EP_DEVICE_ASSERT(num_warps > 1);
         EP_DEVICE_ASSERT(kNumRDMARanks <= num_threads);
 
+        // [DEEPEP_DEBUG] Print IBGDA device-state contents on rank 0 thread 0 to confirm
+        // whether the state is initialized in DeepEP's __device__ instance.
+        // If state is all zeros / num_devices_initialized==0, NVSHMEM's host runtime
+        // is initializing a different __device__ instance than the one this kernel sees.
+        if (thread_id == 0 && rank == 0) {
+            auto _state = ibgda_get_state();
+            printf("[DEEPEP_DEBUG_INIT_STATE] state_ptr=%p num_devices_initialized=%d num_rc_per_pe=%d nvshmemi_npes=%d\n",
+                   _state, _state->num_devices_initialized, _state->num_rc_per_pe,
+                   nvshmemi_device_state_d.npes);
+        }
+
         // waiting for all previous inflight wrs to complete,
         // in case of rewriting cleared rdma_buffer
         auto qps_per_rdma_rank = ibgda_get_state()->num_rc_per_pe * ibgda_get_state()->num_devices_initialized;

--- a/deep_ep/buffer.py
+++ b/deep_ep/buffer.py
@@ -32,7 +32,7 @@ class Buffer:
 
     def __init__(self, group: Optional[dist.ProcessGroup],
                  num_nvl_bytes: int = 0, num_rdma_bytes: int = 0,
-                 low_latency_mode: bool = False,  num_qps_per_rank: int = 24,
+                 low_latency_mode: bool = False,  num_qps_per_rank: int = 8,
                  allow_nvlink_for_normal_mode: bool = True,
                  allow_nvlink_for_low_latency_mode: bool = True,
                  allow_mnnvl: bool = False,


### PR DESCRIPTION
* DeepEP/csrc: Force CUDA RDC when NVSHMEM is used.

When DeepEP is against a source build of NVSHMEM starting with NVSHMEM 3.3.20, multiple instances of nvshmemi_ibgda_device_state_d are detected. One from NVSHMEM, another from the kernels.



* DeepEP/csrc: Update RC selection for NVSHMEM 3.5.

The locations of QPs within the device state struct changed with the addition of QP-specific APIs.

This change updates DeepEP to work with the new layout.

The ibgda_get_rc function is also templated so that main remains backwards compatible with previous versions of NVSHMEM.

Tested with both internode and low_latency kernels on 4 H100 nodes.



* Check Format



---------


(cherry picked from commit 29d31c095796f3c8ece47ee9cdcc167051bbeed9)