### PR TITLE
[HybridEP] Add dense top-k routing scan path

### DIFF
--- a/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
+++ b/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
@@ -76,6 +76,14 @@ using Copy_t =
     >::type
   >::type;
 
+template<int NUM_OF_FLOATS>
+inline __device__ void scalar_copy_float_slice(float* dst, const float* src) {
+  #pragma unroll
+  for(int i = 0; i < NUM_OF_FLOATS; i++){
+    dst[i] = src[i];
+  }
+}
+
 enum scan_state{
   EMPTY = 0, 
   PRIV_SUM = 1 
@@ -405,7 +413,7 @@ struct combine_kernel_dynamic_shared_memory_buffer_t<NUM_OF_STAGES_G2S, NUM_OF_S
   // Only used in BW combine.
   alignas(16) float intra_node_prob_S2G_buffer[NUM_OF_STAGES_S2G][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
   // Shared memory prob buffer for inter node red warp group G2S data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
-  // Only used in BW combine. Only the source rank's E_per_rank slice is loaded (sparse prob optimization).
+  // Only used in BW combine. Local NVLink sources load one E_per_rank slice; remote RDMA sources load a full E*R vector.
   alignas(16) float inter_node_prob_G2S_buffer[NUM_OF_STAGES_G2S][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
   // Shared memory prob buffer for inter node red warp group S2G data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
   // Only used in BW combine.
@@ -413,6 +421,8 @@ struct combine_kernel_dynamic_shared_memory_buffer_t<NUM_OF_STAGES_G2S, NUM_OF_S
 
   // Source rank ID for each intra-node G2S prob stage, so the reduction warp group knows where to place the E_per_rank slice.
   int intra_node_prob_src_rank_G2S_buffer[NUM_OF_STAGES_G2S];
+  // Source rank ID for each local-source inter-node G2S prob stage.
+  int inter_node_prob_src_rank_G2S_buffer[NUM_OF_STAGES_G2S];
 
   // Shared memory mbarrier that protect intra node red warp group G2S token entry. 1st for producer->consumer, 2nd for consumer->producer. Should be 8B alignment(natural alignment).
   alignas(8) uint64_t intra_node_mbarrier_G2S_buffer[NUM_OF_STAGES_G2S][2];
@@ -1647,18 +1657,20 @@ inline __device__ void S2G_warp_group_device_function(const int local_rank,
                     // The source SMEM prob buffer contains the full E*R probs (mostly zeros for sparse routing).
                     // Each rank's E_per_rank slice already has zeros at non-active expert positions.
                     if constexpr(FORWARD_DISPATCH){
-                      static_assert(NUM_OF_EXPERTS_PER_RANK * sizeof(float) >= 16,
-                          "NUM_OF_EXPERTS_PER_RANK * sizeof(float) must be >= 16 for TMA minimum transfer size.");
-                      static_assert((NUM_OF_EXPERTS_PER_RANK * sizeof(float)) % 16 == 0,
-                          "NUM_OF_EXPERTS_PER_RANK * sizeof(float) must be 16B-aligned for TMA.");
                       float* remote_prob_addr = remote_expert_output_prob[remote_rank_id]
                           + output_buffer_index * static_cast<int64_t>(NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)
                           + remote_rank_id * NUM_OF_EXPERTS_PER_RANK;
-                      cuda::ptx::cp_async_bulk(cuda::ptx::space_global,
-                                               cuda::ptx::space_shared,
-                                               reinterpret_cast<void*>(remote_prob_addr),
-                                               reinterpret_cast<const void*>(&smem_buffer_ptr->intra_node_prob_buffer[stage][remote_rank_id * NUM_OF_EXPERTS_PER_RANK]),
-                                               (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)));
+                      const float* local_prob_addr = &smem_buffer_ptr->intra_node_prob_buffer[stage][remote_rank_id * NUM_OF_EXPERTS_PER_RANK];
+                      if constexpr(NUM_OF_EXPERTS_PER_RANK * sizeof(float) >= 16 &&
+                                   (NUM_OF_EXPERTS_PER_RANK * sizeof(float)) % 16 == 0){
+                        cuda::ptx::cp_async_bulk(cuda::ptx::space_global,
+                                                 cuda::ptx::space_shared,
+                                                 reinterpret_cast<void*>(remote_prob_addr),
+                                                 reinterpret_cast<const void*>(local_prob_addr),
+                                                 (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)));
+                      } else {
+                        scalar_copy_float_slice<NUM_OF_EXPERTS_PER_RANK>(remote_prob_addr, local_prob_addr);
+                      }
 
                     }
 
@@ -2377,14 +2389,23 @@ inline __device__ void intra_node_G2S_warp_group_device_function(const int node_
                     // Sparse prob optimization: only read the source rank's E_per_rank slice.
                     // The source rank (current_src_token_id) wrote its probs at offset
                     // current_src_token_id * E_per_rank within the E*R_per_node prob vector.
-                    cuda::ptx::cp_async_bulk(cuda::ptx::space_shared,
-                                             cuda::ptx::space_global,
-                                             reinterpret_cast<void*>(&smem_buffer_ptr->intra_node_prob_G2S_buffer[token_stage][0]),
-                                             reinterpret_cast<const void*>(remote_expert_input_prob[current_src_token_id] + (sparse_to_dense_map_value * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)) + current_src_token_id * NUM_OF_EXPERTS_PER_RANK),
-                                             (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)),
-                                             &smem_buffer_ptr->intra_node_mbarrier_G2S_buffer[token_stage][0]);
+                    float* local_prob_addr = &smem_buffer_ptr->intra_node_prob_G2S_buffer[token_stage][0];
+                    const float* remote_prob_addr = remote_expert_input_prob[current_src_token_id]
+                        + sparse_to_dense_map_value * static_cast<int64_t>(NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)
+                        + current_src_token_id * NUM_OF_EXPERTS_PER_RANK;
+                    if constexpr(NUM_OF_EXPERTS_PER_RANK * sizeof(float) >= 16 &&
+                                 (NUM_OF_EXPERTS_PER_RANK * sizeof(float)) % 16 == 0){
+                      cuda::ptx::cp_async_bulk(cuda::ptx::space_shared,
+                                               cuda::ptx::space_global,
+                                               reinterpret_cast<void*>(local_prob_addr),
+                                               reinterpret_cast<const void*>(remote_prob_addr),
+                                               (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)),
+                                               &smem_buffer_ptr->intra_node_mbarrier_G2S_buffer[token_stage][0]);
 
-                    total_tx_size += (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float));
+                      total_tx_size += (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float));
+                    } else {
+                      scalar_copy_float_slice<NUM_OF_EXPERTS_PER_RANK>(local_prob_addr, remote_prob_addr);
+                    }
                     // Store the source rank ID so the reduction warp group can place probs at the correct offset.
                     smem_buffer_ptr->intra_node_prob_src_rank_G2S_buffer[token_stage] = current_src_token_id;
                   }
@@ -3107,14 +3128,23 @@ inline __device__ void inter_node_G2S_warp_group_device_function(const int node_
 
                   if constexpr(BACKWARD_COMBINE){
                     // Sparse prob optimization: only read the source rank's E_per_rank slice.
-                    cuda::ptx::cp_async_bulk(cuda::ptx::space_shared,
-                                             cuda::ptx::space_global,
-                                             reinterpret_cast<void*>(&smem_buffer_ptr->inter_node_prob_G2S_buffer[token_stage][0]),
-                                             reinterpret_cast<const void*>(remote_expert_input_prob[current_src_token_id] + (sparse_to_dense_map_value * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)) + current_src_token_id * NUM_OF_EXPERTS_PER_RANK),
-                                             (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)),
-                                             &smem_buffer_ptr->inter_node_mbarrier_G2S_buffer[token_stage][0]);
+                    float* local_prob_addr = &smem_buffer_ptr->inter_node_prob_G2S_buffer[token_stage][0];
+                    const float* remote_prob_addr = remote_expert_input_prob[current_src_token_id]
+                        + sparse_to_dense_map_value * static_cast<int64_t>(NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)
+                        + current_src_token_id * NUM_OF_EXPERTS_PER_RANK;
+                    if constexpr(NUM_OF_EXPERTS_PER_RANK * sizeof(float) >= 16 &&
+                                 (NUM_OF_EXPERTS_PER_RANK * sizeof(float)) % 16 == 0){
+                      cuda::ptx::cp_async_bulk(cuda::ptx::space_shared,
+                                               cuda::ptx::space_global,
+                                               reinterpret_cast<void*>(local_prob_addr),
+                                               reinterpret_cast<const void*>(remote_prob_addr),
+                                               (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)),
+                                               &smem_buffer_ptr->inter_node_mbarrier_G2S_buffer[token_stage][0]);
 
-                    total_tx_size += (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float));
+                      total_tx_size += (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float));
+                    } else {
+                      scalar_copy_float_slice<NUM_OF_EXPERTS_PER_RANK>(local_prob_addr, remote_prob_addr);
+                    }
                     // Store the source rank ID so the reduction warp group can place probs at the correct offset.
                     smem_buffer_ptr->inter_node_prob_src_rank_G2S_buffer[token_stage] = current_src_token_id;
                   }

--- a/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
+++ b/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
@@ -399,17 +399,20 @@ struct combine_kernel_dynamic_shared_memory_buffer_t<NUM_OF_STAGES_G2S, NUM_OF_S
   alignas(128) uint16_t inter_node_token_S2G_buffer[NUM_OF_STAGES_S2G][HIDDEN_DIM];
 
   // Shared memory prob buffer for intra node red warp group G2S data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
-  // Only used in BW combine.
-  alignas(16) float intra_node_prob_G2S_buffer[NUM_OF_STAGES_G2S][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
+  // Only used in BW combine. Only the source rank's E_per_rank slice is loaded (sparse prob optimization).
+  alignas(16) float intra_node_prob_G2S_buffer[NUM_OF_STAGES_G2S][NUM_OF_EXPERTS_PER_RANK];
   // Shared memory prob buffer for intra node red warp group S2G data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
   // Only used in BW combine.
   alignas(16) float intra_node_prob_S2G_buffer[NUM_OF_STAGES_S2G][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
   // Shared memory prob buffer for inter node red warp group G2S data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
-  // Only used in BW combine.
+  // Only used in BW combine. Only the source rank's E_per_rank slice is loaded (sparse prob optimization).
   alignas(16) float inter_node_prob_G2S_buffer[NUM_OF_STAGES_G2S][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
   // Shared memory prob buffer for inter node red warp group S2G data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
   // Only used in BW combine.
   alignas(16) float inter_node_prob_S2G_buffer[NUM_OF_STAGES_S2G][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES];
+
+  // Source rank ID for each intra-node G2S prob stage, so the reduction warp group knows where to place the E_per_rank slice.
+  int intra_node_prob_src_rank_G2S_buffer[NUM_OF_STAGES_G2S];
 
   // Shared memory mbarrier that protect intra node red warp group G2S token entry. 1st for producer->consumer, 2nd for consumer->producer. Should be 8B alignment(natural alignment).
   alignas(8) uint64_t intra_node_mbarrier_G2S_buffer[NUM_OF_STAGES_G2S][2];
@@ -446,11 +449,14 @@ struct combine_kernel_dynamic_shared_memory_buffer_t<NUM_OF_STAGES_G2S, NUM_OF_S
   alignas(128) uint16_t inter_node_token_S2G_buffer[NUM_OF_STAGES_S2G][HIDDEN_DIM];
 
   // Shared memory prob buffer for inter node red warp group G2S data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
-  // Only used in BW combine.
-  alignas(16) float inter_node_prob_G2S_buffer[NUM_OF_STAGES_G2S][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
+  // Only used in BW combine. Only the source rank's E_per_rank slice is loaded (sparse prob optimization).
+  alignas(16) float inter_node_prob_G2S_buffer[NUM_OF_STAGES_G2S][NUM_OF_EXPERTS_PER_RANK];
   // Shared memory prob buffer for inter node red warp group S2G data movement. Should be 16B alignment so can be used with TMA. 128B is too strict.
   // Only used in BW combine.
   alignas(16) float inter_node_prob_S2G_buffer[NUM_OF_STAGES_S2G][NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
+
+  // Source rank ID for each G2S prob stage, so the reduction warp group knows where to place the E_per_rank slice.
+  int inter_node_prob_src_rank_G2S_buffer[NUM_OF_STAGES_G2S];
 
   // Shared memory mbarrier that protect inter node red warp group G2S token entry. 1st for producer->consumer, 2nd for consumer->producer. Should be 8B alignment(natural alignment).
   alignas(8) uint64_t inter_node_mbarrier_G2S_buffer[NUM_OF_STAGES_G2S][2];
@@ -1637,13 +1643,22 @@ inline __device__ void S2G_warp_group_device_function(const int local_rank,
                                              (uint32_t)(HIDDEN_DIM * sizeof(TOKEN_DATA_TYPE)));
 
                     // Store the prob from shared to remote global for FW dispatch.
+                    // Only send the destination rank's E_per_rank slice (not the full E*R vector).
+                    // The source SMEM prob buffer contains the full E*R probs (mostly zeros for sparse routing).
+                    // Each rank's E_per_rank slice already has zeros at non-active expert positions.
                     if constexpr(FORWARD_DISPATCH){
-                      float* remote_prob_addr = remote_expert_output_prob[remote_rank_id] + (output_buffer_index * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE));
+                      static_assert(NUM_OF_EXPERTS_PER_RANK * sizeof(float) >= 16,
+                          "NUM_OF_EXPERTS_PER_RANK * sizeof(float) must be >= 16 for TMA minimum transfer size.");
+                      static_assert((NUM_OF_EXPERTS_PER_RANK * sizeof(float)) % 16 == 0,
+                          "NUM_OF_EXPERTS_PER_RANK * sizeof(float) must be 16B-aligned for TMA.");
+                      float* remote_prob_addr = remote_expert_output_prob[remote_rank_id]
+                          + output_buffer_index * static_cast<int64_t>(NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)
+                          + remote_rank_id * NUM_OF_EXPERTS_PER_RANK;
                       cuda::ptx::cp_async_bulk(cuda::ptx::space_global,
                                                cuda::ptx::space_shared,
                                                reinterpret_cast<void*>(remote_prob_addr),
-                                               reinterpret_cast<const void*>(&smem_buffer_ptr->intra_node_prob_buffer[stage][0]),
-                                               (uint32_t)((NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) * sizeof(float)));
+                                               reinterpret_cast<const void*>(&smem_buffer_ptr->intra_node_prob_buffer[stage][remote_rank_id * NUM_OF_EXPERTS_PER_RANK]),
+                                               (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)));
 
                     }
 
@@ -2359,14 +2374,19 @@ inline __device__ void intra_node_G2S_warp_group_device_function(const int node_
                   total_tx_size += (uint32_t)(HIDDEN_DIM * sizeof(uint16_t));
 
                   if constexpr(BACKWARD_COMBINE){
+                    // Sparse prob optimization: only read the source rank's E_per_rank slice.
+                    // The source rank (current_src_token_id) wrote its probs at offset
+                    // current_src_token_id * E_per_rank within the E*R_per_node prob vector.
                     cuda::ptx::cp_async_bulk(cuda::ptx::space_shared,
                                              cuda::ptx::space_global,
                                              reinterpret_cast<void*>(&smem_buffer_ptr->intra_node_prob_G2S_buffer[token_stage][0]),
-                                             reinterpret_cast<const void*>(remote_expert_input_prob[current_src_token_id] + (sparse_to_dense_map_value * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE))),
-                                             (uint32_t)((NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) * sizeof(float)),
+                                             reinterpret_cast<const void*>(remote_expert_input_prob[current_src_token_id] + (sparse_to_dense_map_value * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)) + current_src_token_id * NUM_OF_EXPERTS_PER_RANK),
+                                             (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)),
                                              &smem_buffer_ptr->intra_node_mbarrier_G2S_buffer[token_stage][0]);
 
-                    total_tx_size += (uint32_t)((NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) * sizeof(float));
+                    total_tx_size += (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float));
+                    // Store the source rank ID so the reduction warp group can place probs at the correct offset.
+                    smem_buffer_ptr->intra_node_prob_src_rank_G2S_buffer[token_stage] = current_src_token_id;
                   }
 
                   if(current_src_token_id == last_src_token_id){
@@ -2578,12 +2598,16 @@ inline __device__ void intra_node_red_warp_group_device_function(const int node_
             }
 
             if constexpr(BACKWARD_COMBINE){
+              // Sparse prob optimization: SMEM only has E_per_rank elements for the source rank's slice.
+              // Read the source rank ID and accumulate into the correct position in acc_prob.
+              int src_rank = smem_buffer_ptr->intra_node_prob_src_rank_G2S_buffer[token_stage];
+              int prob_offset = src_rank * NUM_OF_EXPERTS_PER_RANK;
               #pragma unroll
               for(int n = 0; n < NUM_OF_PROB_VEC_ELEMENT_PER_THREAD; n++){
-                int element_id = INTRA_NODE_RED_GROUP::thread_rank() + n * INTRA_NODE_RED_GROUP::size();
-                if(element_id < NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE){
-                  float src_data = load_prob_base_ptr[element_id];
-                  acc_prob[n] += src_data;
+                int global_element_id = INTRA_NODE_RED_GROUP::thread_rank() + n * INTRA_NODE_RED_GROUP::size();
+                int local_element_id = global_element_id - prob_offset;
+                if(local_element_id >= 0 && local_element_id < NUM_OF_EXPERTS_PER_RANK){
+                  acc_prob[n] += load_prob_base_ptr[local_element_id];
                 }
               }
             }
@@ -3082,14 +3106,17 @@ inline __device__ void inter_node_G2S_warp_group_device_function(const int node_
                   total_tx_size += (uint32_t)(HIDDEN_DIM * sizeof(uint16_t));
 
                   if constexpr(BACKWARD_COMBINE){
+                    // Sparse prob optimization: only read the source rank's E_per_rank slice.
                     cuda::ptx::cp_async_bulk(cuda::ptx::space_shared,
                                              cuda::ptx::space_global,
                                              reinterpret_cast<void*>(&smem_buffer_ptr->inter_node_prob_G2S_buffer[token_stage][0]),
-                                             reinterpret_cast<const void*>(remote_expert_input_prob[current_src_token_id] + (sparse_to_dense_map_value * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE))),
-                                             (uint32_t)((NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) * sizeof(float)),
+                                             reinterpret_cast<const void*>(remote_expert_input_prob[current_src_token_id] + (sparse_to_dense_map_value * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)) + current_src_token_id * NUM_OF_EXPERTS_PER_RANK),
+                                             (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float)),
                                              &smem_buffer_ptr->inter_node_mbarrier_G2S_buffer[token_stage][0]);
 
-                    total_tx_size += (uint32_t)((NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) * sizeof(float));
+                    total_tx_size += (uint32_t)(NUM_OF_EXPERTS_PER_RANK * sizeof(float));
+                    // Store the source rank ID so the reduction warp group can place probs at the correct offset.
+                    smem_buffer_ptr->inter_node_prob_src_rank_G2S_buffer[token_stage] = current_src_token_id;
                   }
 
                   if(current_src_token_id == last_src_token_id){
@@ -3376,12 +3403,16 @@ inline __device__ void inter_node_red_warp_group_device_function(const int node_
             }
 
             if constexpr(BACKWARD_COMBINE){
+              // Sparse prob optimization: SMEM only has E_per_rank elements for the source rank's slice.
+              // Read the source rank ID and accumulate into the correct position in acc_prob[0].
+              int src_rank = smem_buffer_ptr->inter_node_prob_src_rank_G2S_buffer[token_stage];
+              int prob_offset = src_rank * NUM_OF_EXPERTS_PER_RANK;
               #pragma unroll
               for(int n = 0; n < NUM_OF_PROB_VEC_ELEMENT_PER_THREAD; n++){
-                int element_id = thread_rank_within_pipeline + n * NUM_OF_THREADS_PER_PIPELINE;
-                if(element_id < NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE){
-                  float src_data = load_prob_base_ptr[element_id];
-                  acc_prob[0][n] += src_data;
+                int global_element_id = thread_rank_within_pipeline + n * NUM_OF_THREADS_PER_PIPELINE;
+                int local_element_id = global_element_id - prob_offset;
+                if(local_element_id >= 0 && local_element_id < NUM_OF_EXPERTS_PER_RANK){
+                  acc_prob[0][n] += load_prob_base_ptr[local_element_id];
                 }
               }
             }

--- a/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
+++ b/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
@@ -5459,6 +5459,16 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
     bool token_needed_by_rank_step2[NUM_OF_RANKS_PER_NODE];
     // Sparse mode needs the full routing map for local_expert_routing_map writes later.
     bool token_routing_map[DENSE_ROUTING ? 1 : (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)];
+    constexpr int NUM_LOCAL_EXPERT_MASK_WORDS = (NUM_OF_EXPERTS_PER_RANK + 31) / 32;
+    static_assert(!DENSE_ROUTING || NUM_LOCAL_EXPERT_MASK_WORDS <= 16,
+                  "Dense scan supports up to 512 local experts per rank.");
+    uint32_t local_expert_mask[DENSE_ROUTING ? NUM_LOCAL_EXPERT_MASK_WORDS : 1];
+    if constexpr(DENSE_ROUTING){
+      #pragma unroll
+      for(int k = 0; k < NUM_LOCAL_EXPERT_MASK_WORDS; k++){
+        local_expert_mask[k] = 0;
+      }
+    }
     #pragma unroll
     for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
       token_needed_by_rank_step2[j] = false;
@@ -5482,6 +5492,12 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
             int local_expert_id = expert_id - node_expert_start;
             int rank_within_node = local_expert_id / NUM_OF_EXPERTS_PER_RANK;
             token_needed_by_rank_step2[rank_within_node] = true;
+            int local_expert_start = local_rank * NUM_OF_EXPERTS_PER_RANK;
+            int local_expert_end = local_expert_start + NUM_OF_EXPERTS_PER_RANK;
+            if(local_expert_id >= local_expert_start && local_expert_id < local_expert_end){
+              int local_expert_idx = local_expert_id - local_expert_start;
+              local_expert_mask[local_expert_idx / 32] |= 1u << (local_expert_idx % 32);
+            }
           }
         }
       }
