### PR TITLE
feat: Add RDMA-Only (Non-NVLink) Topology Support for ElasticBuffer Direct Mode

### DIFF
--- a/csrc/elastic/buffer.hpp
+++ b/csrc/elastic/buffer.hpp
@@ -597,6 +597,7 @@ public:
                                          const int& num_max_tokens_per_rank, const int& hidden,
                                          int num_topk, const bool& use_fp8_dispatch,
                                          const bool& allow_hybrid_mode,
+                                         const bool& has_nvlink,
                                          const bool& allow_multiple_reduction) {
         EP_HOST_ASSERT(num_max_tokens_per_rank > 0 and hidden > 0);
 
@@ -606,9 +607,19 @@ public:
         // NOTES: there are lots of `kNumTopk <= 32` restrictions, so we use 32 to calculate token size
         num_topk = num_topk == 0 ? 32 : num_topk;
 
-        // Topology
-        const auto [num_rdma_ranks, num_nvl_ranks] = nccl::get_physical_domain_size(nccl_comm);
-        const auto [num_scaleout_ranks, num_scaleup_ranks] = nccl::get_logical_domain_size(nccl_comm, allow_hybrid_mode);
+        // Topology (override NVL domain when no NVLink hardware exists)
+        const auto [physical_rdma_ranks, physical_nvl_ranks] = nccl::get_physical_domain_size(nccl_comm);
+        const auto num_nvl_ranks = has_nvlink ? physical_nvl_ranks : 1;
+        const auto num_ranks = physical_rdma_ranks * physical_nvl_ranks;
+        const auto num_rdma_ranks = num_ranks / num_nvl_ranks;
+        int num_scaleout_ranks, num_scaleup_ranks;
+        if (allow_hybrid_mode) {
+            num_scaleout_ranks = num_rdma_ranks;
+            num_scaleup_ranks = num_nvl_ranks;
+        } else {
+            num_scaleout_ranks = 1;
+            num_scaleup_ranks = num_ranks;
+        }
         const auto is_scaleup_nvlink = num_scaleup_ranks == num_nvl_ranks;
 
         // Dispatch size

--- a/csrc/elastic/buffer.hpp
+++ b/csrc/elastic/buffer.hpp
@@ -83,6 +83,7 @@ public:
                   const int64_t& num_buffer_bytes,
                   const bool& deterministic,
                   const bool& allow_hybrid_mode,
+                  const bool& has_nvlink,
                   const bool& allow_multiple_reduction,
                   const bool& prefer_overlap_with_compute,
                   const int& sl_idx, const int& num_allocated_qps,
@@ -100,7 +101,7 @@ public:
         this->nccl_context = std::make_shared<nccl::NCCLSymmetricMemoryContext>(
             nccl_comm, num_ranks, rank_idx,
             layout::WorkspaceLayout::get_num_bytes() + num_buffer_bytes, kBufferAlignment,
-            allow_hybrid_mode, sl_idx, num_allocated_qps);
+            allow_hybrid_mode, has_nvlink, sl_idx, num_allocated_qps);
 
         // Timeout
         this->num_cpu_timeout_secs = num_cpu_timeout_secs;
@@ -1274,7 +1275,7 @@ public:
 
 static void register_apis(pybind11::module_& m) {
     pybind11::class_<ElasticBuffer>(m, "ElasticBuffer")
-        .def(pybind11::init<int, int, int64_t, int64_t, bool, bool, bool, bool, int, int, int, int, bool>())
+        .def(pybind11::init<int, int, int64_t, int64_t, bool, bool, bool, bool, bool, int, int, int, int, bool>())
         .def("destroy", &ElasticBuffer::destroy)
         .def("get_comm_stream", &ElasticBuffer::get_comm_stream)
         .def("get_physical_domain_size", &ElasticBuffer::get_physical_domain_size)

--- a/csrc/kernels/backend/api.cuh
+++ b/csrc/kernels/backend/api.cuh
@@ -74,6 +74,7 @@ public:
                                const int& num_ranks, const int& rank_idx,
                                const size_t& size, const size_t& alignment,
                                const bool& allow_hybrid_mode,
+                               const bool& has_nvlink,
                                const int& sl_idx, const int& num_allocated_qps);
 
     // TODO: finish this with `explicit_destroy`

