### PR TITLE
Fix V2 initialization for pure single-node intra EP

### DIFF
--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -81,17 +81,20 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
     if (get_env<int>("EP_BUFFER_DEBUG"))
         printf("EP NCCL device communicator has %d allocated QPs\n", num_allocated_qps);
 
-    // Query NCCL supported Gin Type
-    ncclCommProperties props = NCCL_COMM_PROPERTIES_INITIALIZER;
-    NCCL_CHECK(ncclCommQueryProperties(comm, &props));
-    EP_HOST_ASSERT(
-        (allow_hybrid_mode ? props.railedGinType : props.ginType) != NCCL_GIN_TYPE_NONE and
-        "NCCL GIN is unavailable. This is usually due to a network configuration issue, "
-        "such as `allow_hybrid_mode=0` (disable direct RDMA kernels) in multi-plane network.");
+    const bool gin_disabled = get_env("EP_DISABLE_GIN", 0) != 0;
+    if (not gin_disabled) {
+        // Query NCCL supported Gin Type
+        ncclCommProperties props = NCCL_COMM_PROPERTIES_INITIALIZER;
+        NCCL_CHECK(ncclCommQueryProperties(comm, &props));
+        EP_HOST_ASSERT(
+            (allow_hybrid_mode ? props.railedGinType : props.ginType) != NCCL_GIN_TYPE_NONE and
+            "NCCL GIN is unavailable. This is usually due to a network configuration issue, "
+            "such as `allow_hybrid_mode=0` (disable direct RDMA kernels) in multi-plane network.");
+    }
 
     // Initialize NCCL device communicator
     ncclDevCommRequirements_t reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
-    if (num_ranks > 1 and get_env("EP_DISABLE_GIN", 0) == 0) {
+    if (num_ranks > 1 and not gin_disabled) {
         reqs.ginContextCount = num_allocated_qps;
         reqs.ginExclusiveContexts = true;
         reqs.ginQueueDepth = 1024;


### PR DESCRIPTION
## Summary

This PR fixes V2/elastic initialization for pure single-node intra-node EP runs where NCCL reports no Gin capability. (#629)

This keeps the existing `EP_DISABLE_GIN` policy: when the variable is set, DeepEP skips Gin context requests instead of forcing Gin availability during preflight initialization.

## Validation

Validated on 8 x NVIDIA B300 GPUs, CUDA 13.2, PyTorch `2.13.0.dev20260502+cu130`, and NCCL `2.30.4`.

```bash
export EP_DISABLE_GIN=1

python tests/elastic/test_ep.py \
  --num-processes 8 \
  --num-tokens 8192 \
  --hidden 7168 \
  --num-topk 8 \
  --num-experts 256 \
  --allow-hybrid-mode 0 \
  --test-first-only
```

Average across 8 ranks:

| Metric | Result | README SM100 EP8 reference |
| --- | ---: | ---: |
| Dispatch | 731.9 GB/s SU | 726 GB/s NVLink |
| Combine | 741.0 GB/s SU | 740 GB/s NVLink |
