### PR TITLE
Fix JIT cache crash for rename-race losers on shared filesystems

### DIFF
--- a/csrc/jit/cache.hpp
+++ b/csrc/jit/cache.hpp
@@ -34,6 +34,9 @@ public:
     // signature), and the winner's directory may not be visible to this client yet on
     // shared filesystems.
     std::shared_ptr<KernelRuntime> put(const std::filesystem::path& key_path, const std::filesystem::path& load_path) {
+        // Share `get`'s validity/diagnostic path so a bad artifact directory is reported
+        // identically no matter which write path caches it
+        EP_HOST_ASSERT(KernelRuntime::check_validity(load_path));
         return cache[key_path] = std::make_shared<KernelRuntime>(load_path);
     }
 };

--- a/csrc/jit/cache.hpp
+++ b/csrc/jit/cache.hpp
@@ -27,6 +27,15 @@ public:
             return cache[dir_path] = std::make_shared<KernelRuntime>(dir_path);
         return nullptr;
     }
+
+    // Load a runtime from `load_path` and cache it under `key_path`. Used by the losing
+    // side of the build rename race: its just-compiled artifacts are equivalent to the
+    // winner's (the cache key hashes the kernel name, source, flags, and compiler
+    // signature), and the winner's directory may not be visible to this client yet on
+    // shared filesystems.
+    std::shared_ptr<KernelRuntime> put(const std::filesystem::path& key_path, const std::filesystem::path& load_path) {
+        return cache[key_path] = std::make_shared<KernelRuntime>(load_path);
+    }
 };
 
 static auto kernel_runtime_cache = std::make_shared<KernelRuntimeCache>();

--- a/csrc/jit/compiler.hpp
+++ b/csrc/jit/compiler.hpp
@@ -146,11 +146,20 @@ public:
         std::error_code error_code;
         std::filesystem::rename(tmp_dir_path, dir_path, error_code);
         if (error_code) {
-            // Another rank beat us, then clean up our dir and use the existing one
+            // Another rank beat us. Do not read `dir_path` here: on a shared filesystem
+            // (e.g. an NFS-mounted `$HOME/.deep_ep`) the winner's rename is not necessarily
+            // visible to this client yet — the cache miss above may have primed a negative
+            // lookup cache entry that outlives the failed rename, so a stat can still report
+            // the directory as missing until the attribute cache expires. Our own artifacts
+            // are equivalent (the cache key hashes the kernel name, source, flags, and
+            // compiler signature), so load them and leave the winner's directory for
+            // future processes.
             // NOTES: avoid `std::filesystem::remove_all` here — it can segfault on
             // distributed filesystems, when concurrent processes operate
             // on the same parent directory, causing stale directory entries
+            const auto runtime = kernel_runtime_cache->put(dir_path, tmp_dir_path);
             safe_remove_all(tmp_dir_path);
+            return runtime;
         }
 
         // Put into the runtime cache

--- a/csrc/jit/compiler.hpp
+++ b/csrc/jit/compiler.hpp
@@ -157,12 +157,17 @@ public:
             // NOTES: avoid `std::filesystem::remove_all` here — it can segfault on
             // distributed filesystems, when concurrent processes operate
             // on the same parent directory, causing stale directory entries
+            if (get_env<int>("EP_JIT_DEBUG"))
+                printf("Rename to %s lost, loading own artifacts from %s\n", dir_path.c_str(), tmp_dir_path.c_str());
             const auto runtime = kernel_runtime_cache->put(dir_path, tmp_dir_path);
             safe_remove_all(tmp_dir_path);
             return runtime;
         }
 
         // Put into the runtime cache
+        // NOTES: only the rename winner reaches this `get`, and its own client just created
+        // `dir_path`, so the lookup is served from fresh positive local state — the stale
+        // negative-entry hazard above only applies to clients that lost the rename
         const auto runtime = kernel_runtime_cache->get(dir_path);
         EP_HOST_ASSERT(runtime != nullptr);
         return runtime;


### PR DESCRIPTION
Fixes #683.

## Problem

On a shared filesystem (the default `$HOME/.deep_ep` is typically NFS on multi-node clusters), the losing side of the compile/rename race in `Compiler::build()` crashes at `EP_HOST_ASSERT(runtime != nullptr)`: its rename fails authoritatively at the server, but the winner's directory may not be visible to its NFS client yet, the initial cache miss primed a negative lookup cache entry that can outlive the failed rename. Full mechanism in #683.

## Change

Make the losing path self-sufficient instead of requiring cross-client visibility:

- `csrc/jit/compiler.hpp`: on rename failure, load the runtime from this process's own just-compiled temp directory (equivalent artifacts. The cache key hashes kernel name, source, flags, and compiler signature), cache it under the canonical `dir_path` key, then delete the temp directory.
- `csrc/jit/cache.hpp`: add `KernelRuntimeCache::put(key_path, load_path)` to construct from one path and cache under another.

This is safe because the `KernelRuntime` constructor consumes the files eagerly (`cuobjdump -symbols`, then `cudaLibraryLoadFromFile`/`cuModuleLoad`) and keeps only GPU handles. Warm starts still read the shared cache exactly as before; other rename failures (e.g. permissions) now degrade gracefully instead of asserting (scope: the rename failure itself — a subsequent failure to load the loser's own artifacts remains fatal, with the same `check_validity` diagnostics as any other cache entry).

## Testing

Two 8-GPU H200 nodes (16 ranks), JIT cache on shared NFS, cold start, `ElasticBuffer` construction plus a dispatch/combine round trip per rank (`EP_JIT_DEBUG=1`):

- **Unpatched**: reproduced: all 8 ranks of the losing node crash at `compiler.hpp:158` while JIT-building the dispatch/combine kernels; the other node hangs in the next collective.
- **Patched, same scenario**: 16/16 pass; the new branch executed 73 times across 80 rank×kernel builds (`Loading CUBIN: <cache>/tmp/<uuid>/kernel.cubin`), and the shared `tmp/` is empty afterwards.
- **Warm start**: 16/16 pass with all 80 loads served from the canonical cache directories; the new branch is never taken.
- The full extension builds cleanly with the patch (torch 2.10, CUDA 13.0, NCCL 2.30.4, sm90).
- Review commit ef2ae56 re-validated on the same setup: the new `EP_JIT_DEBUG` fallback log fired 75/75 times, each paired 1:1 with a tmp-dir CUBIN load, 16/16 ranks green.

