### PR TITLE
NCCL devComm: allocate according to devCommRuntimeVersionSize

### DIFF
--- a/csrc/kernels/backend/api.cuh
+++ b/csrc/kernels/backend/api.cuh
@@ -65,7 +65,7 @@ public:
 
     // NCCL handles
     ncclComm_t comm;
-    ncclDevComm_t dev_comm;
+    ncclDevComm_t* dev_comm;
     ncclWindow_t window;
     void* mapped_window_ptr;
     std::vector<void*> nvl_window_ptrs;

--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -65,11 +65,11 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
                                                        const bool& allow_hybrid_mode,
                                                        const int& sl_idx, const int& num_allocated_qps):
     rank_idx(rank_idx), num_ranks(num_ranks), num_allocated_qps(num_allocated_qps) {
+    int nccl_runtime_version;
+    NCCL_CHECK(ncclGetVersion(&nccl_runtime_version));
     if (get_env("EP_BUFFER_DEBUG", 0)) {
-        int nccl_version;
-        NCCL_CHECK(ncclGetVersion(&nccl_version));
         printf("DeepEP initialized with NCCL version: %d.%d.%d (loaded library)\n",
-               nccl_version / 10000, (nccl_version % 10000) / 100, nccl_version % 100);
+            nccl_runtime_version / 10000, (nccl_runtime_version % 10000) / 100, nccl_runtime_version % 100);
     }
 
     // Reuse the NCCL communicator
@@ -80,11 +80,10 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
         printf("EP NCCL device communicator has %d allocated QPs\n", num_allocated_qps);
 
     // Initialize NCCL device communicator
+    ncclCommProperties props = NCCL_COMM_PROPERTIES_INITIALIZER;
+    NCCL_CHECK(ncclCommQueryProperties(comm, &props));
     ncclDevCommRequirements_t reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
     if (num_ranks > 1 and get_env("EP_DISABLE_GIN", 0) == 0) {
-        // Query NCCL supported Gin Type
-        ncclCommProperties props = NCCL_COMM_PROPERTIES_INITIALIZER;
-        NCCL_CHECK(ncclCommQueryProperties(comm, &props));
         EP_HOST_ASSERT(
             (allow_hybrid_mode ? props.railedGinType : props.ginType) != NCCL_GIN_TYPE_NONE and
             "NCCL GIN is unavailable. This is usually due to a network configuration issue, "
@@ -98,10 +97,19 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
         reqs.ginSignalCount = num_ranks + 2 * 2;
         reqs.ginConnectionType = allow_hybrid_mode ? NCCL_GIN_CONNECTION_RAIL: NCCL_GIN_CONNECTION_FULL;
     }
-    NCCL_CHECK(ncclDevCommCreate(comm, &reqs, &dev_comm));
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)
+    reqs.useRuntimeVersion = true;
+    dev_comm = static_cast<ncclDevComm_t*>(malloc(props.devCommRuntimeVersionSize));
+#else
+    EP_HOST_ASSERT(NCCL_VERSION_CODE == nccl_runtime_version and "Prior to NCCL 2.31, NCCL compile-time and runtime versions must be the same. Please re-compile DeepEP.");
+    dev_comm = static_cast<ncclDevComm_t*>(malloc(sizeof(ncclDevComm_t)));
+#endif
+    EP_HOST_ASSERT(dev_comm != nullptr);
+    NCCL_CHECK(ncclDevCommCreate(comm, &reqs, dev_comm));
 
     // Now we know the NVLink domain size
-    num_nvl_ranks = dev_comm.lsaSize, nvl_rank_idx = dev_comm.lsaRank;
+    ncclTeam_t lsaTeam = ncclTeamLsa(comm);
+    num_nvl_ranks = lsaTeam.nRanks, nvl_rank_idx = lsaTeam.rank;
     num_rdma_ranks = num_ranks / num_nvl_ranks, rdma_rank_idx = rank_idx / num_nvl_ranks;
     EP_HOST_ASSERT(num_ranks % num_nvl_ranks == 0 and nvl_rank_idx == rank_idx % num_nvl_ranks);
     EP_HOST_ASSERT(rank_idx == rdma_rank_idx * num_nvl_ranks + nvl_rank_idx);
