### PR TITLE
Add fence.proxy.async.shared::cta between mbarrier wait and TMA load.

### DIFF
--- a/csrc/kernels/legacy/internode_ll.cu
+++ b/csrc/kernels/legacy/internode_ll.cu
@@ -1060,7 +1060,6 @@ LOW_LATENCY_COMBINE_RECV:
                             num_casted = (info >> 1) + (info & 1);
                         }
                         int num_tma_bytes = num_casted * kNumLogFMTPerWarpBytes + (num_decode_warps - num_casted) * kNumBF16PerWarpBytes;
-                        fence_view_async_shared();
                         tma_load_1d(
                             tma_ld_buffers[stage_idx], buffer + (kUseLogFMT ? kNumMetaBytes : 0), full_barriers[stage_idx], num_tma_bytes);
                         mbarrier_arrive_and_expect_tx(full_barriers[stage_idx], num_tma_bytes);
@@ -1114,7 +1113,7 @@ LOW_LATENCY_COMBINE_RECV:
                             false,
                             topk_weight);
                     }
-
+                    fence_view_async_shared();
                     if (elect_one_sync())
                         mbarrier_arrive(empty_barriers[stage_idx]);
                     stage_idx = (stage_idx + 1) % kNumStages;

--- a/csrc/kernels/legacy/internode_ll.cu
+++ b/csrc/kernels/legacy/internode_ll.cu
@@ -1060,6 +1060,7 @@ LOW_LATENCY_COMBINE_RECV:
                             num_casted = (info >> 1) + (info & 1);
                         }
                         int num_tma_bytes = num_casted * kNumLogFMTPerWarpBytes + (num_decode_warps - num_casted) * kNumBF16PerWarpBytes;
+                        fence_view_async_shared();
                         tma_load_1d(
                             tma_ld_buffers[stage_idx], buffer + (kUseLogFMT ? kNumMetaBytes : 0), full_barriers[stage_idx], num_tma_bytes);
                         mbarrier_arrive_and_expect_tx(full_barriers[stage_idx], num_tma_bytes);

--- a/csrc/kernels/legacy/utils.cuh
+++ b/csrc/kernels/legacy/utils.cuh
@@ -382,6 +382,15 @@ __device__ __forceinline__ void tma_store_fence() {
     asm volatile("fence.proxy.async.shared::cta;");
 }
 
+__device__ __forceinline__ void fence_view_async_shared() {
+    asm volatile (
+        "{\n\t"
+        "fence.proxy.async.shared::cta; \n"
+        "}"
+        ::
+        : "memory");
+}
+
 constexpr uint64_t kEvictFirst = 0x12f0000000000000;
 constexpr uint64_t kEvictNormal = 0x1000000000000000;
 


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/deepseek-ai/DeepEP/issues/621. Compared with the fix in https://github.com/deepseek-ai/DeepEP/pull/632, this version uses a CTA-scope fence, which resolves the problem while preserving performance.

The data race here comes from LDS and TMA loads, so we only need fence.proxy.async.shared::cta; to prevent the TMA load from being issued before LDS has completed.

Thanks to [elvircrn](https://github.com/elvircrn)'s script, I've tried my fix on NVL72, the result is correct and the performance is as good as the original implementation.