--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -65,6 +65,7 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
                                                        const int& num_ranks, const int& rank_idx,
                                                        const size_t& size, const size_t& alignment,
                                                        const bool& allow_hybrid_mode,
+                                                       const bool& has_nvlink,
                                                        const int& sl_idx, const int& num_allocated_qps):
     rank_idx(rank_idx), num_ranks(num_ranks), num_allocated_qps(num_allocated_qps) {
     if (get_env("EP_BUFFER_DEBUG", 0)) {
@@ -102,11 +103,19 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
     }
     NCCL_CHECK(ncclDevCommCreate(comm, &reqs, &dev_comm));
 
-    // Now we know the NVLink domain size
-    num_nvl_ranks = dev_comm.lsaSize, nvl_rank_idx = dev_comm.lsaRank;
+    // Get LSA domain from NCCL (needed for NCCL API calls regardless of NVLink presence)
+    const int num_lsa_ranks = dev_comm.lsaSize, lsa_rank_idx = dev_comm.lsaRank;
+
+    // Override NVL domain when no NVLink hardware exists (PCIe-only topology)
+    // NCCL may report lsaSize > 1 on PCIe due to proximity grouping
+    num_nvl_ranks = has_nvlink ? num_lsa_ranks : 1;
+    nvl_rank_idx = has_nvlink ? lsa_rank_idx : 0;
     num_rdma_ranks = num_ranks / num_nvl_ranks, rdma_rank_idx = rank_idx / num_nvl_ranks;
     EP_HOST_ASSERT(num_ranks % num_nvl_ranks == 0 and nvl_rank_idx == rank_idx % num_nvl_ranks);
     EP_HOST_ASSERT(rank_idx == rdma_rank_idx * num_nvl_ranks + nvl_rank_idx);
+
+    if (not has_nvlink and num_lsa_ranks > 1 and get_env<int>("EP_BUFFER_DEBUG"))
+        printf("[DeepEP] PCIe-only topology detected (NCCL lsaSize=%d), overriding num_nvl_ranks=1\n", num_lsa_ranks);
 
     // Calculate scaleout/up domain size
     if (allow_hybrid_mode) {
@@ -123,12 +132,11 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
     // across all ranks, so no explicit barrier is needed after this call.
     NCCL_CHECK(ncclMemAlloc(&raw_window_ptr, size));
     NCCL_CHECK(ncclCommWindowRegister(comm, raw_window_ptr, size, &window, NCCL_WIN_DEFAULT));
-    NCCL_CHECK(ncclGetLsaDevicePointer(window, 0, nvl_rank_idx, &mapped_window_ptr));
+    NCCL_CHECK(ncclGetLsaDevicePointer(window, 0, lsa_rank_idx, &mapped_window_ptr));
 
     // Get LSA pointers for all LSA peers
-    // TODO: check whether this is correct for network with RDMA
-    nvl_window_ptrs.resize(num_nvl_ranks);
-    for (int i = 0; i < num_nvl_ranks; ++ i)
+    nvl_window_ptrs.resize(num_lsa_ranks);
+    for (int i = 0; i < num_lsa_ranks; ++ i)
         NCCL_CHECK(ncclGetLsaDevicePointer(window, 0, i, &nvl_window_ptrs[i]));
 
     // TODO: push NCCL team to support aligned allocation

--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -106,8 +106,8 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
     // Get LSA domain from NCCL (needed for NCCL API calls regardless of NVLink presence)
     const int num_lsa_ranks = dev_comm.lsaSize, lsa_rank_idx = dev_comm.lsaRank;
 
-    // Override NVL domain when no NVLink hardware exists (PCIe-only topology)
-    // NCCL may report lsaSize > 1 on PCIe due to proximity grouping
+    // Override NVL domain when no NVLink hardware exists (RDMA-only topology)
+    // NCCL may report lsaSize > 1 due to proximity grouping even without NVLink
     num_nvl_ranks = has_nvlink ? num_lsa_ranks : 1;
     nvl_rank_idx = has_nvlink ? lsa_rank_idx : 0;
     num_rdma_ranks = num_ranks / num_nvl_ranks, rdma_rank_idx = rank_idx / num_nvl_ranks;
@@ -115,7 +115,7 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
     EP_HOST_ASSERT(rank_idx == rdma_rank_idx * num_nvl_ranks + nvl_rank_idx);
 
     if (not has_nvlink and num_lsa_ranks > 1 and get_env<int>("EP_BUFFER_DEBUG"))
-        printf("[DeepEP] PCIe-only topology detected (NCCL lsaSize=%d), overriding num_nvl_ranks=1\n", num_lsa_ranks);
+        printf("[DeepEP] Non-NVLink topology detected (NCCL lsaSize=%d), overriding num_nvl_ranks=1\n", num_lsa_ranks);
 
     // Calculate scaleout/up domain size
     if (allow_hybrid_mode) {

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -185,7 +185,7 @@ class ElasticBuffer:
             num_bytes = _C.calculate_elastic_buffer_size(
                 self.nccl_comm_handle.get(),
                 num_max_tokens_per_rank, hidden, num_topk, use_fp8_dispatch,
-                allow_hybrid_mode, allow_multiple_reduction)
+                allow_hybrid_mode, has_nvlink, allow_multiple_reduction)
         if os.environ.get('EP_BUFFER_DEBUG', 0):
             print(f'Initializing EP elastic buffer with {num_bytes} bytes at rank EP {group.rank()}/{group.size()}')
         self.num_bytes = num_bytes
@@ -270,10 +270,11 @@ class ElasticBuffer:
         Returns:
             size: the recommended buffer size in bytes.
         """
+        has_nvlink = get_nvlink_gbs() > 0
         return _C.calculate_elastic_buffer_size(
             get_nccl_comm_handle(group).get(),
             num_max_tokens_per_rank, hidden, num_topk, use_fp8_dispatch,
-            allow_hybrid_mode, allow_multiple_reduction)
+            allow_hybrid_mode, has_nvlink, allow_multiple_reduction)
 
     @staticmethod
     def get_engram_storage_size_hint(num_entries: int, hidden: int,

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -167,8 +167,8 @@ class ElasticBuffer:
         self.prefer_overlap_with_compute = prefer_overlap_with_compute
         self.nccl_comm_handle = get_nccl_comm_handle(group)
 
-        # Detect NVLink topology and auto-disable hybrid mode for PCIe-only setups
-        # NCCL may report num_nvl_ranks > 1 even on PCIe-only topologies (grouping by PCIe proximity),
+        # Detect NVLink topology and auto-disable hybrid mode for non-NVLink setups
+        # NCCL may report num_nvl_ranks > 1 even without NVLink (proximity grouping),
         # so we also check actual NVLink bandwidth to confirm real NVLink hardware exists
         num_rdma_ranks, num_nvl_ranks = _C.get_physical_domain_size(self.nccl_comm_handle.get())
         has_nvlink = get_nvlink_gbs() > 0
@@ -461,7 +461,7 @@ class ElasticBuffer:
 
         """
         assert self.num_nvlink_ranks > 1, \
-            'AGRS requires NVLink connectivity; not available in PCIe/RDMA-only topology'
+            'AGRS requires NVLink connectivity; not available in RDMA-only topology'
         self.runtime.create_agrs_session()
 
     def destroy_agrs_session(self) -> None:

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -163,10 +163,21 @@ class ElasticBuffer:
         self.group = group
         self.rank_idx = group.rank()
         self.num_ranks = group.size()
-        self.allow_hybrid_mode = allow_hybrid_mode
         self.allow_multiple_reduction = allow_multiple_reduction
         self.prefer_overlap_with_compute = prefer_overlap_with_compute
         self.nccl_comm_handle = get_nccl_comm_handle(group)
+
+        # Detect NVLink topology and auto-disable hybrid mode for PCIe-only setups
+        # NCCL may report num_nvl_ranks > 1 even on PCIe-only topologies (grouping by PCIe proximity),
+        # so we also check actual NVLink bandwidth to confirm real NVLink hardware exists
+        num_rdma_ranks, num_nvl_ranks = _C.get_physical_domain_size(self.nccl_comm_handle.get())
+        has_nvlink = get_nvlink_gbs() > 0
+        if not has_nvlink and self.num_ranks > 1 and allow_hybrid_mode:
+            if int(os.environ.get('EP_BUFFER_DEBUG', 0)):
+                print(f'[DeepEP] No NVLink hardware detected (nccl_nvl_ranks={num_nvl_ranks}), '
+                      f'auto-disabling hybrid mode for RDMA-only operation')
+            allow_hybrid_mode = False
+        self.allow_hybrid_mode = allow_hybrid_mode
 
         # Calculate buffer size
         if num_bytes is None:
@@ -207,6 +218,7 @@ class ElasticBuffer:
                                         num_bytes,
                                         deterministic,
                                         allow_hybrid_mode,
+                                        has_nvlink,
                                         allow_multiple_reduction,
                                         prefer_overlap_with_compute,
                                         sl_idx, num_allocated_qps,
@@ -448,6 +460,8 @@ class ElasticBuffer:
         (Experimental) Begin a new all-gather reduce-scatter (AGRS) session. Must be paired with `destroy_agrs_session`.
 
         """
+        assert self.num_nvlink_ranks > 1, \
+            'AGRS requires NVLink connectivity; not available in PCIe/RDMA-only topology'
         self.runtime.create_agrs_session()
 
     def destroy_agrs_session(self) -> None:
@@ -614,7 +628,8 @@ class ElasticBuffer:
             rdma_traffic += (self.num_ranks - self.num_nvlink_ranks) / self.num_ranks
 
         # Found the bounded one
-        if self.num_scaleout_ranks > 1 and (rdma_traffic / rdma_gbs) > (nvlink_traffic / nvlink_gbs):
+        if nvlink_traffic == 0 or (rdma_traffic > 0 and rdma_gbs > 0
+                                   and (rdma_traffic / rdma_gbs) > (nvlink_traffic / nvlink_gbs)):
             bounded_traffic, bounded_gbs = rdma_traffic, rdma_gbs
         else:
             bounded_traffic, bounded_gbs = nvlink_traffic, nvlink_gbs

--- a/deep_ep/utils/envs.py
+++ b/deep_ep/utils/envs.py
@@ -149,6 +149,9 @@ def check_nvlink_connections(group: dist.ProcessGroup) -> None:
     Arguments:
         group: the communication group.
     """
+    if get_nvlink_gbs() == 0:
+        return
+
     # Check NVLink connection
     # NOTES: some A100 PCIE GPUs only have pairwise NVLink connection, so that we can only use EP2
     # TODO: check all cases, all local-node GPUs in the group should be connected via NVLink


### PR DESCRIPTION

  ### Motivation

  DeepEP currently assumes NVLink connectivity between intra-node GPUs. On non-NVLink machines
  (e.g., RTX professional series cards with IB RDMA only), NCCL's LSA domain grouping may report `lsaSize > 1`
  even without real NVLink hardware, causing the hybrid dispatch kernel to crash (NVLink atomic
  barriers fail without NVLink) and the NVLink connectivity check to block initialization.

    This PR enables DeepEP to run on non-NVLink topologies under **direct mode only** — all ranks
  communicate via RDMA without NVLink forwarding. Hybrid mode (hierarchical RDMA + NVLink) is
  automatically disabled when no NVLink hardware is detected.

  ### Changes

  - Detect NVLink presence via `get_nvlink_gbs()` at initialization, automatically selecting
    the appropriate communication path based on hardware topology: NVLink machines use the
    existing hybrid/direct mode logic, non-NVLink machines fall back to RDMA-only direct mode
  - Pass `has_nvlink` flag to C++ backend to override NCCL's LSA domain (`num_nvl_ranks = 1`),
    compatible with the existing direct mode dispatch/combine kernel design
  - Fix division-by-zero in SM estimation when `nvlink_traffic == 0`
  - Guard NVLink-dependent paths (AGRS) and skip NVLink connectivity check on non-NVLink machines

  ### Testing

  - Full `test_ep.py` suite (144 configs) passes on 1/2 node (RDMA-only, EP 1/2×8, direct mode)
  - 1-node CX7 EP8 topology achieves ~53 GB/s dipsatch RDMA bandwidth; 
  - 2-node CX7 EP8*2 topology achieves ~48 GB/s dispatch RDMA bandwidth; 
  - more benchmarks in progress

  ### Notes

  - On RDMA-only topology, the dispatch kernel achieves high bandwidth utilization with very
    few SMs(e.g., 8/12), leaving most SMs free for overlapping computation. 