@@ -150,7 +158,8 @@ void NCCLSymmetricMemoryContext::finalize() {
     symmetric_memory.reset();
 
     // Destroy device communicator
-    NCCL_CHECK(ncclDevCommDestroy(comm, &dev_comm));
+    NCCL_CHECK(ncclDevCommDestroy(comm, dev_comm));
+    free(dev_comm);
 }
 
 }  // namespace deep_ep::nccl

--- a/csrc/kernels/elastic/barrier.hpp
+++ b/csrc/kernels/elastic/barrier.hpp
@@ -21,7 +21,7 @@ public:
         bool sequential;
 
         // Parameters
-        ncclDevComm_t nccl_dev_comm;
+        ncclDevComm_t* nccl_dev_comm;
         ncclWindow_t nccl_window;
         void* workspace;
         int scaleout_rank_idx, scaleup_rank_idx;
@@ -47,13 +47,13 @@ static void __instantiate_kernel() {{
     static void launch_impl(const jit::KernelHandle& kernel, const jit::LaunchConfigHandle& config, Args args) {
         EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(
             kernel, config,
-            args.nccl_dev_comm, args.nccl_window,
+            *args.nccl_dev_comm, args.nccl_window,
             args.workspace, args.scaleout_rank_idx, args.scaleup_rank_idx
         ));
     }
 };
 