@@ -5539,17 +5555,8 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
           bool token_needed_by_this_local_expert = false;
           if(token_out_of_bound == 0){
             if constexpr(DENSE_ROUTING){
-              // Check if any topk index matches this local expert.
-              int target_expert = node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) + j * NUM_OF_EXPERTS_PER_RANK + k;
-              // Re-load topk indices. The compiler should hoist this out of the k loop.
-              const int16_t* topk_base = input_topk_idx + current_token_id * TOPK;
-              #pragma unroll
-              for(int m = 0; m < TOPK; m++){
-                if((int)topk_base[m] == target_expert){
-                  token_needed_by_this_local_expert = true;
-                  break;
-                }
-              }
+              token_needed_by_this_local_expert =
+                  ((local_expert_mask[k / 32] >> (k % 32)) & 1u) != 0;
             } else {
               token_needed_by_this_local_expert = token_routing_map[j * NUM_OF_EXPERTS_PER_RANK + k];
             }
@@ -5586,18 +5593,7 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
           bool local_expert_bools[NUM_OF_EXPERTS_PER_RANK];
           #pragma unroll
           for(int k = 0; k < NUM_OF_EXPERTS_PER_RANK; k++){
-            local_expert_bools[k] = false;
-          }
-          // Re-load topk indices (or reuse from above if we cached them).
-          const int16_t* topk_base = input_topk_idx + current_token_id * TOPK;
-          int local_expert_start = node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) + local_rank * NUM_OF_EXPERTS_PER_RANK;
-          #pragma unroll
-          for(int k = 0; k < TOPK; k++){
-            int expert_id = (int)topk_base[k];
-            int local_idx = expert_id - local_expert_start;
-            if(local_idx >= 0 && local_idx < NUM_OF_EXPERTS_PER_RANK){
-              local_expert_bools[local_idx] = true;
-            }
+            local_expert_bools[k] = ((local_expert_mask[k / 32] >> (k % 32)) & 1u) != 0;
           }
           // Store as expert_to_rank_t chunks.
           expert_to_rank_t* local_expert_routing_map_store_base_addr = reinterpret_cast<expert_to_rank_t*>(local_expert_routing_map + (final_ex_scan[j] * NUM_OF_EXPERTS_PER_RANK));

--- a/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
+++ b/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
@@ -4858,12 +4858,14 @@ __global__ void combine_kernel(const __grid_constant__ combine_kernel_param_t pa
 template<int NUM_THREADS_PER_BLOCK,
          int NUM_OF_BLOCKS,
          int LOCAL_EXPERTS_PADDING_SIZE, 
+         int MAX_NUM_OF_TOKENS_PER_RANK,
          int NUM_OF_TOKENS_PER_CHUNK, 
          int NUM_OF_RANKS_PER_NODE,
          int NUM_OF_NODES,
-         int NUM_OF_EXPERTS_PER_RANK>
+         int NUM_OF_EXPERTS_PER_RANK,
+         int TOPK = 0>  // 0 = bool routing map mode; >0 = dense topk_idx mode with this K value
 __launch_bounds__(NUM_THREADS_PER_BLOCK, 1)
-__global__ void scan(const bool* input_routing_map, 
+__global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int16_t* (TOPK>0)
                      tmp_state_t* tmp, 
                      tmp_state_t* local_experts_tmp, 
                      int32_t* sparse_to_dense_map, 
@@ -4880,6 +4882,12 @@ __global__ void scan(const bool* input_routing_map,
                      const int local_experts_tokens_limit, // This size MUST be multiple of LOCAL_EXPERTS_PADDING_SIZE!
                      const int num_of_tokens_per_rank)
 {
+  // Dense vs sparse routing mode.
+  constexpr bool DENSE_ROUTING = (TOPK > 0);
+  // Cast input pointer to the correct type.
+  const bool* input_routing_map = DENSE_ROUTING ? nullptr : reinterpret_cast<const bool*>(input_routing_data);
+  const int16_t* input_topk_idx = DENSE_ROUTING ? reinterpret_cast<const int16_t*>(input_routing_data) : nullptr;
+
   // Calculate the warps per block.
   constexpr int WARP_SIZE = 32;
   constexpr int NUM_OF_WARPS_PER_BLOCK = NUM_THREADS_PER_BLOCK / WARP_SIZE;
@@ -4907,7 +4915,7 @@ __global__ void scan(const bool* input_routing_map,
 #endif
   // For each token(row in routing map), calculate how many bytes need to be loaded from the routing map and how to load them.
   static_assert(sizeof(bool) == 1, "Bool is not 1 byte???");
-  constexpr int NUM_OF_BYTES_TO_LOAD_FOR_EACH_TOKEN = NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE;
+  constexpr int NUM_OF_BYTES_TO_LOAD_FOR_EACH_TOKEN = DENSE_ROUTING ? (TOPK * sizeof(int16_t)) : (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE);
   using copy_t = Copy_t<NUM_OF_BYTES_TO_LOAD_FOR_EACH_TOKEN>;
   static_assert(NUM_OF_BYTES_TO_LOAD_FOR_EACH_TOKEN % sizeof(copy_t) == 0, "NUM_OF_BYTES_TO_LOAD_FOR_EACH_TOKEN and copy_t mismatch");
   constexpr int ROUTING_MAP_LOAD_ITER = NUM_OF_BYTES_TO_LOAD_FOR_EACH_TOKEN / sizeof(copy_t);
@@ -5010,47 +5018,99 @@ __global__ void scan(const bool* input_routing_map,
     // We need to calculate the per-node routing info and save back to rdma_to_attn_map.
     bool per_node_routing_info = (current_token_local_rank == local_rank);
     int current_token_rdma_to_attn_map_id = current_token_node_rank * rdma_to_attn_map_size_per_node + current_token_local_id;
-    // Global routing map load base addr for current token.
-    const copy_t* routing_map_load_base_addr = reinterpret_cast<const copy_t*>(input_routing_map + 
-                                                                               current_token_id * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES) + 
-                                                                               node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE));
-
-    // Load the routing map for current token.
-    bool token_routing_map[NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
-    #pragma unroll
-    for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
-      *(reinterpret_cast<copy_t*>(token_routing_map) + j) = routing_map_load_base_addr[j];
-    }
-
-    // Convert the routing map to per rank routing info and accumulate to accumulator.
-    // Also convert the per rank routing info to per node routing info.
-    // When permute fusion is enabled, also accumulate local experts to accumulator.
+    // Load routing data and compute per-rank routing info.
     bool token_needed_by_this_node = false;
+    // Per-rank routing flag array (reused in both modes).
+    bool token_needed_by_rank[NUM_OF_RANKS_PER_NODE];
     #pragma unroll
     for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
-      bool token_needed_by_this_rank = false;
+      token_needed_by_rank[j] = false;
+    }
+
+    if constexpr(DENSE_ROUTING){
+      // Dense mode: load TOPK int16 expert indices and check against rank ranges.
+      // Input layout: [num_total_tokens, TOPK] int16_t (NOT per-node sliced — global expert IDs).
+      // Dropped tokens use -1 as sentinel (negative, so naturally excluded by range checks).
+      const copy_t* topk_load_base_addr = reinterpret_cast<const copy_t*>(input_topk_idx + current_token_id * TOPK);
+      int16_t topk_experts[TOPK];
       #pragma unroll
-      for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
-        int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
-        expert_to_rank_t reduction_data = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
-        if(reduction_data != (expert_to_rank_t)0){
-          token_needed_by_this_rank = true;
-          break;
+      for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
+        *(reinterpret_cast<copy_t*>(topk_experts) + j) = topk_load_base_addr[j];
+      }
+      // Compute per-rank and per-node routing from topk expert indices.
+      // Expert global_id maps to node = global_id / (E_per_rank * R_per_node), rank_within_node = (global_id / E_per_rank) % R_per_node.
+      // We only care about experts on the local node (node_rank).
+      constexpr int EXPERTS_PER_NODE = NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE;
+      int node_expert_start = node_rank * EXPERTS_PER_NODE;
+      int node_expert_end = node_expert_start + EXPERTS_PER_NODE;
+      #pragma unroll
+      for(int k = 0; k < TOPK; k++){
+        int expert_id = (int)topk_experts[k];
+        if(expert_id >= node_expert_start && expert_id < node_expert_end){
+          int local_expert_id = expert_id - node_expert_start;
+          int rank_within_node = local_expert_id / NUM_OF_EXPERTS_PER_RANK;
+          token_needed_by_rank[rank_within_node] = true;
+          token_needed_by_this_node = true;
         }
       }
-      if(token_needed_by_this_rank){
-        token_routing_map_sum[j] += 1;
-        token_needed_by_this_node = true;
+      // Accumulate per-rank sums.
+      #pragma unroll
+      for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
+        if(token_needed_by_rank[j]){
+          token_routing_map_sum[j] += 1;
+        }
       }
 #ifdef HYBRID_EP_BUILD_PERMUTE_FUSION_ENABLE
-      if(j == local_rank){
-        int current_local_expert_id = j * NUM_OF_EXPERTS_PER_RANK;
-        #pragma unroll
-        for(int k = 0; k < NUM_OF_EXPERTS_PER_RANK; k++){
-          token_local_experts_routing_map_sum[k] += (int32_t)(token_routing_map[current_local_expert_id + k]);
+      // For permute fusion: compute per-local-expert routing.
+      #pragma unroll
+      for(int k = 0; k < TOPK; k++){
+        int expert_id = (int)topk_experts[k];
+        int local_expert_start = node_expert_start + local_rank * NUM_OF_EXPERTS_PER_RANK;
+        int local_expert_end = local_expert_start + NUM_OF_EXPERTS_PER_RANK;
+        if(expert_id >= local_expert_start && expert_id < local_expert_end){
+          int local_expert_idx = expert_id - local_expert_start;
+          token_local_experts_routing_map_sum[local_expert_idx] += 1;
         }
       }
 #endif
+    } else {
+      // Sparse bool mode: load E_per_rank * R_per_node bools for local node slice.
+      const copy_t* routing_map_load_base_addr = reinterpret_cast<const copy_t*>(input_routing_map +
+                                                                                  current_token_id * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES) +
+                                                                                  node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE));
+      bool token_routing_map[NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
+      #pragma unroll
+      for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
+        *(reinterpret_cast<copy_t*>(token_routing_map) + j) = routing_map_load_base_addr[j];
+      }
+      // Convert per-expert bools to per-rank bools.
+      #pragma unroll
+      for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
+        bool token_needed_by_this_rank = false;
+        #pragma unroll
+        for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
+          int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
+          expert_to_rank_t reduction_data = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
+          if(reduction_data != (expert_to_rank_t)0){
+            token_needed_by_this_rank = true;
+            break;
+          }
+        }
+        token_needed_by_rank[j] = token_needed_by_this_rank;
+        if(token_needed_by_this_rank){
+          token_routing_map_sum[j] += 1;
+          token_needed_by_this_node = true;
+        }
+#ifdef HYBRID_EP_BUILD_PERMUTE_FUSION_ENABLE
+        if(j == local_rank){
+          int current_local_expert_id = j * NUM_OF_EXPERTS_PER_RANK;
+          #pragma unroll
+          for(int k = 0; k < NUM_OF_EXPERTS_PER_RANK; k++){
+            token_local_experts_routing_map_sum[k] += (int32_t)(token_routing_map[current_local_expert_id + k]);
+          }
+        }
+#endif
+      }
     }
 
     // Save the per node routing info back to rdma_to_attn_map if needed.
@@ -5392,75 +5452,72 @@ __global__ void scan(const bool* input_routing_map,
     bool token_needed_by_dense_chunk_layout = first_token_of_a_chunk && current_token_global_chunk_id > 0 && current_token_global_chunk_id < num_of_total_attn_chunks;
 #endif
 
-    // Global routing map load base addr for current token.
-    const copy_t* routing_map_load_base_addr = reinterpret_cast<const copy_t*>(input_routing_map + 
-                                                                               current_token_id * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES) + 
-                                                                               node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE));
+    // Load routing data for current token (reuse for all ranks).
+    // In dense mode: load TOPK int16 expert indices.
+    // In sparse mode: load E_per_rank * R_per_node bools for local node slice.
+    // Also compute per-rank routing flags.
+    bool token_needed_by_rank_step2[NUM_OF_RANKS_PER_NODE];
+    // Sparse mode needs the full routing map for local_expert_routing_map writes later.
+    bool token_routing_map[DENSE_ROUTING ? 1 : (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)];
+    #pragma unroll
+    for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
+      token_needed_by_rank_step2[j] = false;
+    }
 
-    // Load the routing map for current token. Only load when the token is not out-of-bound.
-    bool token_routing_map[NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
-    if(token_out_of_bound == 0){
-      #pragma unroll
-      for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
-        *(reinterpret_cast<copy_t*>(token_routing_map) + j) = routing_map_load_base_addr[j];
+    if constexpr(DENSE_ROUTING){
+      if(token_out_of_bound == 0){
+        const copy_t* topk_load_base_addr = reinterpret_cast<const copy_t*>(input_topk_idx + current_token_id * TOPK);
+        int16_t topk_experts[TOPK];
+        #pragma unroll
+        for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
+          *(reinterpret_cast<copy_t*>(topk_experts) + j) = topk_load_base_addr[j];
+        }
+        constexpr int EXPERTS_PER_NODE = NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE;
+        int node_expert_start = node_rank * EXPERTS_PER_NODE;
+        int node_expert_end = node_expert_start + EXPERTS_PER_NODE;
+        #pragma unroll
+        for(int k = 0; k < TOPK; k++){
+          int expert_id = (int)topk_experts[k];
+          if(expert_id >= node_expert_start && expert_id < node_expert_end){
+            int local_expert_id = expert_id - node_expert_start;
+            int rank_within_node = local_expert_id / NUM_OF_EXPERTS_PER_RANK;
+            token_needed_by_rank_step2[rank_within_node] = true;
+          }
+        }
+      }
+    } else {
+      // Sparse bool mode: load and reduce as before.
+      const copy_t* routing_map_load_base_addr = reinterpret_cast<const copy_t*>(input_routing_map +
+                                                                                  current_token_id * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES) +
+                                                                                  node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE));
+      if(token_out_of_bound == 0){
+        #pragma unroll
+        for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
+          *(reinterpret_cast<copy_t*>(token_routing_map) + j) = routing_map_load_base_addr[j];
+        }
+      }
+      if(token_out_of_bound == 0){
+        #pragma unroll
+        for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
+          #pragma unroll
+          for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
+            int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
+            expert_to_rank_t reduction_data = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
+            if(reduction_data != (expert_to_rank_t)0){
+              token_needed_by_rank_step2[j] = true;
+              break;
+            }
+          }
+        }
       }
     }
