### PR TITLE
Warn if Linux automatic NUMA balancing is enabled at buffer init

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ The library provides some environment variables, which may be useful:
 - General
     - `EP_BUFFER_DEBUG`: `0` or `1`, print buffer initialization, SM approximation, and backend debugging information, `0` by default
     - `EP_SUPPRESS_NCCL_CHECK`: `0` or `1`, suppress NCCL version mismatch checking, `0` by default
+    - `EP_SUPPRESS_NUMA_CHECK`: `0` or `1`, suppress the Linux automatic NUMA balancing warning at import (see [Performance gotchas](#performance-gotchas)), `0` by default
     - `EP_AVOID_RECORD_STREAM`: `0` or `1`, avoid `record_stream` on output tensors, `0` by default
     - `EP_NUM_TOPK_IDX_BITS`: integer, override the number of bits for top-k index encoding, `0` (auto) by default
 - Networking
@@ -398,6 +399,18 @@ If the hardware supports it, we recommend using the following command to set the
 ```bash
 sudo mlxconfig -y -d mlx5_$i set PCI_ATOMIC_MODE=4
 ```
+
+## Performance gotchas
+
+DeepEP's communication kernels run on the critical path of every MoE step, so host-side interference is directly visible in dispatch/combine latency:
+
+- **Linux automatic NUMA balancing** (`kernel.numa_balancing != 0`, enabled by default on most distros). The `task_numa_work` kernel routine rewrites PTEs at the user/kernel boundary and can add up to 16+ ms to affected `internode_dispatch` invocations (issue #624 trace: 139 invocations over 60 s on a 5.15 kernel running SGLang, avg 5 ms with 2 samples in the 16-31 ms bucket). We recommend disabling it on EP serving nodes:
+
+  ```bash
+  sudo sysctl -w kernel.numa_balancing=0
+  ```
+
+  DeepEP emits a warning at module init if it is still enabled. Silence it with `EP_SUPPRESS_NUMA_CHECK=1` if you cannot toggle the sysctl (e.g. inside a container).
 
 ## Experimental branches
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ sudo mlxconfig -y -d mlx5_$i set PCI_ATOMIC_MODE=4
 
 DeepEP's communication kernels run on the critical path of every MoE step, so host-side interference is directly visible in dispatch/combine latency:
 
-- **Linux automatic NUMA balancing** (`kernel.numa_balancing != 0`, enabled by default on most distros). The `task_numa_work` kernel routine rewrites PTEs at the user/kernel boundary and can add milliseconds of tail latency to `internode_dispatch` calls on some configurations (issue #624 trace on a 5.15 kernel running SGLang: 139 invocations over 60 s, avg 5 ms; a separate test on a 5.10 kernel with frequent internode dispatch showed negligible overhead). If you observe unexpected latency spikes on EP serving nodes, consider disabling it:
+- **Linux automatic NUMA balancing** (`kernel.numa_balancing != 0`, enabled by default on most distros). The kernel hands NUMA page scanning (`task_numa_work`) to busy threads at the user/kernel boundary, and the per-scan cost grows with the process's resident memory. An EP serving process with large memory and a busy dispatch thread is the worst case: the trace in issue #624 (hundreds of GB resident, dispatch thread near 100% CPU) hit 139 invocations over 60 s at 5 ms average, while a smaller-footprint setup reported negligible overhead. If you observe unexpected latency spikes on EP serving nodes, consider disabling it:
 
   ```bash
   sudo sysctl -w kernel.numa_balancing=0

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ sudo mlxconfig -y -d mlx5_$i set PCI_ATOMIC_MODE=4
 
 DeepEP's communication kernels run on the critical path of every MoE step, so host-side interference is directly visible in dispatch/combine latency:
 
-- **Linux automatic NUMA balancing** (`kernel.numa_balancing != 0`, enabled by default on most distros). The `task_numa_work` kernel routine rewrites PTEs at the user/kernel boundary and can add up to 16+ ms to affected `internode_dispatch` invocations (issue #624 trace: 139 invocations over 60 s on a 5.15 kernel running SGLang, avg 5 ms with 2 samples in the 16-31 ms bucket). We recommend disabling it on EP serving nodes:
+- **Linux automatic NUMA balancing** (`kernel.numa_balancing != 0`, enabled by default on most distros). The `task_numa_work` kernel routine rewrites PTEs at the user/kernel boundary and can add milliseconds of tail latency to `internode_dispatch` calls on some configurations (issue #624 trace on a 5.15 kernel running SGLang: 139 invocations over 60 s, avg 5 ms; a separate test on a 5.10 kernel with frequent internode dispatch showed negligible overhead). If you observe unexpected latency spikes on EP serving nodes, consider disabling it:
 
   ```bash
   sudo sysctl -w kernel.numa_balancing=0

--- a/deep_ep/__init__.py
+++ b/deep_ep/__init__.py
@@ -87,10 +87,11 @@ def check_numa_balancing():
         import warnings
         warnings.warn(
             f'Automatic NUMA balancing is enabled (kernel.numa_balancing={value}). '
-            'On some kernel versions and workloads, the page scanner can add '
-            'milliseconds of tail latency to RDMA-based internode dispatch '
-            '(see issue #624 for a 5.15-kernel example). '
-            'If you observe unexpected latency spikes, consider: '
+            'The kernel hands NUMA page scanning (task_numa_work) to busy threads, '
+            'and the per-scan cost grows with process memory. For EP serving '
+            'processes with large resident memory, this can add milliseconds of '
+            'tail latency to internode dispatch (see issue #624). '
+            'If you observe latency spikes, consider: '
             '`sudo sysctl -w kernel.numa_balancing=0`. '
             'Set EP_SUPPRESS_NUMA_CHECK=1 to silence this warning. '
             'Details: https://github.com/deepseek-ai/DeepEP/issues/624',

--- a/deep_ep/__init__.py
+++ b/deep_ep/__init__.py
@@ -86,10 +86,14 @@ def check_numa_balancing():
     if value and value != '0':
         import warnings
         warnings.warn(
-            f'Automatic NUMA balancing is enabled (kernel.numa_balancing={value}), which can add '
-            'up to 16+ ms tail latency to DeepEP internode dispatch. Disable with '
-            '`sudo sysctl -w kernel.numa_balancing=0`, or set EP_SUPPRESS_NUMA_CHECK=1 to silence. '
-            'See https://github.com/deepseek-ai/DeepEP/issues/624.',
+            f'Automatic NUMA balancing is enabled (kernel.numa_balancing={value}). '
+            'On some kernel versions and workloads, the page scanner can add '
+            'milliseconds of tail latency to RDMA-based internode dispatch '
+            '(see issue #624 for a 5.15-kernel example). '
+            'If you observe unexpected latency spikes, consider: '
+            '`sudo sysctl -w kernel.numa_balancing=0`. '
+            'Set EP_SUPPRESS_NUMA_CHECK=1 to silence this warning. '
+            'Details: https://github.com/deepseek-ai/DeepEP/issues/624',
             RuntimeWarning, stacklevel=2)
 
 

--- a/deep_ep/__init__.py
+++ b/deep_ep/__init__.py
@@ -68,6 +68,31 @@ def check_nccl_so():
          f'please contact Chenggang or Shangyan to upgrade PyTorch NCCL version')
 
 
+def check_numa_balancing():
+    """
+    Warn if Linux automatic NUMA balancing is enabled, which can add tail latency to internode dispatch.
+    """
+    if int(os.environ.get('EP_SUPPRESS_NUMA_CHECK', 0)):
+        return
+
+    # Non-Linux systems or unreadable procfs (e.g. containers): skip silently
+    try:
+        with open('/proc/sys/kernel/numa_balancing', 'r') as f:
+            value = f.read().strip()
+    except OSError:
+        return
+
+    # `kernel.numa_balancing` is a bitmask; any non-zero value runs `task_numa_work`
+    if value and value != '0':
+        import warnings
+        warnings.warn(
+            f'Automatic NUMA balancing is enabled (kernel.numa_balancing={value}), which can add '
+            'up to 16+ ms tail latency to DeepEP internode dispatch. Disable with '
+            '`sudo sysctl -w kernel.numa_balancing=0`, or set EP_SUPPRESS_NUMA_CHECK=1 to silence. '
+            'See https://github.com/deepseek-ai/DeepEP/issues/624.',
+            RuntimeWarning, stacklevel=2)
+
+
 def init_jit():
     """
     Initialize the JIT compilation runtime. Sets up CUDA and NCCL root paths for the JIT compiler.
@@ -81,6 +106,7 @@ def init_jit():
 
 # Run initialization
 check_nccl_so()
+check_numa_balancing()
 init_jit()
 
 


### PR DESCRIPTION
## Summary

Adds a startup-time warning when `/proc/sys/kernel/numa_balancing != 0`, plus a new `## Performance gotchas` section in the README documenting the mitigation. Fixes #624.

## Background

`@wenjianhn` reported in #624 that Linux automatic NUMA balancing (`kernel.numa_balancing != 0`, default on most 5.x kernels) periodically rewrites PTEs at the user/kernel boundary via `task_numa_work`, which is directly visible on the `deep_ep::Buffer::internode_dispatch` hot path.

`funclatency -d 60 -m -p <pid> task_numa_work` over 60 s on an SGLang workload:

```
avg = 5 msecs, total: 789 msecs, count: 139
msecs distribution: 0-1: 72, 2-3: 8, 8-15: 57, 16-31: 2
```

139 invocations in 60 s, with 2 samples reaching the 16-31 ms bucket — added directly to the EP critical path.

## Change

- `deep_ep/__init__.py`: new `check_numa_balancing()` helper, called between `check_nccl_so()` and `init_jit()` in the existing init block. Mirrors the `check_nccl_so` pattern (env-var suppress, silent skip on non-Linux, single warning emit). `kernel.numa_balancing` is a bitmask, so the check is `value != '0'` (covers modes 1, 2, and OR-ed combinations, all of which run `task_numa_work`).
- `README.md`: new `## Performance gotchas` section documenting the issue and the `sysctl kernel.numa_balancing=0` mitigation, plus an `EP_SUPPRESS_NUMA_CHECK` entry in the env var listing.

The check is opt-out via `EP_SUPPRESS_NUMA_CHECK=1` for CI / containerized environments where the user cannot toggle the sysctl.

## Validation

- Warning fires when `kernel.numa_balancing` is non-zero:
  ```
  $ python -c "import deep_ep"
  RuntimeWarning: Automatic NUMA balancing is enabled (kernel.numa_balancing=1), which can add ...
  ```
- Silent when `kernel.numa_balancing=0`:
  ```
  $ sudo sysctl -w kernel.numa_balancing=0
  $ python -c "import deep_ep"
  (no warning)
  ```
- Silent when `EP_SUPPRESS_NUMA_CHECK=1`:
  ```
  $ EP_SUPPRESS_NUMA_CHECK=1 python -c "import deep_ep"
  (no warning)
  ```
- Silent on non-Linux (no `/proc/sys/kernel/numa_balancing`): `OSError` caught silently.
- `python -m py_compile deep_ep/__init__.py` passes; `git diff --check` clean; file is excluded from the repository ruff target so no lint conflicts.