-static void launch_barrier(const ncclDevComm_t& nccl_dev_comm, const ncclWindow_t& nccl_window,
+static void launch_barrier(ncclDevComm_t* nccl_dev_comm, const ncclWindow_t& nccl_window,
                            void* workspace,
                            const int& scaleout_rank_idx, const int& scaleup_rank_idx,
                            const int& num_scaleout_ranks, const int& num_scaleup_ranks,

--- a/csrc/kernels/elastic/combine.hpp
+++ b/csrc/kernels/elastic/combine.hpp
@@ -32,7 +32,7 @@ public:
         int* psum_num_recv_tokens_per_scaleup_rank;
         int* token_metadata_at_forward;
         int* channel_linked_list;
-        ncclDevComm_t nccl_dev_comm;
+        ncclDevComm_t* nccl_dev_comm;
         ncclWindow_t nccl_window;
         void* buffer;
         void* workspace;
@@ -87,7 +87,7 @@ static void __instantiate_kernel() {{
             EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(kernel, config,
                                                      args.x, args.topk_weights,
                                                      args.src_metadata, args.psum_num_recv_tokens_per_scaleup_rank,
-                                                     args.nccl_dev_comm, args.nccl_window,
+                                                     *args.nccl_dev_comm, args.nccl_window,
                                                      args.buffer, args.workspace,
                                                      args.scaleup_rank_idx,
                                                      args.num_reduced_tokens));
@@ -98,7 +98,7 @@ static void __instantiate_kernel() {{
                                                      args.psum_num_recv_tokens_per_scaleup_rank,
                                                      args.token_metadata_at_forward,
                                                      args.channel_linked_list,
-                                                     args.nccl_dev_comm, args.nccl_window,
+                                                     *args.nccl_dev_comm, args.nccl_window,
                                                      args.buffer, args.workspace,
                                                      args.scaleout_rank_idx, args.scaleup_rank_idx,
                                                      args.num_reduced_tokens));
@@ -117,7 +117,7 @@ static void* launch_combine(void* x,
                             int* psum_num_recv_tokens_per_scaleup_rank,
                             int* token_metadata_at_forward,
                             int* channel_linked_list,
-                            const ncclDevComm_t& nccl_dev_comm, const ncclWindow_t& nccl_window,
+                            ncclDevComm_t* nccl_dev_comm, const ncclWindow_t& nccl_window,
                             void* buffer, void* workspace,
                             const int& num_reduced_tokens, const int& num_max_tokens_per_rank,
                             const int& hidden,

--- a/csrc/kernels/elastic/dispatch.hpp
+++ b/csrc/kernels/elastic/dispatch.hpp
@@ -39,7 +39,7 @@ public:
         int* token_metadata_at_forward;
         int num_tokens;
         int sf_token_stride, sf_hidden_stride;
-        ncclDevComm_t nccl_dev_comm;
+        ncclDevComm_t* nccl_dev_comm;
         ncclWindow_t nccl_window;
         void* buffer;
         void* workspace; void* mapped_host_workspace;
@@ -101,7 +101,7 @@ static void __instantiate_kernel() {{
                 args.dst_buffer_slot_idx,
                 args.num_tokens,
                 args.sf_token_stride, args.sf_hidden_stride,
-                args.nccl_dev_comm, args.nccl_window,
+                *args.nccl_dev_comm, args.nccl_window,
                 args.buffer,
                 args.workspace, args.mapped_host_workspace,
                 args.scaleup_rank_idx));
@@ -118,7 +118,7 @@ static void __instantiate_kernel() {{
                 args.token_metadata_at_forward,
                 args.num_tokens,
                 args.sf_token_stride, args.sf_hidden_stride,
-                args.nccl_dev_comm, args.nccl_window,
+                *args.nccl_dev_comm, args.nccl_window,
                 args.buffer,
                 args.workspace, args.mapped_host_workspace,
                 args.scaleout_rank_idx, args.scaleup_rank_idx
@@ -151,7 +151,7 @@ static void launch_dispatch(void* x, void* sf,
                             const int& hidden, const int& elem_size,
                             const int& num_sf_packs, const int& sf_token_stride, const int& sf_hidden_stride,
                             const int& num_experts, const int& num_topk, const int& expert_alignment,
-                            const ncclDevComm_t& nccl_dev_comm, const ncclWindow_t& nccl_window,
+                            ncclDevComm_t* nccl_dev_comm, const ncclWindow_t& nccl_window,
                             void* buffer,
                             void* workspace, void* mapped_host_workspace,
                             const int& scaleout_rank_idx, const int& scaleup_rank_idx,

--- a/csrc/kernels/elastic/engram.hpp
+++ b/csrc/kernels/elastic/engram.hpp
@@ -25,7 +25,7 @@ public:
         bool allow_hybrid_mode;
 
         // Parameters
-        ncclDevComm_t nccl_dev_comm;
+        ncclDevComm_t* nccl_dev_comm;
         ncclWindow_t nccl_window;
         void* storage;
         void* fetched;
@@ -69,7 +69,7 @@ static void __instantiate_kernel() {{
     static void launch_impl(const jit::KernelHandle& kernel, const jit::LaunchConfigHandle& config, Args args) {
         EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(
             kernel, config,
-            args.nccl_dev_comm, args.nccl_window,
+            *args.nccl_dev_comm, args.nccl_window,
             args.storage, args.fetched,
             args.indices,
             args.last_gin_requests,
@@ -80,7 +80,7 @@ static void __instantiate_kernel() {{
     }
 };
 
-static void launch_engram_fetch(const ncclDevComm_t& nccl_dev_comm, const ncclWindow_t& nccl_window,
+static void launch_engram_fetch(ncclDevComm_t* nccl_dev_comm, const ncclWindow_t& nccl_window,
                                 void* storage, void* fetched,
                                 int* indices,
                                 ncclGinRequest_t* last_gin_requests,
@@ -132,7 +132,7 @@ public:
         int num_scaleout_ranks, num_scaleup_ranks;
         bool allow_hybrid_mode;
 
-        ncclDevComm_t nccl_dev_comm;
+        ncclDevComm_t* nccl_dev_comm;
         ncclWindow_t nccl_window;
         ncclGinRequest_t* last_gin_requests;
 
@@ -160,14 +160,14 @@ static void __instantiate_kernel() {{
     static void launch_impl(const jit::KernelHandle& kernel, const jit::LaunchConfigHandle& config, Args args) {
         EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(
             kernel, config,
-            args.nccl_dev_comm, args.nccl_window,
+            *args.nccl_dev_comm, args.nccl_window,
             args.last_gin_requests
         ));
     }
 };
 
 static void launch_engram_fetch_wait(ncclGinRequest_t* last_gin_requests,
-                                     const ncclDevComm_t& nccl_dev_comm, const ncclWindow_t& nccl_window,
+                                     ncclDevComm_t* nccl_dev_comm, const ncclWindow_t& nccl_window,
                                      const int& num_scaleout_ranks, const int& num_scaleup_ranks,
                                      const int& num_qps,
                                      const bool& allow_hybrid_mode,

--- a/csrc/kernels/elastic/pp_send_recv.hpp
+++ b/csrc/kernels/elastic/pp_send_recv.hpp
@@ -21,7 +21,7 @@ public:
         int64_t num_timeout_cycles;
 
         // Parameters
-        ncclDevComm_t nccl_dev_comm;
+        ncclDevComm_t* nccl_dev_comm;
         ncclWindow_t nccl_window;
         void* x;
         int64_t num_x_bytes;
@@ -52,7 +52,7 @@ static void __instantiate_kernel() {{
     static void launch_impl(const jit::KernelHandle& kernel, const jit::LaunchConfigHandle& config, Args args) {
         EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(
             kernel, config,
-            args.nccl_dev_comm, args.nccl_window,
+            *args.nccl_dev_comm, args.nccl_window,
             args.x, args.num_x_bytes,
             args.buffer, args.workspace,
             args.rank_idx, args.dst_rank_idx,
@@ -61,7 +61,7 @@ static void __instantiate_kernel() {{
     }
 };
 
-static void launch_pp_send(const ncclDevComm_t& nccl_dev_comm,
+static void launch_pp_send(ncclDevComm_t* nccl_dev_comm,
                            const ncclWindow_t& nccl_window,
                            void* x, const int64_t& num_x_bytes,
                            void* buffer, void* workspace,
@@ -103,7 +103,7 @@ public:
         int64_t num_timeout_cycles;
 
         // Parameters
-        ncclDevComm_t nccl_dev_comm;
+        ncclDevComm_t* nccl_dev_comm;
         ncclWindow_t nccl_window;
         void* x;
         int64_t num_x_bytes;
@@ -135,7 +135,7 @@ static void __instantiate_kernel() {{
     static void launch_impl(const jit::KernelHandle& kernel, const jit::LaunchConfigHandle& config, Args args) {
         EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(
             kernel, config,
-            args.nccl_dev_comm, args.nccl_window,
+            *args.nccl_dev_comm, args.nccl_window,
             args.x, args.num_x_bytes,
             args.buffer, args.workspace,
             args.rank_idx, args.src_rank_idx,
@@ -145,7 +145,7 @@ static void __instantiate_kernel() {{
     }
 };
 
-static void launch_pp_recv(const ncclDevComm_t& nccl_dev_comm,
+static void launch_pp_recv(ncclDevComm_t* nccl_dev_comm,
                            const ncclWindow_t& nccl_window,
                            void* x,
                            const int64_t& num_x_bytes,


### PR DESCRIPTION
# Summary
Since the DeepEP device code is JIT compiled, it uses the runtime version of ncclDevComm, not the compile-time version. But the devComm is allocated on the host according to the host-compile-version. If the size of DevComm changes across versions, the allocated devComm may not be big enough.

# Changes
This PR makes changes to ensure the NCCL device API is functional even if the runtime version is not equal to the compile-time version:
1. malloc the devComm according to devCommRuntimeSize
2. set reqs->useRuntimeVersion. This indicates to NCCL that the device code is compiled using the runtime version
3. Pass `ncclDevComm_t*`  instead of `ncclDevComm_t` in most of the code. This makes it more explicit that the size is variable. 

# Testing

Run `test_ep.py`:

* Compile with 2.30.7, run with 2.30.7 -> success
* Compile with 2.31 (`dev` branch on github), run with 2.31 -> success
* Compile with 2.30.7, run with 2.31 -> failure. This condition will not work with 2.30.7 because `devCommRuntimeSize` is not yet exposed. But, in the future, compiling with x and running with x+1 will work.
* Compile with 2.31, run with 2.30.7 -> failure (forward compat is not supported)
