### PR TITLE
Fix the CPU-assisted (GDRCopy) IBGDA path in the legacy kernels

### DIFF
--- a/csrc/kernels/legacy/ibgda_device.cuh
+++ b/csrc/kernels/legacy/ibgda_device.cuh
@@ -172,7 +172,10 @@ __device__ static __forceinline__ void ibgda_submit_requests(nvshmemi_ibgda_devi
         // max mirrors NVSHMEM's own `ibgda_proxy_post_send`. The old code CASed on
         // `tx_wq.prod_idx`, which NVSHMEM wires to a device-side counter the proxy never
         // reads, so submissions were invisible to the proxy and the first dispatch hung
-        // waiting for a doorbell that was never rung.
+        // waiting for a doorbell that was never rung. The slot is a dedicated 8-byte,
+        // naturally aligned uint64_t per QP (NVSHMEM allocates the proxy slot array as
+        // uint64_t entries and the proxy reads them back as uint64_t), matching the
+        // 64-bit atomic width used here.
         atomicMax_system((unsigned long long int*)qp->tx_wq.bf,
                          (unsigned long long int)new_wqe_idx);
     }
@@ -499,8 +502,12 @@ __device__ static __forceinline__ void ibgda_poll_cq(nvshmemi_ibgda_device_cq_t*
 // Wait until wqe `idx - 1` is completed.
 __device__ static __forceinline__ void nvshmemi_ibgda_quiet(int dst_pe, int qp_id) {
     auto qp = ibgda_get_rc(dst_pe, qp_id);
-    auto state = ibgda_get_state();
-    uint64_t prod_idx = state->use_async_postsend ? ld_na_relaxed(qp->tx_wq.prod_idx) : ld_na_relaxed(&qp->mvars.tx_wq.ready_head);
+    // `ready_head` is the submitted frontier in both modes now that
+    // `ibgda_submit_requests` always orders through it. The async branch used to read
+    // `tx_wq.prod_idx`, which the fixed submit path no longer advances (the async
+    // publish goes to `tx_wq.bf` instead), so reading it here would make the drain a
+    // no-op under the CPU handlers.
+    uint64_t prod_idx = ld_na_relaxed(&qp->mvars.tx_wq.ready_head);
     ibgda_poll_cq(qp->tx_wq.cq, prod_idx);
 }
 

--- a/csrc/kernels/legacy/ibgda_device.cuh
+++ b/csrc/kernels/legacy/ibgda_device.cuh
@@ -152,10 +152,11 @@ __device__ static __forceinline__ void ibgda_submit_requests(nvshmemi_ibgda_devi
     // WQE writes must be finished first
     __threadfence();
 
-    unsigned long long int* ready_idx =
-        (unsigned long long int*)(state->use_async_postsend ? qp->tx_wq.prod_idx : &mvars->tx_wq.ready_head);
-
-    // Wait for prior WQE slots to be filled first
+    // Wait for prior WQE slots to be filled first. Submissions must always be ordered
+    // through `ready_head`: NVSHMEM's own submit path CASes on it for QPs shared with
+    // DeepEP (e.g. the barrier inside `Buffer::destroy`), so leaving it stale deadlocks
+    // the first NVSHMEM-side submission.
+    unsigned long long int* ready_idx = (unsigned long long int*)(&mvars->tx_wq.ready_head);
     while (atomicCAS(ready_idx, base_wqe_idx, new_wqe_idx) != base_wqe_idx)
         ;
 
@@ -164,6 +165,16 @@ __device__ static __forceinline__ void ibgda_submit_requests(nvshmemi_ibgda_devi
         constexpr int kNumRequestInBatch = 4;
         if (kAlwaysDoPostSend or (message_idx + 1) % kNumRequestInBatch == 0)
             ibgda_post_send(qp, new_wqe_idx);
+    } else {
+        // CPU-assisted (async post-send) mode: publish the new producer index to the CPU
+        // proxy thread. NVSHMEM wires `tx_wq.bf` to the proxy-polled producer slot in this
+        // mode (the UAR is only mapped for the GPU handler), so a system-scope monotonic
+        // max mirrors NVSHMEM's own `ibgda_proxy_post_send`. The old code CASed on
+        // `tx_wq.prod_idx`, which NVSHMEM wires to a device-side counter the proxy never
+        // reads, so submissions were invisible to the proxy and the first dispatch hung
+        // waiting for a doorbell that was never rung.
+        atomicMax_system((unsigned long long int*)qp->tx_wq.bf,
+                         (unsigned long long int)new_wqe_idx);
     }
 }
 


### PR DESCRIPTION
[docs/nvshmem.md](https://github.com/deepseek-ai/DeepEP/blob/main/docs/nvshmem.md) (§ "Install GDRCopy and load the gdrdrv kernel module") documents the CPU-assisted IBGDA mode as the supported alternative "when modifying the driver regkeys is not an option". In practice that mode (`NVSHMEM_IBGDA_NIC_HANDLER=cpu`) has never worked with DeepEP: the async post-send branch in `ibgda_submit_requests` (csrc/kernels/legacy/ibgda_device.cuh) has two independent defects, either of which is fatal.

**Bug 1 — submissions are invisible to the CPU proxy (first dispatch hangs).**
The async branch CASes on `qp->tx_wq.prod_idx`. NVSHMEM's host code wires that pointer to a device-side management counter (`ibgda_setup_gpu_state`: `rc_h[i].tx_wq.prod_idx = base_mvars_d_addr + prod_idx_offset`), but the proxy thread polls a separate producer-slot array (`nvshmemt_ibgda_progress` reads `qp_shared_object.prod_idx_mobject`). The value DeepEP publishes is therefore never observed, no doorbell is ever rung, and the very first dispatch spins forever waiting for data (surfacing as the NCCL watchdog SIGABRT after 600 s).

**Bug 2 — teardown deadlock on shared QPs.**
The async branch also skips the `ready_head` CAS queue. NVSHMEM's own submit path orders every submission through `mvars->tx_wq.ready_head`, and DeepEP shares the same QP management memory with NVSHMEM. After a DeepEP workload, `resv_head` is far ahead while `ready_head` is still 0; the first NVSHMEM-side submission on a shared QP — the `nvshmem_barrier_all()` inside `Buffer::destroy()` — reserves a slot and then spins forever on `atomicCAS(ready_head==0, expect resv_head)`. That spin has no timeout, so the process hangs in `cuStreamSynchronize` with the GPU at 100%.

**Fix.** Always order submissions through `ready_head` (matching NVSHMEM's protocol), and in the async mode publish the new producer index with a system-scope `atomicMax` on `qp->tx_wq.bf` — in the CPU-assisted modes NVSHMEM wires `bf` to the proxy-polled producer slot (see `ibgda_get_device_qp`), so this mirrors NVSHMEM's own `ibgda_proxy_post_send` exactly and needs no NVSHMEM-side change. System scope keeps the publish visible to the CPU observer also for `NVSHMEM_IBGDA_NIC_HANDLER=cpu_host_memory`, where the slot lives in host memory.

**Validation.** On our rig (NVSHMEM 3.4.5, 2 nodes, 4 RC QPs per rank, `NVSHMEM_IBGDA_NIC_HANDLER=cpu` with GDRCopy) `tests/test_low_latency.py` previously hung at the first dispatch; with only the pointer rewired it then deadlocked in `Buffer::destroy()`. With this patch the full run — benchmark plus teardown (barrier → free → finalize) — completes and exits 0, with benchmark numbers unchanged. The defect is pure protocol logic, independent of the NIC; on ConnectX it should reproduce by simply exporting `NVSHMEM_IBGDA_NIC_HANDLER=cpu` (NVSHMEM built with GDRCopy) and running `tests/test_low_latency.py`.

The GPU-direct doorbell path (`NVSHMEM_IBGDA_NIC_HANDLER=gpu`, the default) is unaffected: its submit branch already ordered through `ready_head` and does not take the async path.