### PR TITLE
fix for link error: libnccl.so.2 can not be found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ if __name__ == '__main__':
     # ``libnccl.so.2`` only, so resolve the real name dynamically.
     sources.extend(['csrc/kernels/backend/nccl.cu'])
     include_dirs.extend([f'{nccl_root_dir}/include'])
+    library_dirs.extend([f'{nccl_root_dir}/lib'])
     nccl_lib = get_nccl_lib_name(nccl_root_dir)
     extra_link_args.extend([f'-l:{nccl_lib}', f'-Wl,-rpath,{nccl_root_dir}/lib'])
 

--- a/setup.py
+++ b/setup.py
@@ -58,16 +58,17 @@ def get_package_version():
         status_output = subprocess.check_output(status_cmd).decode('ascii').strip()
         if status_output:
             print(f'Warning: Git working directory is not clean. Uncommitted changes:\n{status_output}')
-            assert False, 'Git working directory is not clean'
+            raise AssertionError('Git working directory is not clean')
 
         cmd = ['git', 'rev-parse', '--short', 'HEAD']
         revision = '+' + subprocess.check_output(cmd).decode('ascii').rstrip()
-    except:
+    except Exception:
         revision = '+local'
     return f'{public_version}{revision}'
 
 
 class CustomBuildPy(build_py):
+
     def run(self):
         # Make clusters' cache setting default into `envs.py`
         self.generate_default_envs()
@@ -98,9 +99,7 @@ if __name__ == '__main__':
     cxx_flags = ['-O3', '-Wno-deprecated-declarations', '-Wno-unused-variable', '-Wno-sign-compare', '-Wno-reorder', '-Wno-attributes']
     nvcc_flags = ['-O3', '-Xcompiler', '-O3', '--extended-lambda', '--diag-suppress=128,2417']
     sources = ['csrc/python_api.cpp', 'csrc/kernels/legacy/layout.cu', 'csrc/kernels/legacy/intranode.cu']
-    include_dirs = [f'{current_dir}/deep_ep/include',
-                    f'{current_dir}/third-party/fmt/include',
-                    '/usr/local/cuda/include/cccl']
+    include_dirs = [f'{current_dir}/deep_ep/include', f'{current_dir}/third-party/fmt/include', '/usr/local/cuda/include/cccl']
     library_dirs = []
     nvcc_dlink = []
     extra_link_args = ['-lcuda']
@@ -137,7 +136,7 @@ if __name__ == '__main__':
         nvcc_flags.append('-DDISABLE_SM90_FEATURES')
 
         # Disable internode and low-latency kernels
-        assert False, 'Not implemented'
+        raise AssertionError('Not implemented')
     else:
         # Prefer H800 series
         os.environ['TORCH_CUDA_ARCH_LIST'] = os.getenv('TORCH_CUDA_ARCH_LIST', '9.0')
@@ -190,30 +189,26 @@ if __name__ == '__main__':
         if name in os.environ:
             persistent_envs.append((name, os.environ[name]))
     if len(persistent_envs) > 0:
-        print(f' > Persistent envs:')
+        print(' > Persistent envs:')
         for k, v in persistent_envs:
             print(f'   > {k}: {v}')
     print()
 
-    setuptools.setup(
-        name='deep_ep',
-        version=get_package_version(),
-        packages=setuptools.find_packages(include=['deep_ep', 'deep_ep.*']),
-        package_data={
-            'deep_ep': [
-                'include/deep_ep/**/*',
-            ]
-        },
-        ext_modules=[
-            CUDAExtension(name='deep_ep._C',
-                          include_dirs=include_dirs,
-                          library_dirs=library_dirs,
-                          sources=sources,
-                          extra_compile_args=extra_compile_args,
-                          extra_link_args=extra_link_args)
-        ],
-        cmdclass={
-            'build_ext': BuildExtension,
-            'build_py': CustomBuildPy
-        }
-    )
+    setuptools.setup(name='deep_ep',
+                     version=get_package_version(),
+                     packages=setuptools.find_packages(include=['deep_ep', 'deep_ep.*']),
+                     package_data={'deep_ep': [
+                         'include/deep_ep/**/*',
+                     ]},
+                     ext_modules=[
+                         CUDAExtension(name='deep_ep._C',
+                                       include_dirs=include_dirs,
+                                       library_dirs=library_dirs,
+                                       sources=sources,
+                                       extra_compile_args=extra_compile_args,
+                                       extra_link_args=extra_link_args)
+                     ],
+                     cmdclass={
+                         'build_ext': BuildExtension,
+                         'build_py': CustomBuildPy
+                     })


### PR DESCRIPTION
fix for link error: libnccl.so.2 can not be found.

link error happens when run `bash build.sh` in Python 3.10.12
```
[9/9] /usr/local/cuda/bin/nvcc /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/cuda_driver.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/nccl.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/nvshmem.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/internode.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/internode_ll.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/intranode.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/layout.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/python_api.o -o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/dlink.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options ''"'"'-fPIC'"'"'' -dlink -L/root/miniconda3/envs/deepepv2/lib/python3.10/site-packages/nvidia/nvshmem/lib -lnvshmem_device -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=_C -gencode=arch=compute_90,code=sm_90
g++ -pthread -B /root/miniconda3/envs/deepepv2/compiler_compat -Wno-unused-result -Wsign-compare -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /root/miniconda3/envs/deepepv2/include -fPIC -O2 -isystem /root/miniconda3/envs/deepepv2/include -shared /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/cuda_driver.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/nccl.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/nvshmem.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/internode.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/internode_ll.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/intranode.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/legacy/layout.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/python_api.o /mnt/deepep-v2/DeepEP/build/temp.linux-x86_64-cpython-310/csrc/kernels/backend/dlink.o -L/root/miniconda3/envs/deepepv2/lib/python3.10/site-packages/nvidia/nvshmem/lib -L/root/miniconda3/envs/deepepv2/lib/python3.10/site-packages/torch/lib -L/usr/local/cuda/lib64 -lc10 -ltorch -ltorch_cpu -ltorch_python -lcudart -lc10_cuda -ltorch_cuda -o build/lib.linux-x86_64-cpython-310/deep_ep/_C.cpython-310-x86_64-linux-gnu.so -lcuda -l:libnvshmem_host.so.3 -l:libnvshmem_device.a -Wl,-rpath,/root/miniconda3/envs/deepepv2/lib/python3.10/site-packages/nvidia/nvshmem/lib -l:libnccl.so.2 -Wl,-rpath,/root/miniconda3/envs/deepepv2/lib/python3.10/site-packages/nvidia/nccl/lib
/root/miniconda3/envs/deepepv2/compiler_compat/ld: cannot find -l:libnccl.so.2: No such file or directory
collect2: error: ld returned 1 exit status
error: command '/usr/bin/g++' failed with exit code 1
```