-    
-    // Convert the routing map to per rank routing info for current token, 
-    // then produce the per-rank final exclusive scan within the warp for this tile.
+
+    // Convert the per-rank routing flags to per-rank final exclusive scan within the warp for this tile.
     int32_t final_ex_scan[NUM_OF_RANKS_PER_NODE];
     #pragma unroll
     for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
       int32_t temp_scan = 0;
-      bool token_needed_by_this_rank = false;
-      // Old warp-level scan implementation, using warp shuffle, suitable for general data type, but not fast enough for bool type.
-      // If the token is not out-of-bound, check whether this rank need this token.
-      /*if(token_out_of_bound == 0){
-        #pragma unroll
-        for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
-          int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
-          expert_to_rank_t reduction_data = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
-          if(reduction_data != (expert_to_rank_t)0){
-            token_needed_by_this_rank = true;
-            break;
-          }
-        }
-        if(token_needed_by_this_rank){
-          temp_scan = 1;
-        }else{
-          temp_scan = 0;
-        }
-      }
-      
-      // Each warp perform a inclusive scan from all threads(lanes).
-      #pragma unroll
-      for(int k = 1; k < WARP_SIZE; k *= 2){
-        int32_t temp = __shfl_up_sync(~0, temp_scan, k);
-        if(lane_id >= k){
-          temp_scan += temp;
-        }
-      }
-
-      // The inclusive scan from last lane is the sum of this rank of this tile. Need to accumulate that for later tiles.
-      int32_t temp_sum = __shfl_sync(~0, temp_scan, WARP_SIZE - 1);
-
-      // Make scan exclusive.
-      int32_t exclusive_scan = __shfl_up_sync(~0, temp_scan, 1);
-      temp_scan = (lane_id >= 1) ? exclusive_scan : 0;*/
-
-      // New warp-level scan implementation for bool value, using warp vote instead of warp shuffle. Warp vote is way faster than warp shuffle.
-      // If the token is not out-of-bound, check whether this rank need this token.
-      if(token_out_of_bound == 0){
-        #pragma unroll
-        for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
-          int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
-          expert_to_rank_t reduction_data = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
-          if(reduction_data != (expert_to_rank_t)0){
-            token_needed_by_this_rank = true;
-            break;
-          }
-        }
-      }
+      bool token_needed_by_this_rank = token_needed_by_rank_step2[j];
 
       // Each warp vote to create a bit mask indicating which token is needed by this rank within this tile.
       unsigned vote_result = __ballot_sync(~0, token_needed_by_this_rank);
@@ -5481,7 +5538,21 @@ __global__ void scan(const bool* input_routing_map,
         for(int k = 0; k < NUM_OF_EXPERTS_PER_RANK; k++){
           bool token_needed_by_this_local_expert = false;
           if(token_out_of_bound == 0){
-            token_needed_by_this_local_expert = token_routing_map[j * NUM_OF_EXPERTS_PER_RANK + k];
+            if constexpr(DENSE_ROUTING){
+              // Check if any topk index matches this local expert.
+              int target_expert = node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) + j * NUM_OF_EXPERTS_PER_RANK + k;
+              // Re-load topk indices. The compiler should hoist this out of the k loop.
+              const int16_t* topk_base = input_topk_idx + current_token_id * TOPK;
+              #pragma unroll
+              for(int m = 0; m < TOPK; m++){
+                if((int)topk_base[m] == target_expert){
+                  token_needed_by_this_local_expert = true;
+                  break;
+                }
+              }
+            } else {
+              token_needed_by_this_local_expert = token_routing_map[j * NUM_OF_EXPERTS_PER_RANK + k];
+            }
           }
           unsigned local_expert_vote_result = __ballot_sync(~0, token_needed_by_this_local_expert);
           int32_t local_expert_temp_sum = __popc(local_expert_vote_result);
@@ -5510,11 +5581,37 @@ __global__ void scan(const bool* input_routing_map,
 #else
       // Each thread save local routing map for this token of the local rank to local_expert_routing_map if this token is needed by the local rank.
       if(j == local_rank && token_needed_by_this_rank){
-        expert_to_rank_t* local_expert_routing_map_store_base_addr = reinterpret_cast<expert_to_rank_t*>(local_expert_routing_map + (final_ex_scan[j] * NUM_OF_EXPERTS_PER_RANK));
-        #pragma unroll
-        for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
-          int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
-          local_expert_routing_map_store_base_addr[k] = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
+        if constexpr(DENSE_ROUTING){
+          // Reconstruct per-expert bool routing map from topk indices for the local rank.
+          bool local_expert_bools[NUM_OF_EXPERTS_PER_RANK];
+          #pragma unroll
+          for(int k = 0; k < NUM_OF_EXPERTS_PER_RANK; k++){
+            local_expert_bools[k] = false;
+          }
+          // Re-load topk indices (or reuse from above if we cached them).
+          const int16_t* topk_base = input_topk_idx + current_token_id * TOPK;
+          int local_expert_start = node_rank * (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE) + local_rank * NUM_OF_EXPERTS_PER_RANK;
+          #pragma unroll
+          for(int k = 0; k < TOPK; k++){
+            int expert_id = (int)topk_base[k];
+            int local_idx = expert_id - local_expert_start;
+            if(local_idx >= 0 && local_idx < NUM_OF_EXPERTS_PER_RANK){
+              local_expert_bools[local_idx] = true;
+            }
+          }
+          // Store as expert_to_rank_t chunks.
+          expert_to_rank_t* local_expert_routing_map_store_base_addr = reinterpret_cast<expert_to_rank_t*>(local_expert_routing_map + (final_ex_scan[j] * NUM_OF_EXPERTS_PER_RANK));
+          #pragma unroll
+          for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
+            local_expert_routing_map_store_base_addr[k] = *(reinterpret_cast<expert_to_rank_t*>(local_expert_bools) + k);
+          }
+        } else {
+          expert_to_rank_t* local_expert_routing_map_store_base_addr = reinterpret_cast<expert_to_rank_t*>(local_expert_routing_map + (final_ex_scan[j] * NUM_OF_EXPERTS_PER_RANK));
+          #pragma unroll
+          for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
+            int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
+            local_expert_routing_map_store_base_addr[k] = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
+          }
         }
       }
 #endif
@@ -5563,37 +5660,54 @@ __global__ void scan(const bool* input_routing_map,
       int current_token_node_id = current_token_attn_to_rdma_map_node_id < node_rank ? current_token_attn_to_rdma_map_node_id : current_token_attn_to_rdma_map_node_id + 1;
       int current_token_local_id = current_token_id / (NUM_OF_NODES - 1);
 
-      const copy_t* routing_map_load_base_addr = reinterpret_cast<const copy_t*>(input_routing_map + 
-                                                                                ((node_rank * NUM_OF_RANKS_PER_NODE + local_rank) * num_of_tokens_per_rank + current_token_local_id) *
-                                                                                (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES) + 
-                                                                                (current_token_node_id * NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE));
-
       bool* attn_to_rdma_map_base_addr = attn_to_rdma_map + (current_token_local_id * (NUM_OF_NODES - 1) + current_token_attn_to_rdma_map_node_id);
 
-      // Load the routing map for current token row.
-      bool token_routing_map[NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
-      #pragma unroll
-      for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
-        *(reinterpret_cast<copy_t*>(token_routing_map) + j) = routing_map_load_base_addr[j];
-      }
-
-      // Convert the routing map to per rank routing info and then to per node routing info.
+      // Check if any expert on the target node is needed by this token.
       bool token_needed_by_this_node = false;
-      #pragma unroll
-      for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
-        bool token_needed_by_this_rank = false;
+
+      if constexpr(DENSE_ROUTING){
+        // Dense mode: check if any topk expert falls on current_token_node_id.
+        // The global token id for this local token on the local rank.
+        int global_token_id = (node_rank * NUM_OF_RANKS_PER_NODE + local_rank) * num_of_tokens_per_rank + current_token_local_id;
+        const int16_t* topk_base = input_topk_idx + global_token_id * TOPK;
+        constexpr int EXPERTS_PER_NODE = NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE;
+        int target_node_expert_start = current_token_node_id * EXPERTS_PER_NODE;
+        int target_node_expert_end = target_node_expert_start + EXPERTS_PER_NODE;
         #pragma unroll
-        for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
-          int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
-          expert_to_rank_t reduction_data = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map) + current_expert_to_rank_t_id);
-          if(reduction_data != (expert_to_rank_t)0){
-            token_needed_by_this_rank = true;
+        for(int k = 0; k < TOPK; k++){
+          int expert_id = (int)topk_base[k];
+          if(expert_id >= target_node_expert_start && expert_id < target_node_expert_end){
+            token_needed_by_this_node = true;
             break;
           }
         }
-        if(token_needed_by_this_rank){
-          token_needed_by_this_node = true;
-          break;
+      } else {
+        // Sparse bool mode: load routing map for target node and reduce.
+        const copy_t* routing_map_load_base_addr = reinterpret_cast<const copy_t*>(input_routing_map +
+                                                                                   ((node_rank * NUM_OF_RANKS_PER_NODE + local_rank) * num_of_tokens_per_rank + current_token_local_id) *
+                                                                                   (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES) +
+                                                                                   (current_token_node_id * NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE));
+        bool token_routing_map_step3[NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE];
+        #pragma unroll
+        for(int j = 0; j < ROUTING_MAP_LOAD_ITER; j++){
+          *(reinterpret_cast<copy_t*>(token_routing_map_step3) + j) = routing_map_load_base_addr[j];
+        }
+        #pragma unroll
+        for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
+          bool token_needed_by_this_rank = false;
+          #pragma unroll
+          for(int k = 0; k < EXPERTS_TO_RANK_REDUCE_ITER; k++){
+            int current_expert_to_rank_t_id = j * EXPERTS_TO_RANK_REDUCE_ITER + k;
+            expert_to_rank_t reduction_data = *(reinterpret_cast<expert_to_rank_t*>(token_routing_map_step3) + current_expert_to_rank_t_id);
+            if(reduction_data != (expert_to_rank_t)0){
+              token_needed_by_this_rank = true;
+              break;
+            }
+          }
+          if(token_needed_by_this_rank){
+            token_needed_by_this_node = true;
+            break;
+          }
         }
       }
 
@@ -5660,8 +5774,10 @@ public:
            // Block size for preprocessing kernel.
            int NUM_THREADS_PER_BLOCK, 
            // Grid size for preprocessing kernel(1:1 block:SM mapping).
