### PR TITLE
legacy: allow build-time override of watchdog timeout constants

### DIFF
--- a/csrc/kernels/legacy/compiled.cuh
+++ b/csrc/kernels/legacy/compiled.cuh
@@ -14,5 +14,13 @@
 #define LEGACY_FINISHED_SUM_TAG 1024
 #define LEGACY_NUM_WAIT_NANOSECONDS 500
 
+// Overridable at build time (e.g. -DLEGACY_NUM_CPU_TIMEOUT_SECS=1800) for consumers
+// whose first-step warmup legitimately exceeds the default: JIT kernel compilation
+// (e.g. DeepGEMM) on a subset of ranks holds the others inside dispatch past 100 s,
+// which the watchdog then misreports as a communication timeout.
+#ifndef LEGACY_NUM_CPU_TIMEOUT_SECS
 #define LEGACY_NUM_CPU_TIMEOUT_SECS 100
+#endif
+#ifndef LEGACY_NUM_TIMEOUT_CYCLES
 #define LEGACY_NUM_TIMEOUT_CYCLES 200000000000ull  // 200G cycles ~= 100s
+#endif


### PR DESCRIPTION
## Summary
Wraps `LEGACY_NUM_CPU_TIMEOUT_SECS` / `LEGACY_NUM_TIMEOUT_CYCLES` in `#ifndef` so integrators can raise the watchdog at build time (e.g. `-DLEGACY_NUM_CPU_TIMEOUT_SECS=1800`) without patching sources. Defaults unchanged.

## Motivation
On first run, frameworks that JIT-compile their expert GEMMs hold some ranks inside dispatch while peers finish compiling. Concretely: SGLang's DeepGEMM warmup (10–20 min cold, per its own log banner) exceeds the hardcoded 100 s watchdog, which then kills the run with `DeepEP error: timeout (dispatch CPU)` although no communication fault exists.

Measured on 2× p5en.48xlarge (H200, 16 EFA NICs, EP16, Qwen3-30B-A3B-FP8, SGLang 0.5.5.post3): with the constant raised to 1800 s the identical workload completes and serves; write-up with numbers: https://dmvevents.github.io/deepep-efa-guidance/sections/08-v1-nvshmem-backend.html

## Notes
- Touches only the legacy (`deep_ep.Buffer`) path where the constant lives; happy to extend the same guard to the EPv2 tree if wanted.
- An env-var runtime override would be nicer but the constants are compiled into device code; `#ifndef` is the minimal non-breaking step.
- Ready for review — 8-line `#ifndef` wrap, zero behavior change when nothing is `-D`-defined. Note the two constants are coupled (200G cycles ~= 100 s device-side): overriding only `LEGACY_NUM_CPU_TIMEOUT_SECS` leaves the device timeout at its default, so integrators should raise both together.
