### PR TITLE
Handle token padding & Add check for inter-node case

### DIFF
--- a/csrc/hybrid_ep/config.cuh
+++ b/csrc/hybrid_ep/config.cuh
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <map>
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <stdexcept>
 #include <optional>
@@ -13,6 +14,40 @@
 // Now we support up to 72(GB200) ranks per node.
 // This will be used to initialize the template param_t for communication kernel.
 #define MAX_NUM_OF_RANKS_PER_NODE 72
+
+static constexpr int64_t HYBRID_EP_IB_QP_MAX_TX_DEPTH = 65536;
+static constexpr int64_t HYBRID_EP_DISPATCH_TX_DEPTH_TOKEN_FACTOR = 3;
+static constexpr int64_t HYBRID_EP_DISPATCH_TX_DEPTH_EXTRA = 1;
+
+static inline bool hybrid_ep_token_capacity_is_valid(
+    int max_num_of_tokens_per_rank, int num_of_nodes, const char* config_name) {
+  if (num_of_nodes <= 1) {
+    return true;
+  }
+
+  int64_t tx_depth =
+      HYBRID_EP_DISPATCH_TX_DEPTH_TOKEN_FACTOR *
+          static_cast<int64_t>(max_num_of_tokens_per_rank) +
+      HYBRID_EP_DISPATCH_TX_DEPTH_EXTRA;
+  if (tx_depth < HYBRID_EP_IB_QP_MAX_TX_DEPTH) {
+    return true;
+  }
+
+  int max_num_of_tokens_per_rank_supported = static_cast<int>(
+      (HYBRID_EP_IB_QP_MAX_TX_DEPTH - 1 - HYBRID_EP_DISPATCH_TX_DEPTH_EXTRA) /
+      HYBRID_EP_DISPATCH_TX_DEPTH_TOKEN_FACTOR);
+  fprintf(stderr,
+          "[Error] Invalid %s: max_num_of_tokens_per_rank=%d exceeds the supported "
+          "maximum number of %d tokens in multi-node mode (required IB QP tx depth %ld, "
+          "limit < %ld).\n",
+          config_name,
+          max_num_of_tokens_per_rank,
+          max_num_of_tokens_per_rank_supported,
+          static_cast<long>(tx_depth),
+          static_cast<long>(HYBRID_EP_IB_QP_MAX_TX_DEPTH));
+  fflush(stderr);
+  return false;
+}
 
 // Config used for buffer allocation.
 struct BufferConfig {
@@ -44,6 +79,8 @@ struct BufferConfig {
     valid &= ((num_of_experts_per_rank * num_of_ranks_per_node) % 4 == 0);
     // TMA requires (num_of_tokens_per_chunk * num_of_ranks_per_node * 4) % 16 == 0
     valid &= ((num_of_tokens_per_chunk_dispatch_api * num_of_ranks_per_node) % 4 == 0);
+    valid &= hybrid_ep_token_capacity_is_valid(
+        max_num_of_tokens_per_rank, num_of_nodes, "BufferConfig");
     if(!valid){
       fprintf(stderr, "[Error] Invalid BufferConfig: hidden_dim=%d, num_of_experts_per_rank=%d, num_of_ranks_per_node=%d, num_of_tokens_per_chunk_dispatch_api=%d\n", 
               hidden_dim, num_of_experts_per_rank, num_of_ranks_per_node, num_of_tokens_per_chunk_dispatch_api);
@@ -119,6 +156,8 @@ struct HybridEpConfigInstance {
     valid &= ((num_of_experts_per_rank * num_of_ranks_per_node) % 4 == 0);
     // TMA requires (num_of_tokens_per_chunk * num_of_ranks_per_node * 4) % 16 == 0
     valid &= ((num_of_tokens_per_chunk_dispatch_api * num_of_ranks_per_node) % 4 == 0);
+    valid &= hybrid_ep_token_capacity_is_valid(
+        max_num_of_tokens_per_rank, num_of_nodes, "HybridEpConfigInstance");
     // In fuse mode, all chunk sizes must be the same
     if (fuse_permute_dispatch) {
       bool chunk_match = (num_of_tokens_per_chunk_dispatch_api == num_of_tokens_per_chunk_combine_api)

--- a/csrc/hybrid_ep/config.cuh
+++ b/csrc/hybrid_ep/config.cuh
@@ -49,6 +49,18 @@ static inline bool hybrid_ep_token_capacity_is_valid(
   return false;
 }
 
+static inline int hybrid_ep_pad_num_of_tokens_per_rank(
+    int max_num_of_tokens_per_rank, int num_of_tokens_per_chunk_combine_api) {
+  if (num_of_tokens_per_chunk_combine_api <= 0) {
+    return max_num_of_tokens_per_rank;
+  }
+  return static_cast<int>(
+      (static_cast<int64_t>(max_num_of_tokens_per_rank) +
+       num_of_tokens_per_chunk_combine_api - 1) /
+      num_of_tokens_per_chunk_combine_api *
+      num_of_tokens_per_chunk_combine_api);
+}
+
 // Config used for buffer allocation.
 struct BufferConfig {
   int hidden_dim;
@@ -361,7 +373,6 @@ public:
 
         // Fill BufferConfig
         buffer_config.hidden_dim = hidden_dim;
-        buffer_config.max_num_of_tokens_per_rank = std::max(max_num_of_tokens_per_rank, 512);
         buffer_config.num_of_experts_per_rank = num_local_experts;
         buffer_config.num_of_ranks_per_node = num_of_ranks_per_node;
         buffer_config.num_of_nodes = num_of_nodes;
@@ -371,6 +382,9 @@ public:
         buffer_config.token_data_type = use_fp8 ? APP_TOKEN_DATA_TYPE::UINT8 : APP_TOKEN_DATA_TYPE::UINT16;
         buffer_config.num_of_tokens_per_chunk_dispatch_api = get_env_int("NUM_OF_TOKENS_PER_CHUNK_DISPATCH_API", 64);
         buffer_config.num_of_tokens_per_chunk_combine_api = get_env_int("NUM_OF_TOKENS_PER_CHUNK_COMBINE_API", 64);
+        buffer_config.max_num_of_tokens_per_rank = hybrid_ep_pad_num_of_tokens_per_rank(
+            std::max(max_num_of_tokens_per_rank, 512),
+            buffer_config.num_of_tokens_per_chunk_combine_api);
         buffer_config.num_of_dispatch_chunks = (buffer_config.max_num_of_tokens_per_rank - 1)
             / buffer_config.num_of_tokens_per_chunk_dispatch_api + 1;
         buffer_config.num_of_combine_chunks = (buffer_config.max_num_of_tokens_per_rank - 1)
@@ -449,6 +463,10 @@ public:
     // shared memory fits within the device limit. Reduces stages down to
     // MIN_STAGES, then errors if still too large.
     void adjust_template(HybridEpConfigInstance& config, bool fuse_permute_dispatch = false) {
+        config.max_num_of_tokens_per_rank = hybrid_ep_pad_num_of_tokens_per_rank(
+            config.max_num_of_tokens_per_rank,
+            config.num_of_tokens_per_chunk_combine_api);
+
         const int max_smem = max_smem_per_block;
         constexpr int MIN_STAGES = 2;
 
@@ -536,5 +554,8 @@ public:
             fflush(stderr);
             throw std::runtime_error("Cannot fit kernels into shared memory even with minimum stages.");
         }
+        buffer_config.max_num_of_tokens_per_rank = std::max(
+            buffer_config.max_num_of_tokens_per_rank,
+            config.max_num_of_tokens_per_rank);
     }
 };


### PR DESCRIPTION
1. Add check for inter-node dispatch
2. Fix bug that the num-of-tokens should be evenly divisible by the chunk size.