-           int NUM_OF_BLOCKS>
-  static void metadata_preprocessing(const bool* input_routing_map, 
+           int NUM_OF_BLOCKS,
+           // 0 = bool routing map mode; >0 = dense topk_idx mode with this K value
+           int TOPK = 0>
+  static void metadata_preprocessing(const void* input_routing_data,  // bool* (TOPK==0) or int16_t* (TOPK>0)
                                      tmp_state_t* preprocessing_tmp,
                                      tmp_state_t* preprocessing_local_experts_tmp,
                                      int32_t* sparse_to_dense_map,
@@ -5700,9 +5816,9 @@ public:
 #endif
 
     // Launch the preprocessing kernel to process the global routing map.
-    scan<NUM_THREADS_PER_BLOCK, NUM_OF_BLOCKS, LOCAL_EXPERTS_PADDING_SIZE, NUM_OF_TOKENS_PER_CHUNK, NUM_OF_RANKS_PER_NODE, NUM_OF_NODES, NUM_OF_EXPERTS_PER_RANK>
+    scan<NUM_THREADS_PER_BLOCK, NUM_OF_BLOCKS, LOCAL_EXPERTS_PADDING_SIZE, MAX_NUM_OF_TOKENS_PER_RANK, NUM_OF_TOKENS_PER_CHUNK, NUM_OF_RANKS_PER_NODE, NUM_OF_NODES, NUM_OF_EXPERTS_PER_RANK, TOPK>
     <<<NUM_OF_BLOCKS, NUM_THREADS_PER_BLOCK, 0, stream>>>
-    (input_routing_map, preprocessing_tmp, preprocessing_local_experts_tmp, sparse_to_dense_map, rdma_to_attn_map, attn_to_rdma_map, num_of_tokens_for_experts, local_expert_routing_map, 
+    (input_routing_data, preprocessing_tmp, preprocessing_local_experts_tmp, sparse_to_dense_map, rdma_to_attn_map, attn_to_rdma_map, num_of_tokens_for_experts, local_expert_routing_map,
     dense_chunk_layout, dense_to_expert_map, num_of_local_experts_tokens, token_drop_triggered, node_rank, local_rank, local_experts_tokens_limit, num_of_tokens_per_rank);
 
     // Check if there is any CUDA error.

--- a/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
+++ b/csrc/hybrid_ep/backend/hybrid_ep_backend.cuh
@@ -4943,6 +4943,10 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
   //static_assert(NUM_OF_RANKS_PER_NODE % sizeof(rank_to_node_t) == 0, "NUM_OF_RANKS_PER_NODE and rank_to_node_t mismatch");
   //constexpr int RANKS_TO_NODE_REDUCE_ITER = NUM_OF_RANKS_PER_NODE / sizeof(rank_to_node_t);
 
+  constexpr int NUM_RANK_MASK_WORDS = (NUM_OF_RANKS_PER_NODE + 31) / 32;
+  static_assert(!DENSE_ROUTING || NUM_RANK_MASK_WORDS <= 16,
+                "Dense scan supports up to 512 ranks per node.");
+
   // How do a warp save per-rank routing info back to shared memory. What's the max number of elements does each thread save back.
   constexpr int NUM_OF_RANKS_PER_THREAD = ((NUM_OF_RANKS_PER_NODE - 1) / WARP_SIZE) + 1;
 #ifdef HYBRID_EP_BUILD_PERMUTE_FUSION_ENABLE
@@ -5020,11 +5024,20 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
     int current_token_rdma_to_attn_map_id = current_token_node_rank * rdma_to_attn_map_size_per_node + current_token_local_id;
     // Load routing data and compute per-rank routing info.
     bool token_needed_by_this_node = false;
-    // Per-rank routing flag array (reused in both modes).
-    bool token_needed_by_rank[NUM_OF_RANKS_PER_NODE];
-    #pragma unroll
-    for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
-      token_needed_by_rank[j] = false;
+    // Per-rank routing flags. Dense mode uses a compact bitset to avoid a large
+    // per-thread bool array when the NVL domain has many ranks.
+    bool token_needed_by_rank[DENSE_ROUTING ? 1 : NUM_OF_RANKS_PER_NODE];
+    uint32_t rank_mask[DENSE_ROUTING ? NUM_RANK_MASK_WORDS : 1];
+    if constexpr(DENSE_ROUTING){
+      #pragma unroll
+      for(int j = 0; j < NUM_RANK_MASK_WORDS; j++){
+        rank_mask[j] = 0;
+      }
+    } else {
+      #pragma unroll
+      for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
+        token_needed_by_rank[j] = false;
+      }
     }
 
     if constexpr(DENSE_ROUTING){
@@ -5049,14 +5062,14 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
         if(expert_id >= node_expert_start && expert_id < node_expert_end){
           int local_expert_id = expert_id - node_expert_start;
           int rank_within_node = local_expert_id / NUM_OF_EXPERTS_PER_RANK;
-          token_needed_by_rank[rank_within_node] = true;
+          rank_mask[rank_within_node / 32] |= 1u << (rank_within_node % 32);
           token_needed_by_this_node = true;
         }
       }
       // Accumulate per-rank sums.
       #pragma unroll
       for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
-        if(token_needed_by_rank[j]){
+        if(((rank_mask[j / 32] >> (j % 32)) & 1u) != 0){
           token_routing_map_sum[j] += 1;
         }
       }
@@ -5456,22 +5469,28 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
     // In dense mode: load TOPK int16 expert indices.
     // In sparse mode: load E_per_rank * R_per_node bools for local node slice.
     // Also compute per-rank routing flags.
-    bool token_needed_by_rank_step2[NUM_OF_RANKS_PER_NODE];
+    bool token_needed_by_rank_step2[DENSE_ROUTING ? 1 : NUM_OF_RANKS_PER_NODE];
     // Sparse mode needs the full routing map for local_expert_routing_map writes later.
     bool token_routing_map[DENSE_ROUTING ? 1 : (NUM_OF_EXPERTS_PER_RANK * NUM_OF_RANKS_PER_NODE)];
     constexpr int NUM_LOCAL_EXPERT_MASK_WORDS = (NUM_OF_EXPERTS_PER_RANK + 31) / 32;
     static_assert(!DENSE_ROUTING || NUM_LOCAL_EXPERT_MASK_WORDS <= 16,
                   "Dense scan supports up to 512 local experts per rank.");
     uint32_t local_expert_mask[DENSE_ROUTING ? NUM_LOCAL_EXPERT_MASK_WORDS : 1];
+    uint32_t rank_mask[DENSE_ROUTING ? NUM_RANK_MASK_WORDS : 1];
     if constexpr(DENSE_ROUTING){
       #pragma unroll
       for(int k = 0; k < NUM_LOCAL_EXPERT_MASK_WORDS; k++){
         local_expert_mask[k] = 0;
       }
-    }
-    #pragma unroll
-    for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
-      token_needed_by_rank_step2[j] = false;
+      #pragma unroll
+      for(int k = 0; k < NUM_RANK_MASK_WORDS; k++){
+        rank_mask[k] = 0;
+      }
+    } else {
+      #pragma unroll
+      for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
+        token_needed_by_rank_step2[j] = false;
+      }
     }
 
     if constexpr(DENSE_ROUTING){
@@ -5491,7 +5510,7 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
           if(expert_id >= node_expert_start && expert_id < node_expert_end){
             int local_expert_id = expert_id - node_expert_start;
             int rank_within_node = local_expert_id / NUM_OF_EXPERTS_PER_RANK;
-            token_needed_by_rank_step2[rank_within_node] = true;
+            rank_mask[rank_within_node / 32] |= 1u << (rank_within_node % 32);
             int local_expert_start = local_rank * NUM_OF_EXPERTS_PER_RANK;
             int local_expert_end = local_expert_start + NUM_OF_EXPERTS_PER_RANK;
             if(local_expert_id >= local_expert_start && local_expert_id < local_expert_end){
@@ -5533,7 +5552,12 @@ __global__ void scan(const void* input_routing_data,  // bool* (TOPK==0) or int1
     #pragma unroll
     for(int j = 0; j < NUM_OF_RANKS_PER_NODE; j++){
       int32_t temp_scan = 0;
-      bool token_needed_by_this_rank = token_needed_by_rank_step2[j];
+      bool token_needed_by_this_rank;
+      if constexpr(DENSE_ROUTING){
+        token_needed_by_this_rank = ((rank_mask[j / 32] >> (j % 32)) & 1u) != 0;
+      } else {
+        token_needed_by_this_rank = token_needed_by_rank_step2[j];
+      }
 
       // Each warp vote to create a bit mask indicating which token is needed by this rank within this tile.
       unsigned vote_result = __ballot_sync(~0, token_needed_by_this_rank);

--- a/csrc/hybrid_ep/config.cuh
+++ b/csrc/hybrid_ep/config.cuh
@@ -287,13 +287,23 @@ static SmemSizes compute_smem_sizes(const HybridEpConfigInstance& c) {
         b.add((int64_t)c.num_of_stages_s2g_combine_api * c.hidden_dim * 2, 128);
         if (c.backward_combine_api) {
             if (multinode) {
-                b.add((int64_t)c.num_of_stages_g2s_combine_api * c.num_of_experts_per_rank * c.num_of_ranks_per_node * 4, 16);
+                // intra_node_prob_G2S: E_per_rank per stage (sparse prob optimization)
+                b.add((int64_t)c.num_of_stages_g2s_combine_api * c.num_of_experts_per_rank * 4, 16);
+                // intra_node_prob_S2G: E*R per stage (full vector for RDMA)
                 b.add((int64_t)c.num_of_stages_s2g_combine_api * c.num_of_experts_per_rank * c.num_of_ranks_per_node * 4, 16);
+                // inter_node_prob_G2S: E*R per stage (reads from RDMA landing buffer, already reduced)
                 b.add((int64_t)c.num_of_stages_g2s_combine_api * c.num_of_experts_per_rank * c.num_of_ranks_per_node * 4, 16);
+                // inter_node_prob_S2G: E*R*N per stage
                 b.add((int64_t)c.num_of_stages_s2g_combine_api * c.num_of_experts_per_rank * c.num_of_ranks_per_node * c.num_of_nodes * 4, 16);
+                // intra_node_prob_src_rank: int per stage
+                b.add((int64_t)c.num_of_stages_g2s_combine_api * 4, 4);
             } else {
-                b.add((int64_t)c.num_of_stages_g2s_combine_api * c.num_of_experts_per_rank * c.num_of_ranks_per_node * 4, 16);
+                // inter_node_prob_G2S: E_per_rank per stage (sparse prob optimization)
+                b.add((int64_t)c.num_of_stages_g2s_combine_api * c.num_of_experts_per_rank * 4, 16);
+                // inter_node_prob_S2G: E*R per stage
                 b.add((int64_t)c.num_of_stages_s2g_combine_api * c.num_of_experts_per_rank * c.num_of_ranks_per_node * 4, 16);
+                // inter_node_prob_src_rank: int per stage
+                b.add((int64_t)c.num_of_stages_g2s_combine_api * 4, 4);
             }
         }
         if (multinode)

--- a/csrc/hybrid_ep/config.cuh
+++ b/csrc/hybrid_ep/config.cuh
@@ -297,6 +297,8 @@ static SmemSizes compute_smem_sizes(const HybridEpConfigInstance& c) {
                 b.add((int64_t)c.num_of_stages_s2g_combine_api * c.num_of_experts_per_rank * c.num_of_ranks_per_node * c.num_of_nodes * 4, 16);
                 // intra_node_prob_src_rank: int per stage
                 b.add((int64_t)c.num_of_stages_g2s_combine_api * 4, 4);
+                // inter_node_prob_src_rank: int per stage for local-source G2S entries
+                b.add((int64_t)c.num_of_stages_g2s_combine_api * 4, 4);
             } else {
                 // inter_node_prob_G2S: E_per_rank per stage (sparse prob optimization)
                 b.add((int64_t)c.num_of_stages_g2s_combine_api * c.num_of_experts_per_rank * 4, 16);

--- a/csrc/hybrid_ep/config.cuh
+++ b/csrc/hybrid_ep/config.cuh
@@ -113,7 +113,9 @@ struct HybridEpConfigInstance {
   int num_of_ranks_per_node;
   int num_of_nodes;
   int pad_multiple;
-  int topk;  // 0 = sparse bool routing map; >0 = dense int16 topk_idx mode
+  // 0 = sparse bool routing map; >0 = dense int16 topk_idx mode. Dense mode
+  // specializes preprocessing kernels by TOPK, so expected K values should be bounded.
+  int topk;
 
   /*
    *  Metadata-preprocessing API Config

--- a/csrc/hybrid_ep/config.cuh
+++ b/csrc/hybrid_ep/config.cuh
@@ -113,6 +113,7 @@ struct HybridEpConfigInstance {
   int num_of_ranks_per_node;
   int num_of_nodes;
   int pad_multiple;
+  int topk;  // 0 = sparse bool routing map; >0 = dense int16 topk_idx mode
 
   /*
    *  Metadata-preprocessing API Config
@@ -452,6 +453,7 @@ public:
         config.num_of_additional_in_flight_s2g_unpermute_block_combine_api = get_env_int("NUM_OF_ADDITIONAL_IN_FLIGHT_S2G_UNPERMUTE_BLOCK_COMBINE_API", 2);
         
         config.pad_multiple = 1;
+        config.topk = 0;  // default: sparse bool routing map
 
         // If we use the fused permute-dispatch kernel, the number of blocks
         // for the permute part is the same as the number of blocks for the dispatch part.

--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -301,6 +301,19 @@ void Executor::dispatch_core(HybridEpConfigInstance config, DispatchArgs& args) 
     param.multinode_aux_ptr = reinterpret_cast<void*>(inter_node_dispatch_buffers->mr_info);
 #endif
 #endif
+    static constexpr bool kZeroDispatchProbBufferBeforeSparseWrites = false;
+    if constexpr (kZeroDispatchProbBufferBeforeSparseWrites) {
+        if (config.forward_dispatch_api && args.num_dispatched_tokens_tensor.has_value()) {
+            // Sparse prob dispatch writes only the destination rank's E_per_rank slice.
+            // A dense memset would preserve the old full-probs output contract, but it can be
+            // redundant and expensive when TOPK is large, so keep this path disabled by default.
+            int num_dispatched_tokens = args.num_dispatched_tokens_tensor.value().item<int>();
+            size_t probs_sz = static_cast<size_t>(num_dispatched_tokens) *
+                config.num_of_experts_per_rank * config.num_of_ranks_per_node * sizeof(float);
+            CUDA_CHECK(cudaMemsetAsync(intra_node_dispatch_buffers->expert_output_prob, 0, probs_sz, args.stream));
+        }
+    }
+
     // Launch kernel
     kernel_cache.run_dispatch_kernel<DType>(config, param, args.fuse_permute_dispatch, args.non_blocking, args.stream);
     nvtxRangePop();  // End of dispatch_core nvtx range

--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -33,6 +33,8 @@ torch::Tensor Executor::allgather_routing_map(
     auto num_of_tokens_per_rank = local_routing_map.size(-2);
     auto group_size = process_group.attr("size")().cast<int>();
     bool dense_routing = (config.topk > 0);
+    // Custom allgather requires 16B-aligned payloads. Dense int16 routing falls back
+    // to NCCL when num_tokens * TOPK * sizeof(int16_t) is not aligned.
     bool custom_allgather_aligned = (local_routing_map.numel() * local_routing_map.element_size()) % 16 == 0;
     if (!dense_routing) {
         assert(num_cols == config.num_of_experts_per_rank * config.num_of_ranks_per_node * config.num_of_nodes);

--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -29,25 +29,40 @@ torch::Tensor Executor::allgather_routing_map(
     nvtxRangePushA("allgather_routing_map in hybrid-ep");
 
     auto torch_distributed = py::module_::import("torch.distributed");
-    auto num_of_expert = local_routing_map.size(-1);
+    auto num_cols = local_routing_map.size(-1);  // E_total (sparse) or TOPK (dense)
     auto num_of_tokens_per_rank = local_routing_map.size(-2);
     auto group_size = process_group.attr("size")().cast<int>();
-    assert(num_of_expert == config.num_of_experts_per_rank * config.num_of_ranks_per_node * config.num_of_nodes);
+    bool dense_routing = (config.topk > 0);
+    bool custom_allgather_aligned = (local_routing_map.numel() * local_routing_map.element_size()) % 16 == 0;
+    if (!dense_routing) {
+        assert(num_cols == config.num_of_experts_per_rank * config.num_of_ranks_per_node * config.num_of_nodes);
+    } else {
+        assert(num_cols == config.topk);
+    }
+    auto dtype = dense_routing ? torch::kInt16 : torch::kBool;
 
     torch::Tensor global_routing_map;
     // At inter-node case, we will use NCCL allgather
-    if(config.num_of_nodes > 1 || !enable_custom_allgather) {
+    if(config.num_of_nodes > 1 || !enable_custom_allgather || !custom_allgather_aligned) {
         global_routing_map = torch::empty(
-            {num_of_tokens_per_rank * group_size, num_of_expert},
-            torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA)
+            {num_of_tokens_per_rank * group_size, num_cols},
+            torch::TensorOptions().dtype(dtype).device(torch::kCUDA)
         );
-        torch_distributed.attr("all_gather_into_tensor")(global_routing_map, local_routing_map, process_group);
+        if (dense_routing) {
+            // NCCL does not support int16 directly. View as int8 for the collective,
+            // then reinterpret the gathered bytes through the int16 output tensor.
+            auto local_as_bytes = local_routing_map.view(torch::kInt8);
+            auto global_as_bytes = global_routing_map.view(torch::kInt8);
+            torch_distributed.attr("all_gather_into_tensor")(global_as_bytes, local_as_bytes, process_group);
+        } else {
+            torch_distributed.attr("all_gather_into_tensor")(global_routing_map, local_routing_map, process_group);
+        }
     } else { // At intra-node case, we will use custom allgather
         allgather_obj.launch(local_routing_map, /*NUM_OF_SMS=*/32, at::cuda::getCurrentCUDAStream());
         global_routing_map = torch::from_blob(
             allgather_obj.get_output_buffer(), 
-            {num_of_tokens_per_rank * group_size, num_of_expert},
-            torch::TensorOptions().dtype(torch::kBool).device(torch::kCUDA)
+            {num_of_tokens_per_rank * group_size, num_cols},
+            torch::TensorOptions().dtype(dtype).device(torch::kCUDA)
         );
     }
 
@@ -133,7 +148,7 @@ HandleImpl Executor::metadata_preprocess_core(
   }
 
   kernel_cache.run_preprocess_kernel(
-      config, global_routing_map.data_ptr<bool>(), 
+      config, global_routing_map.data_ptr(),
       preprocessing_tmp, preprocessing_local_experts_tmp,
       handle.sparse_to_dense_map.data_ptr<int32_t>(),
       handle.rdma_to_attn_map.data_ptr<bool>(), handle.attn_to_rdma_map.data_ptr<bool>(),

--- a/csrc/hybrid_ep/extension/allgather.cu
+++ b/csrc/hybrid_ep/extension/allgather.cu
@@ -3,6 +3,9 @@
 
 #include "allgather.cuh"
 
+#include <algorithm>
+#include <cstdint>
+
 #define MAX_BLOCKS 256
 #define TIMEOUT 20000000000ull
 
@@ -115,6 +118,7 @@ void CustomAllgather::init(pybind11::object process_group, int rank_idx, BufferC
     this->num_of_experts_per_rank = buffer_config.num_of_experts_per_rank;
     this->num_of_tokens_per_rank = buffer_config.max_num_of_tokens_per_rank;
     this->num_of_nodes = buffer_config.num_of_nodes;
+    this->routing_bytes_per_token = num_of_experts_per_rank * num_of_ranks_per_node * num_of_nodes * sizeof(bool);
     this->allocator = allocator;
     this->process_group = process_group;
 }
@@ -125,6 +129,9 @@ bool CustomAllgather::grow_buffer_config(const HybridEpConfigInstance& config, B
     changed |= grow_to(buf_config.num_of_experts_per_rank, config.num_of_experts_per_rank);
     changed |= grow_to(buf_config.max_num_of_tokens_per_rank, config.max_num_of_tokens_per_rank);
     changed |= grow_to(buf_config.num_of_nodes, config.num_of_nodes);
+    int sparse_bytes_per_token = config.num_of_experts_per_rank * config.num_of_ranks_per_node * config.num_of_nodes * sizeof(bool);
+    int dense_bytes_per_token = config.topk > 0 ? config.topk * static_cast<int>(sizeof(int16_t)) : 0;
+    changed |= grow_to(routing_bytes_per_token, std::max(sparse_bytes_per_token, dense_bytes_per_token));
     return changed;
 }
 
@@ -141,9 +148,7 @@ void CustomAllgather::allocate_buffers() {
 
 void CustomAllgather::allocate_ag_buffer() {
     // Allocate the output buffer
-    auto num_of_expert = num_of_experts_per_rank * num_of_ranks_per_node * num_of_nodes;
-    auto gathered_elets = num_of_expert * num_of_tokens_per_rank * num_of_ranks_per_node * num_of_nodes;
-    auto gathered_bytes = gathered_elets * sizeof(bool);
+    auto gathered_bytes = routing_bytes_per_token * num_of_tokens_per_rank * num_of_ranks_per_node * num_of_nodes;
     allocator->allocate(&dst_buffer, gathered_bytes);
 
     if(num_of_nodes == 1) {

--- a/csrc/hybrid_ep/extension/allgather.cuh
+++ b/csrc/hybrid_ep/extension/allgather.cuh
@@ -38,6 +38,7 @@ private:
     int num_of_experts_per_rank;
     int num_of_tokens_per_rank;
     int num_of_nodes;
+    int routing_bytes_per_token;
     ExtendedMemoryAllocator *allocator;
     pybind11::object process_group;
 };

--- a/csrc/hybrid_ep/jit/compiler.cu
+++ b/csrc/hybrid_ep/jit/compiler.cu
@@ -208,7 +208,8 @@ std::string NVCCCompiler::get_metadata_preprocessing_code(HybridEpConfigInstance
          std::to_string(config.num_of_ranks_per_node) + ", " + std::to_string(config.num_of_nodes) + ", " +
          std::to_string(config.num_of_experts_per_rank) + ">::metadata_preprocessing<" +
          std::to_string(config.pad_multiple) + ", " + std::to_string(config.num_of_tokens_per_chunk_preprocessing_api) + ", " +
-         std::to_string(config.num_of_threads_per_block_preprocessing_api) + ", " + std::to_string(config.num_of_blocks_preprocessing_api) + R"(>;
+         std::to_string(config.num_of_threads_per_block_preprocessing_api) + ", " + std::to_string(config.num_of_blocks_preprocessing_api) + ", " +
+         std::to_string(config.topk) + R"(>;
             return func_ptr;
           }
         }
@@ -280,7 +281,7 @@ node_rank(node_rank), local_rank(local_rank), nvcc_compiler(base_path, comm_id) 
 
 void KernelCache::run_preprocess_kernel(
     HybridEpConfigInstance config, 
-    const bool* input_routing_map,
+    const void* input_routing_map,
     hybrid_ep::tmp_state_t* preprocessing_tmp,
     hybrid_ep::tmp_state_t* preprocessing_local_experts_tmp,
     int32_t* sparse_to_dense_map,
@@ -312,6 +313,7 @@ void KernelCache::run_preprocess_kernel(
         config.num_of_tokens_per_chunk_preprocessing_api,
         config.num_of_threads_per_block_preprocessing_api,
         config.num_of_blocks_preprocessing_api,
+        config.topk,
         fuse_permute_dispatch,
         non_blocking
     );
@@ -325,7 +327,7 @@ void KernelCache::run_preprocess_kernel(
     auto preprocessing_instance = kernel_cache[preprocess_kernel_key];
 
     // Cast the function pointer to the correct type
-    using PreprocessingFuncPtr = void (*)(const bool*, hybrid_ep::tmp_state_t*, hybrid_ep::tmp_state_t*, int32_t*, bool*, bool*, int32_t*, bool*, int32_t*, int32_t*, int32_t*, int*, const int, const int, const int, const int, cudaStream_t);
+    using PreprocessingFuncPtr = void (*)(const void*, hybrid_ep::tmp_state_t*, hybrid_ep::tmp_state_t*, int32_t*, bool*, bool*, int32_t*, bool*, int32_t*, int32_t*, int32_t*, int*, const int, const int, const int, const int, cudaStream_t);
     auto func_ptr = std::any_cast<PreprocessingFuncPtr>(preprocessing_instance);
 
     // Run the kernel
@@ -454,5 +456,4 @@ void KernelCache::run_combine_kernel(
     // Run the kernel
     func_ptr(param, stream);
 }
-
 

--- a/csrc/hybrid_ep/jit/compiler.cuh
+++ b/csrc/hybrid_ep/jit/compiler.cuh
@@ -70,7 +70,7 @@ public:
 
     void run_preprocess_kernel(
         HybridEpConfigInstance config, 
-        const bool* input_routing_map,
+        const void* input_routing_map,
         hybrid_ep::tmp_state_t* preprocessing_tmp,
         hybrid_ep::tmp_state_t* preprocessing_local_experts_tmp,
         int32_t* sparse_to_dense_map,

--- a/csrc/hybrid_ep/pybind_hybrid_ep.cu
+++ b/csrc/hybrid_ep/pybind_hybrid_ep.cu
@@ -73,6 +73,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                        &HybridEpConfigInstance::num_of_ranks_per_node)
         .def_readwrite("num_of_nodes", &HybridEpConfigInstance::num_of_nodes)
         .def_readwrite("pad_multiple", &HybridEpConfigInstance::pad_multiple)
+        .def_readwrite("topk", &HybridEpConfigInstance::topk)
         // Metadata-preprocessing API Config
         .def_readwrite("num_of_tokens_per_chunk_preprocessing_api", &HybridEpConfigInstance::num_of_tokens_per_chunk_preprocessing_api)
         .def_readwrite(

--- a/deep_ep/hybrid_ep_buffer.py
+++ b/deep_ep/hybrid_ep_buffer.py
@@ -6,6 +6,8 @@ import shutil
 import hybrid_ep_cpp
 import warnings
 
+INT16_EXPERT_LIMIT = torch.iinfo(torch.int16).max + 1
+
 def indices_to_map(
     topk_idx: torch.Tensor,
     topk_weights: torch.Tensor,
@@ -29,6 +31,22 @@ def indices_to_map(
     else:
         probs = None
     return routing_map, probs
+
+
+def dense_indices_to_probs(
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_of_tokens: int,
+    num_of_experts: int,
+):
+    probs = torch.zeros(
+        num_of_tokens, num_of_experts, device=topk_idx.device, dtype=torch.float32
+    )
+    valid = (topk_idx >= 0) & (topk_idx < num_of_experts)
+    safe_idx = torch.where(valid, topk_idx, torch.zeros_like(topk_idx)).long()
+    safe_weights = torch.where(valid, topk_weights, torch.zeros_like(topk_weights)).to(probs.dtype)
+    probs.scatter_add_(1, safe_idx, safe_weights)
+    return probs
 
 
 class HybridEPBuffer:
@@ -177,6 +195,7 @@ class HybridEPBuffer:
         num_dispatched_tokens_tensor: torch.Tensor = None,
         num_dispatched_tokens: int = None,
         handle: tuple = None,
+        dense_routing: bool = False,
     ):
         """
         Dispatch the data to the experts.
@@ -186,33 +205,59 @@ class HybridEPBuffer:
 
         Backward direction:
         combine_in_backward <- local_unpermute -> expert_mlp -> local_permute -> dispatch_in_backward
+
+        When dense_routing=True, topk_idx is passed directly as int16 (skipping indices_to_map).
+        This reduces allgather size from T*E_total to T*K*2 bytes.
+        Dropped tokens should use -1 as sentinel (naturally ignored by range checks in the kernel).
         """
         num_of_tokens, hidden_dim = hidden.shape
 
-        if routing_map is not None:
+        if dense_routing:
+            assert topk_idx is not None or handle is not None, \
+                "topk_idx is required for dense_routing mode when handle is None"
+            assert num_of_experts is not None or topk_idx is None, \
+                "num_of_experts is required for dense_routing mode"
+            assert num_of_experts is None or num_of_experts <= INT16_EXPERT_LIMIT, \
+                "dense_routing uses int16 topk_idx, so num_of_experts must be <= 32768"
+            routing_data = None
+            if topk_idx is not None:
+                topk = topk_idx.size(-1)
+                routing_data = topk_idx.to(torch.int16).contiguous()
+                if probs is None and topk_weights is not None:
+                    probs = dense_indices_to_probs(
+                        topk_idx, topk_weights, num_of_tokens, num_of_experts
+                    )
+            else:
+                topk = 0
+        elif routing_map is not None:
             assert routing_map.dtype == torch.bool
             num_of_experts = routing_map.size(-1)
+            topk = 0
+            routing_data = routing_map
         else:
             # Generate the routing map and the probs according to the topk_idx and topk_weights.
             assert (
                 num_of_experts is not None
             ), "The number of experts should be provided on index-based routing."
+            topk = 0
             if topk_idx is not None:
                 routing_map, probs = indices_to_map(
                     topk_idx, topk_weights, num_of_tokens, num_of_experts
                 )
+            routing_data = routing_map
 
         assert (
-            handle is not None or routing_map is not None
+            handle is not None or routing_data is not None
         ), "The handle and routing_map should not be both None"
         if handle is None:
             config = self.update_template_config(
                 hidden_dim=hidden_dim,
                 num_of_tokens_per_rank=num_of_tokens,
+                topk=topk,
             )
             handle_impl = self.runtime.metadata_preprocessing(
                 config=config,
-                routing_map=routing_map,
+                routing_map=routing_data,
                 num_of_tokens_per_rank=num_of_tokens,
                 enable_permute=False,
                 non_blocking=False,
@@ -321,12 +366,14 @@ class HybridEPBuffer:
         # Otherwise, tokens_per_expert is copied through pinned memory so Python can derive num_permuted_tokens.
         non_blocking: bool = False,
         fuse_permute_dispatch: bool = False,
+        dense_routing: bool = False,
         # Deprecated parameters
         num_dispatched_tokens: int = None,
         use_host_meta: bool = None,
     ):
         """
         Dispatch the data to the experts with permute.
+        When dense_routing=True, topk_idx is passed directly as int16 (skipping indices_to_map).
         """
         if num_dispatched_tokens is not None:
             warnings.warn("The num_dispatched_tokens is deprecated, it will be removed in the future.")
@@ -336,9 +383,28 @@ class HybridEPBuffer:
 
         with torch.cuda.nvtx.range("hybrid-ep dispatch with permute phase"):
             num_of_tokens_per_rank, hidden_dim = hidden.shape
-            if routing_map is not None:
+            if dense_routing:
+                assert topk_idx is not None or handle is not None, \
+                    "topk_idx is required for dense_routing mode when handle is None"
+                assert num_of_experts is not None or topk_idx is None, \
+                    "num_of_experts is required for dense_routing mode"
+                assert num_of_experts is None or num_of_experts <= INT16_EXPERT_LIMIT, \
+                    "dense_routing uses int16 topk_idx, so num_of_experts must be <= 32768"
+                routing_data = None
+                if topk_idx is not None:
+                    topk = topk_idx.size(-1)
+                    routing_data = topk_idx.to(torch.int16).contiguous()
+                    if probs is None and topk_weights is not None:
+                        probs = dense_indices_to_probs(
+                            topk_idx, topk_weights, num_of_tokens_per_rank, num_of_experts
+                        )
+                else:
+                    topk = 0
+            elif routing_map is not None:
                 assert routing_map.dtype == torch.bool
                 num_of_experts = routing_map.size(-1)
+                topk = 0
+                routing_data = routing_map
             else:
                 # Generate the routing map and the probs according to the topk_idx and topk_weights.
                 if topk_idx is not None:
@@ -348,6 +414,8 @@ class HybridEPBuffer:
                     routing_map, probs = indices_to_map(
                         topk_idx, topk_weights, num_of_tokens_per_rank, num_of_experts
                     )
+                topk = 0
+                routing_data = routing_map
             if non_blocking:
                 assert num_permuted_tokens is not None and num_permuted_tokens >= 0, \
                     "The num_permuted_tokens is required for non-blocking mode."
@@ -356,9 +424,9 @@ class HybridEPBuffer:
                         f"num_permuted_tokens ({num_permuted_tokens}) must be a multiple of pad_multiple ({pad_multiple}) in non-blocking mode."
 
             if handle is None:
-                assert hidden.size(0) == routing_map.size(
+                assert hidden.size(0) == routing_data.size(
                     0
-                ), "The hidden and the routing_map should have the same row number."
+                ), "The hidden and the routing data should have the same row number."
                 config = self.update_template_config(
                     hidden_dim=hidden_dim,
                     num_of_tokens_per_rank=num_of_tokens_per_rank,
@@ -366,10 +434,11 @@ class HybridEPBuffer:
                     pad_multiple=pad_multiple,
                     use_fp8=use_fp8,
                     fuse_permute_dispatch=fuse_permute_dispatch,
+                    topk=topk,
                 )
                 handle_impl = self.runtime.metadata_preprocessing(
                     config=config,
-                    routing_map=routing_map,
+                    routing_map=routing_data,
                     num_of_tokens_per_rank=num_of_tokens_per_rank,
                     num_permuted_tokens=num_permuted_tokens,
                     pad_multiple=pad_multiple,

--- a/deep_ep/hybrid_ep_buffer.py
+++ b/deep_ep/hybrid_ep_buffer.py
@@ -195,7 +195,6 @@ class HybridEPBuffer:
         num_dispatched_tokens_tensor: torch.Tensor = None,
         num_dispatched_tokens: int = None,
         handle: tuple = None,
-        dense_routing: bool = False,
     ):
         """
         Dispatch the data to the experts.
@@ -206,45 +205,30 @@ class HybridEPBuffer:
         Backward direction:
         combine_in_backward <- local_unpermute -> expert_mlp -> local_permute -> dispatch_in_backward
 
-        When dense_routing=True, topk_idx is passed directly as int16 (skipping indices_to_map).
+        When routing_map is omitted, topk_idx is passed directly as int16 (skipping indices_to_map).
         This reduces allgather size from T*E_total to T*K*2 bytes.
         Dropped tokens should use -1 as sentinel (naturally ignored by range checks in the kernel).
         """
         num_of_tokens, hidden_dim = hidden.shape
 
-        if dense_routing:
-            assert topk_idx is not None or handle is not None, \
-                "topk_idx is required for dense_routing mode when handle is None"
-            assert num_of_experts is not None or topk_idx is None, \
-                "num_of_experts is required for dense_routing mode"
-            assert num_of_experts is None or num_of_experts <= INT16_EXPERT_LIMIT, \
-                "dense_routing uses int16 topk_idx, so num_of_experts must be <= 32768"
-            routing_data = None
-            if topk_idx is not None:
-                topk = topk_idx.size(-1)
-                routing_data = topk_idx.to(torch.int16).contiguous()
-                if probs is None and topk_weights is not None:
-                    probs = dense_indices_to_probs(
-                        topk_idx, topk_weights, num_of_tokens, num_of_experts
-                    )
-            else:
-                topk = 0
-        elif routing_map is not None:
+        if routing_map is not None:
             assert routing_map.dtype == torch.bool
             num_of_experts = routing_map.size(-1)
             topk = 0
             routing_data = routing_map
-        else:
-            # Generate the routing map and the probs according to the topk_idx and topk_weights.
-            assert (
-                num_of_experts is not None
-            ), "The number of experts should be provided on index-based routing."
-            topk = 0
-            if topk_idx is not None:
-                routing_map, probs = indices_to_map(
+        elif topk_idx is not None:
+            assert num_of_experts is not None, "num_of_experts is required with topk_idx"
+            assert num_of_experts <= INT16_EXPERT_LIMIT, \
+                "dense topk_idx routing uses int16 expert IDs, so num_of_experts must be <= 32768"
+            topk = topk_idx.size(-1)
+            routing_data = topk_idx.to(torch.int16).contiguous()
+            if probs is None and topk_weights is not None:
+                probs = dense_indices_to_probs(
                     topk_idx, topk_weights, num_of_tokens, num_of_experts
                 )
-            routing_data = routing_map
+        else:
+            topk = 0
+            routing_data = None
 
         assert (
             handle is not None or routing_data is not None
@@ -366,14 +350,13 @@ class HybridEPBuffer:
         # Otherwise, tokens_per_expert is copied through pinned memory so Python can derive num_permuted_tokens.
         non_blocking: bool = False,
         fuse_permute_dispatch: bool = False,
-        dense_routing: bool = False,
         # Deprecated parameters
         num_dispatched_tokens: int = None,
         use_host_meta: bool = None,
     ):
         """
         Dispatch the data to the experts with permute.
-        When dense_routing=True, topk_idx is passed directly as int16 (skipping indices_to_map).
+        When routing_map is omitted, topk_idx is passed directly as int16 (skipping indices_to_map).
         """
         if num_dispatched_tokens is not None:
             warnings.warn("The num_dispatched_tokens is deprecated, it will be removed in the future.")
@@ -383,39 +366,24 @@ class HybridEPBuffer:
 
         with torch.cuda.nvtx.range("hybrid-ep dispatch with permute phase"):
             num_of_tokens_per_rank, hidden_dim = hidden.shape
-            if dense_routing:
-                assert topk_idx is not None or handle is not None, \
-                    "topk_idx is required for dense_routing mode when handle is None"
-                assert num_of_experts is not None or topk_idx is None, \
-                    "num_of_experts is required for dense_routing mode"
-                assert num_of_experts is None or num_of_experts <= INT16_EXPERT_LIMIT, \
-                    "dense_routing uses int16 topk_idx, so num_of_experts must be <= 32768"
-                routing_data = None
-                if topk_idx is not None:
-                    topk = topk_idx.size(-1)
-                    routing_data = topk_idx.to(torch.int16).contiguous()
-                    if probs is None and topk_weights is not None:
-                        probs = dense_indices_to_probs(
-                            topk_idx, topk_weights, num_of_tokens_per_rank, num_of_experts
-                        )
-                else:
-                    topk = 0
-            elif routing_map is not None:
+            if routing_map is not None:
                 assert routing_map.dtype == torch.bool
                 num_of_experts = routing_map.size(-1)
                 topk = 0
                 routing_data = routing_map
-            else:
-                # Generate the routing map and the probs according to the topk_idx and topk_weights.
-                if topk_idx is not None:
-                    assert (
-                        num_of_experts is not None
-                    ), "The number of experts should be provided on index-based routing."
-                    routing_map, probs = indices_to_map(
+            elif topk_idx is not None:
+                assert num_of_experts is not None, "num_of_experts is required with topk_idx"
+                assert num_of_experts <= INT16_EXPERT_LIMIT, \
+                    "dense topk_idx routing uses int16 expert IDs, so num_of_experts must be <= 32768"
+                topk = topk_idx.size(-1)
+                routing_data = topk_idx.to(torch.int16).contiguous()
+                if probs is None and topk_weights is not None:
+                    probs = dense_indices_to_probs(
                         topk_idx, topk_weights, num_of_tokens_per_rank, num_of_experts
                     )
+            else:
                 topk = 0
-                routing_data = routing_map
+                routing_data = None
             if non_blocking:
                 assert num_permuted_tokens is not None and num_permuted_tokens >= 0, \
                     "The num_permuted_tokens is required for non-blocking mode."

--- a/deep_ep/hybrid_ep_buffer.py
+++ b/deep_ep/hybrid_ep_buffer.py
@@ -7,6 +7,8 @@ import hybrid_ep_cpp
 import warnings
 
 INT16_EXPERT_LIMIT = torch.iinfo(torch.int16).max + 1
+DENSE_ROUTING_EXPERTS_PER_RANK_LIMIT = 512
+DENSE_ROUTING_RANKS_PER_NODE_LIMIT = 512
 
 def indices_to_map(
     topk_idx: torch.Tensor,
@@ -19,15 +21,20 @@ def indices_to_map(
     """
     # Generate the routing map and the probs according to the topk_idx and topk_weights.
     assert topk_idx is not None
-    routing_map = torch.zeros(
-        num_of_tokens, num_of_experts, device="cuda", dtype=torch.bool
+    valid = (topk_idx >= 0) & (topk_idx < num_of_experts)
+    safe_idx = torch.where(valid, topk_idx, torch.zeros_like(topk_idx)).to(torch.int64)
+
+    routing_counts = torch.zeros(
+        num_of_tokens, num_of_experts, device=topk_idx.device, dtype=torch.int32
     )
-    routing_map = routing_map.scatter(1, topk_idx.to(torch.int64), 1).bool()
+    routing_counts.scatter_add_(1, safe_idx, valid.to(torch.int32))
+    routing_map = routing_counts.bool()
     if topk_weights is not None:
         probs = torch.zeros(
-            num_of_tokens, num_of_experts, device="cuda", dtype=torch.float32
+            num_of_tokens, num_of_experts, device=topk_idx.device, dtype=torch.float32
         )
-        probs = probs.scatter(1, topk_idx.to(torch.int64), topk_weights)
+        safe_weights = torch.where(valid, topk_weights, torch.zeros_like(topk_weights)).to(probs.dtype)
+        probs.scatter_add_(1, safe_idx, safe_weights)
     else:
         probs = None
     return routing_map, probs
@@ -42,6 +49,7 @@ def dense_indices_to_probs(
     probs = torch.zeros(
         num_of_tokens, num_of_experts, device=topk_idx.device, dtype=torch.float32
     )
+    # Valid top-k routing has distinct expert IDs per token. Duplicate IDs are malformed input.
     valid = (topk_idx >= 0) & (topk_idx < num_of_experts)
     safe_idx = torch.where(valid, topk_idx, torch.zeros_like(topk_idx)).long()
     safe_weights = torch.where(valid, topk_weights, torch.zeros_like(topk_weights)).to(probs.dtype)
@@ -135,6 +143,78 @@ class HybridEPBuffer:
         if os.path.exists(jit_cache_path):
             shutil.rmtree(jit_cache_path)
 
+    def _expected_num_of_experts(self, num_of_experts_per_rank: int = None):
+        if num_of_experts_per_rank is None:
+            num_of_experts_per_rank = self.configurer.buffer_config.num_of_experts_per_rank
+        num_of_experts_per_rank = int(num_of_experts_per_rank)
+        return (
+            num_of_experts_per_rank,
+            num_of_experts_per_rank
+            * self.num_of_hybrid_ep_ranks_per_nvlink_domain
+            * self.num_of_nodes,
+        )
+
+    def _use_dense_topk_routing(self, num_of_experts: int, num_of_experts_per_rank: int):
+        return (
+            num_of_experts <= INT16_EXPERT_LIMIT
+            and num_of_experts_per_rank <= DENSE_ROUTING_EXPERTS_PER_RANK_LIMIT
+            and self.num_of_hybrid_ep_ranks_per_nvlink_domain <= DENSE_ROUTING_RANKS_PER_NODE_LIMIT
+        )
+
+    def _prepare_routing_data(
+        self,
+        *,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        num_of_tokens: int,
+        num_of_experts: int,
+        probs: torch.Tensor,
+        routing_map: torch.Tensor,
+        num_of_experts_per_rank: int = None,
+    ):
+        if routing_map is not None:
+            assert routing_map.dtype == torch.bool
+            num_of_experts = routing_map.size(-1)
+            if probs is not None:
+                assert probs.size(0) == num_of_tokens and probs.size(-1) == num_of_experts
+            return 0, routing_map, probs, num_of_experts
+
+        if topk_idx is None:
+            return 0, None, probs, num_of_experts
+
+        assert num_of_experts is not None, "num_of_experts is required with topk_idx"
+        num_of_experts_per_rank, expected_num_of_experts = self._expected_num_of_experts(
+            num_of_experts_per_rank
+        )
+        assert num_of_experts == expected_num_of_experts, (
+            f"num_of_experts ({num_of_experts}) must match the HybridEP layout "
+            f"({expected_num_of_experts})"
+        )
+        if probs is not None:
+            assert probs.size(0) == num_of_tokens and probs.size(-1) == num_of_experts
+
+        topk = topk_idx.size(-1)
+        if self._use_dense_topk_routing(num_of_experts, num_of_experts_per_rank):
+            # Dense mode stores signed int16 global expert IDs. Valid IDs are
+            # [0, num_of_experts); -1 is the dropped-token sentinel.
+            routing_data = topk_idx.to(torch.int16).contiguous()
+            if probs is None and topk_weights is not None:
+                probs = dense_indices_to_probs(
+                    topk_idx, topk_weights, num_of_tokens, num_of_experts
+                )
+            return topk, routing_data, probs, num_of_experts
+
+        # Preserve the pre-dense topk_idx behavior for layouts outside dense kernel limits.
+        routing_data, inferred_probs = indices_to_map(
+            topk_idx,
+            topk_weights if probs is None else None,
+            num_of_tokens,
+            num_of_experts,
+        )
+        if probs is None:
+            probs = inferred_probs
+        return 0, routing_data, probs, num_of_experts
+
     def update_template_config(
         self,
         hidden_dim: int = None,
@@ -205,30 +285,22 @@ class HybridEPBuffer:
         Backward direction:
         combine_in_backward <- local_unpermute -> expert_mlp -> local_permute -> dispatch_in_backward
 
-        When routing_map is omitted, topk_idx is passed directly as int16 (skipping indices_to_map).
+        When routing_map is omitted, topk_idx is passed directly as int16 when dense routing
+        limits allow it (skipping indices_to_map), otherwise it falls back to the sparse map.
         This reduces allgather size from T*E_total to T*K*2 bytes.
+        If both routing_map and topk_idx are provided, routing_map takes precedence.
         Dropped tokens should use -1 as sentinel (naturally ignored by range checks in the kernel).
         """
         num_of_tokens, hidden_dim = hidden.shape
 
-        if routing_map is not None:
-            assert routing_map.dtype == torch.bool
-            num_of_experts = routing_map.size(-1)
-            topk = 0
-            routing_data = routing_map
-        elif topk_idx is not None:
-            assert num_of_experts is not None, "num_of_experts is required with topk_idx"
-            assert num_of_experts <= INT16_EXPERT_LIMIT, \
-                "dense topk_idx routing uses int16 expert IDs, so num_of_experts must be <= 32768"
-            topk = topk_idx.size(-1)
-            routing_data = topk_idx.to(torch.int16).contiguous()
-            if probs is None and topk_weights is not None:
-                probs = dense_indices_to_probs(
-                    topk_idx, topk_weights, num_of_tokens, num_of_experts
-                )
-        else:
-            topk = 0
-            routing_data = None
+        topk, routing_data, probs, _ = self._prepare_routing_data(
+            topk_idx=topk_idx,
+            topk_weights=topk_weights,
+            num_of_tokens=num_of_tokens,
+            num_of_experts=num_of_experts,
+            probs=probs,
+            routing_map=routing_map,
+        )
 
         assert (
             handle is not None or routing_data is not None
@@ -356,7 +428,9 @@ class HybridEPBuffer:
     ):
         """
         Dispatch the data to the experts with permute.
-        When routing_map is omitted, topk_idx is passed directly as int16 (skipping indices_to_map).
+        When routing_map is omitted, topk_idx is passed directly as int16 when dense routing
+        limits allow it (skipping indices_to_map), otherwise it falls back to the sparse map.
+        If both routing_map and topk_idx are provided, routing_map takes precedence.
         """
         if num_dispatched_tokens is not None:
             warnings.warn("The num_dispatched_tokens is deprecated, it will be removed in the future.")
@@ -366,24 +440,15 @@ class HybridEPBuffer:
 
         with torch.cuda.nvtx.range("hybrid-ep dispatch with permute phase"):
             num_of_tokens_per_rank, hidden_dim = hidden.shape
-            if routing_map is not None:
-                assert routing_map.dtype == torch.bool
-                num_of_experts = routing_map.size(-1)
-                topk = 0
-                routing_data = routing_map
-            elif topk_idx is not None:
-                assert num_of_experts is not None, "num_of_experts is required with topk_idx"
-                assert num_of_experts <= INT16_EXPERT_LIMIT, \
-                    "dense topk_idx routing uses int16 expert IDs, so num_of_experts must be <= 32768"
-                topk = topk_idx.size(-1)
-                routing_data = topk_idx.to(torch.int16).contiguous()
-                if probs is None and topk_weights is not None:
-                    probs = dense_indices_to_probs(
-                        topk_idx, topk_weights, num_of_tokens_per_rank, num_of_experts
-                    )
-            else:
-                topk = 0
-                routing_data = None
+            topk, routing_data, probs, _ = self._prepare_routing_data(
+                topk_idx=topk_idx,
+                topk_weights=topk_weights,
+                num_of_tokens=num_of_tokens_per_rank,
+                num_of_experts=num_of_experts,
+                probs=probs,
+                routing_map=routing_map,
+                num_of_experts_per_rank=num_of_experts_per_rank,
+            )
             if non_blocking:
                 assert num_permuted_tokens is not None and num_permuted_tokens >= 0, \
                     "The num_permuted_tokens is required for non-blocking mode."

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved
 import argparse
+import inspect
 import time
 import torch
 import torch.distributed as dist
@@ -55,6 +56,33 @@ def bitwise_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
     b_bytes = b.contiguous().view(torch.uint8)
     return torch.equal(a_bytes, b_bytes)
 
+
+def assert_bitwise_equal(name: str, ref: torch.Tensor, test: torch.Tensor, context: str = ""):
+    if ref is None or test is None:
+        return
+    if bitwise_equal(ref, test):
+        return
+    mismatch = (ref.contiguous().view(torch.uint8) != test.contiguous().view(torch.uint8)).sum().item()
+    elem_mismatch = (ref != test).sum().item()
+    pct = 100.0 * elem_mismatch / max(ref.numel(), 1)
+    msg = (f"{name} mismatch{context}: {elem_mismatch}/{ref.numel()} elements "
+           f"({pct:.2f}%), {mismatch} bytes differ, shape={list(ref.shape)}")
+    flat_ref = ref.contiguous().view(-1)
+    flat_test = test.contiguous().view(-1)
+    diff_idx = (flat_ref != flat_test).nonzero(as_tuple=True)[0][:5]
+    for idx in diff_idx:
+        i = idx.item()
+        msg += f"\n    [{i}]: ref={flat_ref[i].item()}, got={flat_test[i].item()}"
+    assert False, msg
+
+
+def supports_kwarg(fn, name: str) -> bool:
+    """Return whether a bound Python method accepts a keyword argument."""
+    try:
+        return name in inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+
 def init_tensor(
     hidden_dim: int,
     seq_len: int,
@@ -104,6 +132,8 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
         use_fp8=use_fp8,
     )
     dtype_str = "FP8" if hidden.dtype == torch.uint8 else "BF16"
+    supports_dense_dispatch = supports_kwarg(buffer.dispatch, "dense_routing")
+    supports_dense_permute = supports_kwarg(buffer.dispatch_with_permute, "dense_routing")
     dist.barrier()
     if dist.get_rank() == 0:
         print(f'\n=== Correctness Check ({dtype_str}, {dist.get_world_size()} ranks) ===', flush=True)
@@ -168,51 +198,61 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
     if dist.get_rank() == 0:
         print('  dispatch+combine API: PASS', flush=True)
 
-    # Dense routing dispatch correctness check
-    for with_probs in [True, False]:
-        dispatched_hidden_ref, dispatched_probs_ref, dispatched_scaling_factor_ref = (
-            ref.dispatch(
-                hidden, routing_map, probs if with_probs else None, scaling_factor
+    # Dense top-k routing dispatch correctness check. Older hybrid-ep branches do
+    # not expose dense_routing yet, so skip this block when the installed package
+    # lacks the keyword.
+    if supports_dense_dispatch:
+        for with_probs in [True, False]:
+            context = f" (dense_routing=True, with_probs={with_probs})"
+            dispatched_hidden_ref, dispatched_probs_ref, dispatched_scaling_factor_ref = (
+                ref.dispatch(
+                    hidden, routing_map, probs if with_probs else None, scaling_factor
+                )
             )
-        )
-        (
-            dispatched_hidden_dense,
-            dispatched_probs_dense,
-            dispatched_scaling_factor_dense,
-            handle_dense,
-        ) = buffer.dispatch(
-            hidden=hidden, scaling_factor=scaling_factor, topk_idx=topk_idx,
-            topk_weights=topk_weights if with_probs else None, num_of_experts=NUM_OF_EXPERTS,
-            dense_routing=True,
-        )
+            (
+                dispatched_hidden_dense,
+                dispatched_probs_dense,
+                dispatched_scaling_factor_dense,
+                handle_dense,
+            ) = buffer.dispatch(
+                hidden=hidden, scaling_factor=scaling_factor, topk_idx=topk_idx,
+                topk_weights=topk_weights if with_probs else None, num_of_experts=NUM_OF_EXPERTS,
+                dense_routing=True,
+            )
 
-        assert bitwise_equal(dispatched_hidden_ref, dispatched_hidden_dense)
-        if dispatched_probs_dense is not None and dispatched_probs_ref is not None:
-            start, end = ref._local_expert_range_per_node()
-            assert bitwise_equal(dispatched_probs_ref, dispatched_probs_dense[:, start:end])
-            masked_probs = torch.zeros_like(dispatched_probs_dense)
-            masked_probs[:, start:end] = dispatched_probs_dense[:, start:end]
-            dispatched_probs_dense = masked_probs
+            assert_bitwise_equal("Dense dispatch hidden", dispatched_hidden_ref, dispatched_hidden_dense, context)
+            assert_bitwise_equal("Dense dispatch scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor_dense, context)
+            if dispatched_probs_dense is not None and dispatched_probs_ref is not None:
+                start, end = ref._local_expert_range_per_node()
+                assert_bitwise_equal("Dense dispatch probs", dispatched_probs_ref, dispatched_probs_dense[:, start:end], context)
+                masked_probs = torch.zeros_like(dispatched_probs_dense)
+                masked_probs[:, start:end] = dispatched_probs_dense[:, start:end]
+                dispatched_probs_dense = masked_probs
 
-        _, _, _, num_dispatched_tokens, local_expert_routing_map, _, _ = handle_dense
-        num_dispatched_tokens = num_dispatched_tokens.cpu()
-        local_expert_routing_map = local_expert_routing_map[
-            : num_dispatched_tokens.item()
-        ]
-        copy_times = local_expert_routing_map.sum(dim=1)
-        hidden_to_combine = dispatched_hidden_dense.to(torch.bfloat16) * copy_times.unsqueeze(1)
-        combined_hidden, combined_probs = buffer.combine(
-            hidden_to_combine, dispatched_probs_dense, handle_dense
-        )
-        combined_hidden = combined_hidden / TOPK
+            _, _, _, num_dispatched_tokens, local_expert_routing_map, _, _ = handle_dense
+            num_dispatched_tokens = num_dispatched_tokens.cpu()
+            local_expert_routing_map = local_expert_routing_map[
+                : num_dispatched_tokens.item()
+            ]
+            copy_times = local_expert_routing_map.sum(dim=1)
+            hidden_to_combine = dispatched_hidden_dense.to(torch.bfloat16) * copy_times.unsqueeze(1)
+            combined_hidden, combined_probs = buffer.combine(
+                hidden_to_combine, dispatched_probs_dense, handle_dense
+            )
+            combined_hidden = combined_hidden / TOPK
 
-        assert torch.allclose(combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2)
-        if combined_probs is not None and probs is not None:
-            assert bitwise_equal(combined_probs, probs)
+            assert torch.allclose(combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2), \
+                f"Dense combine hidden mismatch{context}"
+            if combined_probs is not None and probs is not None:
+                assert_bitwise_equal("Dense combine probs", probs, combined_probs, context)
 
-    dist.barrier()
-    if dist.get_rank() == 0:
-        print('  dispatch+combine API (dense routing): PASS', flush=True)
+        dist.barrier()
+        if dist.get_rank() == 0:
+            print('  dispatch+combine API (dense routing): PASS', flush=True)
+    else:
+        dist.barrier()
+        if dist.get_rank() == 0:
+            print('  dispatch+combine API (dense routing): SKIP (unsupported)', flush=True)
 
     # Dispatch with permute correctness check
     for fuse_permute_dispatch in [False, True]:
@@ -303,6 +343,76 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
                 else 'dispatch_with_permute + combine_with_unpermute API (fused)'
             )
             print(f'  {api_name}: PASS', flush=True)
+
+    # Dense top-k routing with permute correctness check. This exercises scan
+    # with dense topk_idx input and enable_permute=True, i.e. the path that
+    # produces dense_chunk_layout and dense_to_expert_map.
+    if supports_dense_permute:
+        for fuse_permute_dispatch in [False, True]:
+            for with_probs in [True, False]:
+                context = (f" (dense_routing=True, with_probs={with_probs}, "
+                           f"fuse_permute_dispatch={fuse_permute_dispatch})")
+                (
+                    dispatched_hidden_dense,
+                    dispatched_probs_dense,
+                    dispatched_scaling_factor_dense,
+                    _tokens_per_expert_dense,
+                    handle_dense,
+                ) = buffer.dispatch_with_permute(
+                    hidden=hidden,
+                    topk_idx=topk_idx,
+                    topk_weights=topk_weights if with_probs else None,
+                    num_of_experts=NUM_OF_EXPERTS,
+                    scaling_factor=scaling_factor,
+                    pad_multiple=PAD_MULTIPLE,
+                    fuse_permute_dispatch=fuse_permute_dispatch,
+                    dense_routing=True,
+                )
+
+                (
+                    dispatched_hidden_ref,
+                    dispatched_probs_ref,
+                    dispatched_scaling_factor_ref,
+                ) = ref.dispatch(
+                    hidden,
+                    routing_map,
+                    probs if with_probs else None,
+                    scaling_factor,
+                    pad_multiple=PAD_MULTIPLE,
+                    enable_permute=True,
+                )
+
+                assert_bitwise_equal("Dense dispatch+permute hidden", dispatched_hidden_ref, dispatched_hidden_dense, context)
+                assert_bitwise_equal("Dense dispatch+permute probs", dispatched_probs_ref, dispatched_probs_dense, context)
+                assert_bitwise_equal("Dense dispatch+permute scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor_dense, context)
+
+                combined_hidden, combined_probs = buffer.combine_with_unpermute(
+                    hidden=dispatched_hidden_dense.to(torch.bfloat16),
+                    probs=dispatched_probs_dense,
+                    handle=handle_dense,
+                    pad_multiple=PAD_MULTIPLE,
+                    fuse_unpermute_combine=fuse_permute_dispatch,
+                )
+                combined_hidden = combined_hidden / TOPK
+
+                assert torch.allclose(
+                    combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2
+                ), f"Dense combine+unpermute hidden mismatch{context}"
+                if combined_probs is not None and probs is not None:
+                    assert_bitwise_equal("Dense combine+unpermute probs", probs, combined_probs, context)
+
+            dist.barrier()
+            if dist.get_rank() == 0:
+                api_name = (
+                    'dispatch_with_permute + combine_with_unpermute API (dense routing, non-fused)'
+                    if not fuse_permute_dispatch
+                    else 'dispatch_with_permute + combine_with_unpermute API (dense routing, fused)'
+                )
+                print(f'  {api_name}: PASS', flush=True)
+    else:
+        dist.barrier()
+        if dist.get_rank() == 0:
+            print('  dispatch_with_permute + combine_with_unpermute API (dense routing): SKIP (unsupported)', flush=True)
 
 
 def _gather_times(t):

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -79,6 +79,8 @@ def assert_bitwise_equal(name: str, ref: torch.Tensor, test: torch.Tensor, conte
 def supports_dense_topk_routing() -> bool:
     """Return whether the installed HybridEP supports dense topk_idx metadata."""
     try:
+        # Test-only compatibility check: production code still falls back to sparse routing
+        # when a dense-capable build receives a layout outside dense kernel limits.
         return hasattr(hybrid_ep_cpp.HybridEpConfigInstance(), "topk")
     except (TypeError, ValueError, AttributeError):
         return False
@@ -137,72 +139,28 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
     if dist.get_rank() == 0:
         print(f'\n=== Correctness Check ({dtype_str}, {dist.get_world_size()} ranks) ===', flush=True)
 
-    # Dispatch correctness check
-    for with_probs in [True, False]:
-        # The check for the dispatch
-        dispatched_hidden_ref, dispatched_probs_ref, dispatched_scaling_factor_ref = (
-            ref.dispatch(
-                hidden, routing_map, probs if with_probs else None, scaling_factor
-            )
-        )
-        (
-            dispatched_hidden,
-            dispatched_probs,
-            dispatched_scaling_factor,
-            handle,
-        ) = buffer.dispatch(
-            hidden=hidden, scaling_factor=scaling_factor, routing_map=routing_map,
-            probs=probs if with_probs else None,
-        )
-
-        assert bitwise_equal(dispatched_hidden_ref, dispatched_hidden)
-        if dispatched_probs is not None and dispatched_probs_ref is not None:
-            start, end = ref._local_expert_range_per_node()
-            masked_probs = torch.zeros_like(dispatched_probs)
-            masked_probs[:, start:end] = dispatched_probs[:, start:end]
-            assert bitwise_equal(dispatched_probs_ref, dispatched_probs[:, start:end])
-            dispatched_probs = masked_probs
-        if (
-            dispatched_scaling_factor is not None
-            and dispatched_scaling_factor_ref is not None
-        ):
-            assert bitwise_equal(
-                dispatched_scaling_factor_ref, dispatched_scaling_factor
-            )
-
-        _, _, _, num_dispatched_tokens, local_expert_routing_map, _, _ = handle
-        num_dispatched_tokens = num_dispatched_tokens.cpu()
-        local_expert_routing_map = local_expert_routing_map[
-            : num_dispatched_tokens.item()
-        ]
-        # Simulate the permute and expert and unpermute. The expert is identity op
-        copy_times = local_expert_routing_map.sum(dim=1)
-        dispatched_hidden = dispatched_hidden.to(torch.bfloat16)  
-        # The combine only support bf16
-        hidden_to_combine = dispatched_hidden * copy_times.unsqueeze(1)
-        probs_to_combine = dispatched_probs
-
-        # The check for the combine
-        combined_hidden, combined_probs = buffer.combine(
-            hidden_to_combine, probs_to_combine, handle
-        )
-
-        # The reconstucted value should be TOPK times larger than the input hidden
-        combined_hidden = combined_hidden / TOPK
-
-        assert torch.allclose(combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2)
-        if combined_probs is not None and probs is not None:
-            assert bitwise_equal(combined_probs, probs)
-
-    dist.barrier()
-    if dist.get_rank() == 0:
-        print('  dispatch+combine API: PASS', flush=True)
-
-    # Dense top-k routing dispatch correctness check. Older hybrid-ep branches do
-    # not expose dense topk_idx metadata yet, so skip this block when unsupported.
+    # Dispatch correctness check. Older hybrid-ep branches do not expose dense
+    # topk_idx metadata yet, so skip the dense routing mode when unsupported.
+    routing_modes = [("sparse routing", False)]
     if supports_dense_topk:
+        routing_modes.append(("dense topk_idx", True))
+
+    for routing_label, use_dense_topk in routing_modes:
         for with_probs in [True, False]:
-            context = f" (dense topk_idx, with_probs={with_probs})"
+            context = f" ({routing_label}, with_probs={with_probs})"
+            dispatch_kwargs = {"hidden": hidden, "scaling_factor": scaling_factor}
+            if use_dense_topk:
+                dispatch_kwargs.update({
+                    "topk_idx": topk_idx,
+                    "topk_weights": topk_weights if with_probs else None,
+                    "num_of_experts": NUM_OF_EXPERTS,
+                })
+            else:
+                dispatch_kwargs.update({
+                    "routing_map": routing_map,
+                    "probs": probs if with_probs else None,
+                })
+
             dispatched_hidden_ref, dispatched_probs_ref, dispatched_scaling_factor_ref = (
                 ref.dispatch(
                     hidden, routing_map, probs if with_probs else None, scaling_factor
@@ -213,16 +171,13 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
                 dispatched_probs_dense,
                 dispatched_scaling_factor_dense,
                 handle_dense,
-            ) = buffer.dispatch(
-                hidden=hidden, scaling_factor=scaling_factor, topk_idx=topk_idx,
-                topk_weights=topk_weights if with_probs else None, num_of_experts=NUM_OF_EXPERTS,
-            )
+            ) = buffer.dispatch(**dispatch_kwargs)
 
-            assert_bitwise_equal("Dense dispatch hidden", dispatched_hidden_ref, dispatched_hidden_dense, context)
-            assert_bitwise_equal("Dense dispatch scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor_dense, context)
+            assert_bitwise_equal("Dispatch hidden", dispatched_hidden_ref, dispatched_hidden_dense, context)
+            assert_bitwise_equal("Dispatch scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor_dense, context)
             if dispatched_probs_dense is not None and dispatched_probs_ref is not None:
                 start, end = ref._local_expert_range_per_node()
-                assert_bitwise_equal("Dense dispatch probs", dispatched_probs_ref, dispatched_probs_dense[:, start:end], context)
+                assert_bitwise_equal("Dispatch probs", dispatched_probs_ref, dispatched_probs_dense[:, start:end], context)
                 masked_probs = torch.zeros_like(dispatched_probs_dense)
                 masked_probs[:, start:end] = dispatched_probs_dense[:, start:end]
                 dispatched_probs_dense = masked_probs
@@ -240,14 +195,16 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
             combined_hidden = combined_hidden / TOPK
 
             assert torch.allclose(combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2), \
-                f"Dense combine hidden mismatch{context}"
+                f"Combine hidden mismatch{context}"
             if combined_probs is not None and probs is not None:
-                assert_bitwise_equal("Dense combine probs", probs, combined_probs, context)
+                assert_bitwise_equal("Combine probs", probs, combined_probs, context)
 
         dist.barrier()
         if dist.get_rank() == 0:
-            print('  dispatch+combine API (dense routing): PASS', flush=True)
-    else:
+            dense_suffix = " (dense routing)" if use_dense_topk else ""
+            print(f'  dispatch+combine API{dense_suffix}: PASS', flush=True)
+
+    if not supports_dense_topk:
         dist.barrier()
         if dist.get_rank() == 0:
             print('  dispatch+combine API (dense routing): SKIP (unsupported)', flush=True)
@@ -255,10 +212,6 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
     # Dispatch with permute correctness check. Dense topk_idx mode exercises
     # scan with enable_permute=True, i.e. the path that produces
     # dense_chunk_layout and dense_to_expert_map.
-    routing_modes = [("sparse routing", False)]
-    if supports_dense_topk:
-        routing_modes.append(("dense topk_idx", True))
-
     for routing_label, use_dense_topk in routing_modes:
         for fuse_permute_dispatch in [False, True]:
             for with_probs in [True, False]:

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -168,6 +168,52 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
     if dist.get_rank() == 0:
         print('  dispatch+combine API: PASS', flush=True)
 
+    # Dense routing dispatch correctness check
+    for with_probs in [True, False]:
+        dispatched_hidden_ref, dispatched_probs_ref, dispatched_scaling_factor_ref = (
+            ref.dispatch(
+                hidden, routing_map, probs if with_probs else None, scaling_factor
+            )
+        )
+        (
+            dispatched_hidden_dense,
+            dispatched_probs_dense,
+            dispatched_scaling_factor_dense,
+            handle_dense,
+        ) = buffer.dispatch(
+            hidden=hidden, scaling_factor=scaling_factor, topk_idx=topk_idx,
+            topk_weights=topk_weights if with_probs else None, num_of_experts=NUM_OF_EXPERTS,
+            dense_routing=True,
+        )
+
+        assert bitwise_equal(dispatched_hidden_ref, dispatched_hidden_dense)
+        if dispatched_probs_dense is not None and dispatched_probs_ref is not None:
+            start, end = ref._local_expert_range_per_node()
+            assert bitwise_equal(dispatched_probs_ref, dispatched_probs_dense[:, start:end])
+            masked_probs = torch.zeros_like(dispatched_probs_dense)
+            masked_probs[:, start:end] = dispatched_probs_dense[:, start:end]
+            dispatched_probs_dense = masked_probs
+
+        _, _, _, num_dispatched_tokens, local_expert_routing_map, _, _ = handle_dense
+        num_dispatched_tokens = num_dispatched_tokens.cpu()
+        local_expert_routing_map = local_expert_routing_map[
+            : num_dispatched_tokens.item()
+        ]
+        copy_times = local_expert_routing_map.sum(dim=1)
+        hidden_to_combine = dispatched_hidden_dense.to(torch.bfloat16) * copy_times.unsqueeze(1)
+        combined_hidden, combined_probs = buffer.combine(
+            hidden_to_combine, dispatched_probs_dense, handle_dense
+        )
+        combined_hidden = combined_hidden / TOPK
+
+        assert torch.allclose(combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2)
+        if combined_probs is not None and probs is not None:
+            assert bitwise_equal(combined_probs, probs)
+
+    dist.barrier()
+    if dist.get_rank() == 0:
+        print('  dispatch+combine API (dense routing): PASS', flush=True)
+
     # Dispatch with permute correctness check
     for fuse_permute_dispatch in [False, True]:
         for with_probs in [True, False]:

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -432,25 +432,25 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
     t = bench(lambda: buffer.dispatch(**dispatch_args))[0]
     _report_bw(f'dispatch ({dtype_str}, probs=True)', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
     t = bench(lambda: buffer.combine(**combine_args))[0]
-    _report_bw('combine (probs=True)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
+    _report_bw(f'combine ({dtype_str}, probs=True)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
 
     # Non-permute (probs=False)
     t = bench(lambda: buffer.dispatch(**dispatch_noprob_args))[0]
     _report_bw(f'dispatch ({dtype_str}, probs=False)', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
     t = bench(lambda: buffer.combine(**combine_noprob_args))[0]
-    _report_bw('combine (probs=False)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
+    _report_bw(f'combine ({dtype_str}, probs=False)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
 
     # Permute (non-fused)
     t = bench(lambda: buffer.dispatch_with_permute(**dispatch_wp_args))[0]
-    _report_bw(f'dispatch+permute ({dtype_str})', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
+    _report_bw(f'dispatch+permute ({dtype_str}, probs=True)', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
     t = bench(lambda: buffer.combine_with_unpermute(**combine_wp_args))[0]
-    _report_bw('combine+unpermute', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
+    _report_bw(f'combine+unpermute ({dtype_str}, probs=True)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
 
     # Fused
     t = bench(lambda: buffer.dispatch_with_permute(**dispatch_fused_args))[0]
-    _report_bw(f'fused dispatch+permute ({dtype_str})', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
+    _report_bw(f'fused dispatch+permute ({dtype_str}, probs=True)', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
     t = bench(lambda: buffer.combine_with_unpermute(**combine_fused_args))[0]
-    _report_bw('fused combine+unpermute', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
+    _report_bw(f'fused combine+unpermute ({dtype_str}, probs=True)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
 
     # ---- Kineto / nsys profiling ----
     # Kineto measures pure GPU kernel time only (no CPU overhead, no d2d, no device_sync)
@@ -465,7 +465,7 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
         dispatch_t, combine_t = bench_kineto(
             lambda: (buffer.dispatch(**dispatch_args), buffer.combine(**combine_args)),
             kernel_names=('dispatch_kernel', 'combine_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
-        _report_kineto(f'dispatch kernel ({dtype_str}, probs=True)', 'combine kernel (probs=True)',
+        _report_kineto(f'dispatch kernel ({dtype_str}, probs=True)', f'combine kernel ({dtype_str}, probs=True)',
                        dispatch_t, nvl_dispatch_actual, combine_t, nvl_combine, rdma_dispatch, rdma_combine)
 
         # Non-fused kernel profiling (probs=False)
@@ -473,7 +473,7 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
         dispatch_t, combine_t = bench_kineto(
             lambda: (buffer.dispatch(**dispatch_noprob_args), buffer.combine(**combine_noprob_args)),
             kernel_names=('dispatch_kernel', 'combine_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
-        _report_kineto(f'dispatch kernel ({dtype_str}, probs=False)', 'combine kernel (probs=False)',
+        _report_kineto(f'dispatch kernel ({dtype_str}, probs=False)', f'combine kernel ({dtype_str}, probs=False)',
                        dispatch_t, nvl_dispatch_actual, combine_t, nvl_combine, rdma_dispatch, rdma_combine)
 
         # Fused kernel profiling
@@ -481,7 +481,7 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
         dispatch_t, combine_t = bench_kineto(
             lambda: (buffer.dispatch_with_permute(**dispatch_fused_args), buffer.combine_with_unpermute(**combine_fused_args)),
             kernel_names=('dispatch_kernel', 'combine_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
-        _report_kineto(f'fused dispatch+permute kernel ({dtype_str})', 'fused combine+unpermute kernel',
+        _report_kineto(f'fused dispatch+permute kernel ({dtype_str}, probs=True)', f'fused combine+unpermute kernel ({dtype_str}, probs=True)',
                        dispatch_t, nvl_dispatch_actual, combine_t, nvl_combine, rdma_dispatch, rdma_combine)
 
         # Non-fused permute/unpermute kernel profiling (isolate permute_kernel and unpermute_kernel times)
@@ -505,32 +505,32 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
     else:
         if torch.distributed.get_rank() == 0:
             torch.cuda.profiler.start()
-        with torch.cuda.nvtx.range(f"hybrid-ep dispatch ({dtype_str})"):
+        with torch.cuda.nvtx.range(f"hybrid-ep dispatch ({dtype_str}, probs=True)"):
             if rank == 0:
-                print(f"profile hybrid-ep dispatch ({dtype_str})", flush=True)
+                print(f"profile hybrid-ep dispatch ({dtype_str}, probs=True)", flush=True)
             nsys_dispatch_args = {'hidden': hidden, 'scaling_factor': scaling_factor, 'topk_idx': topk_idx, 'topk_weights': topk_weights, 'num_of_experts': NUM_OF_EXPERTS}
             bench(lambda: buffer.dispatch(**nsys_dispatch_args))
-        with torch.cuda.nvtx.range("hybrid-ep combine"):
+        with torch.cuda.nvtx.range(f"hybrid-ep combine ({dtype_str}, probs=True)"):
             if rank == 0:
-                print(f"profile hybrid-ep combine", flush=True)
+                print(f"profile hybrid-ep combine ({dtype_str}, probs=True)", flush=True)
             bench(lambda: buffer.combine(**combine_args))
-        with torch.cuda.nvtx.range(f"hybrid-ep dispatch+permute ({dtype_str})"):
+        with torch.cuda.nvtx.range(f"hybrid-ep dispatch+permute ({dtype_str}, probs=True)"):
             if rank == 0:
-                print(f"profile hybrid-ep dispatch+permute ({dtype_str})", flush=True)
+                print(f"profile hybrid-ep dispatch+permute ({dtype_str}, probs=True)", flush=True)
             nsys_dispatch_wp_args = {'hidden': hidden, 'scaling_factor': scaling_factor, 'routing_map': routing_map, 'probs': probs, 'pad_multiple': PAD_MULTIPLE}
             bench(lambda: buffer.dispatch_with_permute(**nsys_dispatch_wp_args))
-        with torch.cuda.nvtx.range("hybrid-ep combine+unpermute"):
+        with torch.cuda.nvtx.range(f"hybrid-ep combine+unpermute ({dtype_str}, probs=True)"):
             if rank == 0:
-                print(f"profile hybrid-ep combine+unpermute", flush=True)
+                print(f"profile hybrid-ep combine+unpermute ({dtype_str}, probs=True)", flush=True)
             bench(lambda: buffer.combine_with_unpermute(**combine_wp_args))
-        with torch.cuda.nvtx.range(f"hybrid-ep dispatch+permute fused"):
+        with torch.cuda.nvtx.range(f"hybrid-ep dispatch+permute fused ({dtype_str}, probs=True)"):
             if rank == 0:
-                print(f"profile hybrid-ep dispatch+permute fused", flush=True)
+                print(f"profile hybrid-ep dispatch+permute fused ({dtype_str}, probs=True)", flush=True)
             nsys_dispatch_fused_args = {'hidden': hidden, 'scaling_factor': scaling_factor, 'routing_map': routing_map, 'probs': probs, 'pad_multiple': PAD_MULTIPLE, 'fuse_permute_dispatch': True}
             bench(lambda: buffer.dispatch_with_permute(**nsys_dispatch_fused_args))
-        with torch.cuda.nvtx.range("hybrid-ep combine+unpermute fused"):
+        with torch.cuda.nvtx.range(f"hybrid-ep combine+unpermute fused ({dtype_str}, probs=True)"):
             if rank == 0:
-                print(f"profile hybrid-ep combine+unpermute", flush=True)
+                print(f"profile hybrid-ep combine+unpermute fused ({dtype_str}, probs=True)", flush=True)
             bench(lambda: buffer.combine_with_unpermute(**combine_fused_args))
         time.sleep(1)
         if torch.distributed.get_rank() == 0:

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -200,18 +200,30 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
                 enable_permute=True,
             )
 
-            assert bitwise_equal(dispatched_hidden_ref, dispatched_hidden), \
-                f"Dispatch hidden mismatch (with_probs={with_probs}, fuse={fuse_permute_dispatch})"
-            if dispatched_probs is not None and dispatched_probs_ref is not None:
-                assert bitwise_equal(dispatched_probs_ref, dispatched_probs), \
-                    f"Dispatch probs mismatch (with_probs={with_probs}, fuse={fuse_permute_dispatch})"
-            if (
-                dispatched_scaling_factor is not None
-                and dispatched_scaling_factor_ref is not None
-            ):
-                assert bitwise_equal(
-                    dispatched_scaling_factor_ref, dispatched_scaling_factor
-                ), f"Dispatch scaling_factor mismatch (with_probs={with_probs}, fuse={fuse_permute_dispatch})"
+            def check_bitwise(name, ref, test):
+                if ref is None or test is None:
+                    return
+                if not bitwise_equal(ref, test):
+                    total = ref.numel()
+                    mismatch = (ref.contiguous().view(torch.uint8) != test.contiguous().view(torch.uint8)).sum().item()
+                    # Count element-level mismatches (not byte-level)
+                    elem_mismatch = (ref != test).sum().item()
+                    pct = 100.0 * elem_mismatch / max(ref.numel(), 1)
+                    msg = (f"{name} mismatch (with_probs={with_probs}, fuse={fuse_permute_dispatch}): "
+                           f"{elem_mismatch}/{ref.numel()} elements ({pct:.2f}%), "
+                           f"{mismatch} bytes differ, shape={list(ref.shape)}")
+                    # Print first few mismatching positions
+                    flat_ref = ref.contiguous().view(-1)
+                    flat_test = test.contiguous().view(-1)
+                    diff_idx = (flat_ref != flat_test).nonzero(as_tuple=True)[0][:5]
+                    for idx in diff_idx:
+                        i = idx.item()
+                        msg += f"\n    [{i}]: ref={flat_ref[i].item()}, got={flat_test[i].item()}"
+                    assert False, msg
+
+            check_bitwise("Dispatch hidden", dispatched_hidden_ref, dispatched_hidden)
+            check_bitwise("Dispatch probs", dispatched_probs_ref, dispatched_probs)
+            check_bitwise("Dispatch scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor)
 
             # The combine only support bf16
             dispatched_hidden = dispatched_hidden.to(torch.bfloat16)
@@ -318,6 +330,11 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
                      'topk_weights': topk_weights, 'num_of_experts': NUM_OF_EXPERTS, 'handle': handle}
     combine_args = {'hidden': dispatched_hidden_bf16, 'probs': dispatched_probs, 'handle': handle}
 
+    # Dispatch/combine with probs=False variants
+    dispatch_noprob_args = {'hidden': hidden, 'scaling_factor': scaling_factor, 'topk_idx': topk_idx,
+                            'topk_weights': None, 'num_of_experts': NUM_OF_EXPERTS, 'handle': handle}
+    combine_noprob_args = {'hidden': dispatched_hidden_bf16, 'probs': None, 'handle': handle}
+
     # Permute (non-fused)
     dispatched_hidden_wp, dispatched_probs_wp, _, tpe_wp, handle_wp = (
         buffer.dispatch_with_permute(hidden=hidden, scaling_factor=scaling_factor,
@@ -365,11 +382,17 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
         print(f'                combine  = fused_combine_unpermute_kernel + misc', flush=True)
         print(f'  (misc = device_sync, update_flag, etc.)', flush=True)
 
-    # Non-permute
+    # Non-permute (probs=True)
     t = bench(lambda: buffer.dispatch(**dispatch_args))[0]
-    _report_bw(f'dispatch ({dtype_str})', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
+    _report_bw(f'dispatch ({dtype_str}, probs=True)', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
     t = bench(lambda: buffer.combine(**combine_args))[0]
-    _report_bw('combine', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
+    _report_bw('combine (probs=True)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
+
+    # Non-permute (probs=False)
+    t = bench(lambda: buffer.dispatch(**dispatch_noprob_args))[0]
+    _report_bw(f'dispatch ({dtype_str}, probs=False)', t, nvl_dispatch_actual, 'nvl_recv_bytes', rdma_dispatch, 'rdma_send_bytes')
+    t = bench(lambda: buffer.combine(**combine_noprob_args))[0]
+    _report_bw('combine (probs=False)', t, nvl_combine, 'combine_send_bytes', rdma_combine, 'rdma_recv_bytes')
 
     # Permute (non-fused)
     t = bench(lambda: buffer.dispatch_with_permute(**dispatch_wp_args))[0]
@@ -391,12 +414,20 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
             print(f'  Non-fused:  dispatch_kernel only  |  combine_kernel only', flush=True)
             print(f'  Fused:      fused_permute_dispatch_kernel only  |  fused_combine_unpermute_kernel only', flush=True)
 
-        # Non-fused kernel profiling
+        # Non-fused kernel profiling (probs=True)
         group.barrier()
         dispatch_t, combine_t = bench_kineto(
             lambda: (buffer.dispatch(**dispatch_args), buffer.combine(**combine_args)),
             kernel_names=('dispatch_kernel', 'combine_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
-        _report_kineto(f'dispatch kernel ({dtype_str})', 'combine kernel',
+        _report_kineto(f'dispatch kernel ({dtype_str}, probs=True)', 'combine kernel (probs=True)',
+                       dispatch_t, nvl_dispatch_actual, combine_t, nvl_combine, rdma_dispatch, rdma_combine)
+
+        # Non-fused kernel profiling (probs=False)
+        group.barrier()
+        dispatch_t, combine_t = bench_kineto(
+            lambda: (buffer.dispatch(**dispatch_noprob_args), buffer.combine(**combine_noprob_args)),
+            kernel_names=('dispatch_kernel', 'combine_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
+        _report_kineto(f'dispatch kernel ({dtype_str}, probs=False)', 'combine kernel (probs=False)',
                        dispatch_t, nvl_dispatch_actual, combine_t, nvl_combine, rdma_dispatch, rdma_combine)
 
         # Fused kernel profiling
@@ -406,6 +437,25 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
             kernel_names=('dispatch_kernel', 'combine_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
         _report_kineto(f'fused dispatch+permute kernel ({dtype_str})', 'fused combine+unpermute kernel',
                        dispatch_t, nvl_dispatch_actual, combine_t, nvl_combine, rdma_dispatch, rdma_combine)
+
+        # Non-fused permute/unpermute kernel profiling (isolate permute_kernel and unpermute_kernel times)
+        group.barrier()
+        dispatch_t, permute_t = bench_kineto(
+            lambda: buffer.dispatch_with_permute(**dispatch_wp_args),
+            kernel_names=('dispatch_kernel', 'permute_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
+        combine_t, unpermute_t = bench_kineto(
+            lambda: buffer.combine_with_unpermute(**combine_wp_args),
+            kernel_names=('combine_kernel', 'unpermute_kernel'), barrier_comm_profiling=True, suppress_kineto_output=True)
+        d_times = _gather_times(dispatch_t)
+        p_times = _gather_times(permute_t)
+        c_times = _gather_times(combine_t)
+        u_times = _gather_times(unpermute_t)
+        if rank == 0:
+            fmt = lambda ts: f'avg={sum(ts)/len(ts)*1e6:.1f} us [min={min(ts)*1e6:.1f}, max={max(ts)*1e6:.1f}]'
+            print(f'  {"dispatch_kernel (in dispatch+permute):":<{LOG_LABEL_WIDTH}} {fmt(d_times)}', flush=True)
+            print(f'  {"permute_kernel:":<{LOG_LABEL_WIDTH}} {fmt(p_times)}', flush=True)
+            print(f'  {"unpermute_kernel:":<{LOG_LABEL_WIDTH}} {fmt(u_times)}', flush=True)
+            print(f'  {"combine_kernel (in combine+unpermute):":<{LOG_LABEL_WIDTH}} {fmt(c_times)}', flush=True)
     else:
         if torch.distributed.get_rank() == 0:
             torch.cuda.profiler.start()
@@ -446,7 +496,8 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
     stream = torch.cuda.Stream()
     with torch.cuda.stream(stream):
-        for use_fp8 in [False, True]:
+        fp8_modes = [False] if args.only_bf16 else [False, True]
+        for use_fp8 in fp8_modes:
             buffer = deep_ep.HybridEPBuffer(
                 group=group,
                 hidden_dim=HIDDEN_DIM,
@@ -487,5 +538,7 @@ if __name__ == "__main__":
                        help='Number of processes to spawn (default: 4)')
     parser.add_argument('--nsys-profile', action='store_true', default=False,
                        help='benchmark with nsys profile or not (default: False)')
+    parser.add_argument('--only-bf16', action='store_true', default=False,
+                       help='Skip FP8 tests, only run BF16 (default: False)')
     args = parser.parse_args()
     torch.multiprocessing.spawn(test_main, args=(args.num_processes, args), nprocs=args.num_processes)

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -321,7 +321,7 @@ def test_hybrid_ep_benchmark(buffer: deep_ep.HybridEPBuffer, group: dist.Process
     multinode = (NUM_OF_NODES > 1)
 
     # ---- Setup: collect handles, build args dicts (also serves as warmup) ----
-    # Non-permute
+    # Non-permute (forward dispatch with probs)
     dispatched_hidden, dispatched_probs, _, handle = (
         buffer.dispatch(hidden=hidden, scaling_factor=scaling_factor, topk_idx=topk_idx,
                         topk_weights=topk_weights, num_of_experts=NUM_OF_EXPERTS))

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved
 import argparse
-import inspect
 import time
 import torch
 import torch.distributed as dist
 import os
 import deep_ep
+import hybrid_ep_cpp
 
 from utils import TorchRef, bench, bench_kineto, init_dist, count_rdma_send_from_routing_map
 
@@ -76,11 +76,11 @@ def assert_bitwise_equal(name: str, ref: torch.Tensor, test: torch.Tensor, conte
     assert False, msg
 
 
-def supports_kwarg(fn, name: str) -> bool:
-    """Return whether a bound Python method accepts a keyword argument."""
+def supports_dense_topk_routing() -> bool:
+    """Return whether the installed HybridEP supports dense topk_idx metadata."""
     try:
-        return name in inspect.signature(fn).parameters
-    except (TypeError, ValueError):
+        return hasattr(hybrid_ep_cpp.HybridEpConfigInstance(), "topk")
+    except (TypeError, ValueError, AttributeError):
         return False
 
 def init_tensor(
@@ -132,8 +132,7 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
         use_fp8=use_fp8,
     )
     dtype_str = "FP8" if hidden.dtype == torch.uint8 else "BF16"
-    supports_dense_dispatch = supports_kwarg(buffer.dispatch, "dense_routing")
-    supports_dense_permute = supports_kwarg(buffer.dispatch_with_permute, "dense_routing")
+    supports_dense_topk = supports_dense_topk_routing()
     dist.barrier()
     if dist.get_rank() == 0:
         print(f'\n=== Correctness Check ({dtype_str}, {dist.get_world_size()} ranks) ===', flush=True)
@@ -152,7 +151,8 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
             dispatched_scaling_factor,
             handle,
         ) = buffer.dispatch(
-            hidden=hidden, scaling_factor=scaling_factor, topk_idx=topk_idx, topk_weights=topk_weights if with_probs else None, num_of_experts=NUM_OF_EXPERTS,
+            hidden=hidden, scaling_factor=scaling_factor, routing_map=routing_map,
+            probs=probs if with_probs else None,
         )
 
         assert bitwise_equal(dispatched_hidden_ref, dispatched_hidden)
@@ -199,11 +199,10 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
         print('  dispatch+combine API: PASS', flush=True)
 
     # Dense top-k routing dispatch correctness check. Older hybrid-ep branches do
-    # not expose dense_routing yet, so skip this block when the installed package
-    # lacks the keyword.
-    if supports_dense_dispatch:
+    # not expose dense topk_idx metadata yet, so skip this block when unsupported.
+    if supports_dense_topk:
         for with_probs in [True, False]:
-            context = f" (dense_routing=True, with_probs={with_probs})"
+            context = f" (dense topk_idx, with_probs={with_probs})"
             dispatched_hidden_ref, dispatched_probs_ref, dispatched_scaling_factor_ref = (
                 ref.dispatch(
                     hidden, routing_map, probs if with_probs else None, scaling_factor
@@ -217,7 +216,6 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
             ) = buffer.dispatch(
                 hidden=hidden, scaling_factor=scaling_factor, topk_idx=topk_idx,
                 topk_weights=topk_weights if with_probs else None, num_of_experts=NUM_OF_EXPERTS,
-                dense_routing=True,
             )
 
             assert_bitwise_equal("Dense dispatch hidden", dispatched_hidden_ref, dispatched_hidden_dense, context)
@@ -254,120 +252,43 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
         if dist.get_rank() == 0:
             print('  dispatch+combine API (dense routing): SKIP (unsupported)', flush=True)
 
-    # Dispatch with permute correctness check
-    for fuse_permute_dispatch in [False, True]:
-        for with_probs in [True, False]:
-            # The check for the dispatch
-            (
-                dispatched_hidden,
-                dispatched_probs,
-                dispatched_scaling_factor,
-                tokens_per_expert,
-                handle,
-            ) = buffer.dispatch_with_permute(
-                hidden=hidden,
-                routing_map=routing_map,
-                probs=probs if with_probs else None,
-                scaling_factor=scaling_factor,
-                pad_multiple=PAD_MULTIPLE,
-                fuse_permute_dispatch=fuse_permute_dispatch,
-            )
-            
-            (
-                dispatched_hidden_ref,
-                dispatched_probs_ref,
-                dispatched_scaling_factor_ref,
-            ) = ref.dispatch(
-                hidden,
-                routing_map,
-                probs if with_probs else None,
-                scaling_factor,
-                pad_multiple=PAD_MULTIPLE,
-                enable_permute=True,
-            )
+    # Dispatch with permute correctness check. Dense topk_idx mode exercises
+    # scan with enable_permute=True, i.e. the path that produces
+    # dense_chunk_layout and dense_to_expert_map.
+    routing_modes = [("sparse routing", False)]
+    if supports_dense_topk:
+        routing_modes.append(("dense topk_idx", True))
 
-            def check_bitwise(name, ref, test):
-                if ref is None or test is None:
-                    return
-                if not bitwise_equal(ref, test):
-                    total = ref.numel()
-                    mismatch = (ref.contiguous().view(torch.uint8) != test.contiguous().view(torch.uint8)).sum().item()
-                    # Count element-level mismatches (not byte-level)
-                    elem_mismatch = (ref != test).sum().item()
-                    pct = 100.0 * elem_mismatch / max(ref.numel(), 1)
-                    msg = (f"{name} mismatch (with_probs={with_probs}, fuse={fuse_permute_dispatch}): "
-                           f"{elem_mismatch}/{ref.numel()} elements ({pct:.2f}%), "
-                           f"{mismatch} bytes differ, shape={list(ref.shape)}")
-                    # Print first few mismatching positions
-                    flat_ref = ref.contiguous().view(-1)
-                    flat_test = test.contiguous().view(-1)
-                    diff_idx = (flat_ref != flat_test).nonzero(as_tuple=True)[0][:5]
-                    for idx in diff_idx:
-                        i = idx.item()
-                        msg += f"\n    [{i}]: ref={flat_ref[i].item()}, got={flat_test[i].item()}"
-                    assert False, msg
-
-            check_bitwise("Dispatch hidden", dispatched_hidden_ref, dispatched_hidden)
-            check_bitwise("Dispatch probs", dispatched_probs_ref, dispatched_probs)
-            check_bitwise("Dispatch scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor)
-
-            # The combine only support bf16
-            dispatched_hidden = dispatched_hidden.to(torch.bfloat16)
-            hidden_to_combine = dispatched_hidden
-            probs_to_combine = dispatched_probs
-
-            # The check for the combine
-            combined_hidden, combined_probs = buffer.combine_with_unpermute(
-                hidden=hidden_to_combine,
-                probs=probs_to_combine,
-                handle=handle,
-                pad_multiple=PAD_MULTIPLE,
-                fuse_unpermute_combine=fuse_permute_dispatch,
-            )
-
-            # The reconstucted value should be TOPK times larger than the input hidden
-            combined_hidden = combined_hidden / TOPK
-
-            assert torch.allclose(
-                combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2
-            ), f"Combine hidden mismatch (with_probs={with_probs}, fuse_permute_dispatch={fuse_permute_dispatch})"
-            if combined_probs is not None and probs is not None:
-                assert bitwise_equal(combined_probs, probs), \
-                    f"Combine probs mismatch (with_probs={with_probs}, fuse_permute_dispatch={fuse_permute_dispatch})"
-
-        dist.barrier()
-        if dist.get_rank() == 0:
-            api_name = (
-                'dispatch_with_permute + combine_with_unpermute API (non-fused)'
-                if not fuse_permute_dispatch
-                else 'dispatch_with_permute + combine_with_unpermute API (fused)'
-            )
-            print(f'  {api_name}: PASS', flush=True)
-
-    # Dense top-k routing with permute correctness check. This exercises scan
-    # with dense topk_idx input and enable_permute=True, i.e. the path that
-    # produces dense_chunk_layout and dense_to_expert_map.
-    if supports_dense_permute:
+    for routing_label, use_dense_topk in routing_modes:
         for fuse_permute_dispatch in [False, True]:
             for with_probs in [True, False]:
-                context = (f" (dense_routing=True, with_probs={with_probs}, "
+                context = (f" ({routing_label}, with_probs={with_probs}, "
                            f"fuse_permute_dispatch={fuse_permute_dispatch})")
+                dispatch_kwargs = {
+                    "hidden": hidden,
+                    "scaling_factor": scaling_factor,
+                    "pad_multiple": PAD_MULTIPLE,
+                    "fuse_permute_dispatch": fuse_permute_dispatch,
+                }
+                if use_dense_topk:
+                    dispatch_kwargs.update({
+                        "topk_idx": topk_idx,
+                        "topk_weights": topk_weights if with_probs else None,
+                        "num_of_experts": NUM_OF_EXPERTS,
+                    })
+                else:
+                    dispatch_kwargs.update({
+                        "routing_map": routing_map,
+                        "probs": probs if with_probs else None,
+                    })
+
                 (
-                    dispatched_hidden_dense,
-                    dispatched_probs_dense,
-                    dispatched_scaling_factor_dense,
-                    _tokens_per_expert_dense,
-                    handle_dense,
-                ) = buffer.dispatch_with_permute(
-                    hidden=hidden,
-                    topk_idx=topk_idx,
-                    topk_weights=topk_weights if with_probs else None,
-                    num_of_experts=NUM_OF_EXPERTS,
-                    scaling_factor=scaling_factor,
-                    pad_multiple=PAD_MULTIPLE,
-                    fuse_permute_dispatch=fuse_permute_dispatch,
-                    dense_routing=True,
-                )
+                    dispatched_hidden,
+                    dispatched_probs,
+                    dispatched_scaling_factor,
+                    _tokens_per_expert,
+                    handle,
+                ) = buffer.dispatch_with_permute(**dispatch_kwargs)
 
                 (
                     dispatched_hidden_ref,
@@ -382,14 +303,14 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
                     enable_permute=True,
                 )
 
-                assert_bitwise_equal("Dense dispatch+permute hidden", dispatched_hidden_ref, dispatched_hidden_dense, context)
-                assert_bitwise_equal("Dense dispatch+permute probs", dispatched_probs_ref, dispatched_probs_dense, context)
-                assert_bitwise_equal("Dense dispatch+permute scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor_dense, context)
+                assert_bitwise_equal("Dispatch+permute hidden", dispatched_hidden_ref, dispatched_hidden, context)
+                assert_bitwise_equal("Dispatch+permute probs", dispatched_probs_ref, dispatched_probs, context)
+                assert_bitwise_equal("Dispatch+permute scaling_factor", dispatched_scaling_factor_ref, dispatched_scaling_factor, context)
 
                 combined_hidden, combined_probs = buffer.combine_with_unpermute(
-                    hidden=dispatched_hidden_dense.to(torch.bfloat16),
-                    probs=dispatched_probs_dense,
-                    handle=handle_dense,
+                    hidden=dispatched_hidden.to(torch.bfloat16),
+                    probs=dispatched_probs,
+                    handle=handle,
                     pad_multiple=PAD_MULTIPLE,
                     fuse_unpermute_combine=fuse_permute_dispatch,
                 )
@@ -397,19 +318,21 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
 
                 assert torch.allclose(
                     combined_hidden, hidden.to(torch.bfloat16), atol=2e-5, rtol=1e-2
-                ), f"Dense combine+unpermute hidden mismatch{context}"
+                ), f"Combine+unpermute hidden mismatch{context}"
                 if combined_probs is not None and probs is not None:
-                    assert_bitwise_equal("Dense combine+unpermute probs", probs, combined_probs, context)
+                    assert_bitwise_equal("Combine+unpermute probs", probs, combined_probs, context)
 
             dist.barrier()
             if dist.get_rank() == 0:
+                dense_suffix = "dense routing, " if use_dense_topk else ""
                 api_name = (
-                    'dispatch_with_permute + combine_with_unpermute API (dense routing, non-fused)'
+                    f'dispatch_with_permute + combine_with_unpermute API ({dense_suffix}non-fused)'
                     if not fuse_permute_dispatch
-                    else 'dispatch_with_permute + combine_with_unpermute API (dense routing, fused)'
+                    else f'dispatch_with_permute + combine_with_unpermute API ({dense_suffix}fused)'
                 )
                 print(f'  {api_name}: PASS', flush=True)
-    else:
+
+    if not supports_dense_topk:
         dist.barrier()
         if dist.get_rank() == 0:
             print('  dispatch_with_permute + combine_with_unpermute API (dense routing): SKIP (unsupported)', flush=True)


### PR DESCRIPTION
## Summary
- Add dense int16 top-k routing input for HybridEP metadata preprocessing.
- Optimize dense scan with local-expert and rank bitsets.
- Improve HybridEP test diagnostics and benchmark labels, including with/without-probs paths.

## Performance
Primary impact is scan preprocessing: dense scan is significantly faster on the target dense top-k path. End-to-end dispatch/combine bandwidth is effectively unchanged versus upstream hybrid-ep in single-node B300 tests, with no observed regression.

## Testing
- Built on B300 with `TORCH_CUDA_ARCH_LIST="10.0;10.3+PTX"`.
- `tests/test_hybrid_ep.py --num-processes 8` on B300 for default config.
- Same test for H=512/E=8/K=8 and H=4096/E=8/K=8.
- BF16 and FP8 correctness passed, including dense top-k scan and dense top-k scan+permute paths.
- Re-ran updated test script against upstream hybrid-ep; dense-routing checks skip cleanly when unsupported.