### PR TITLE
DeepEP v2:Add experimental direct recv_x dispatch path.

### DIFF
--- a/csrc/elastic/buffer.hpp
+++ b/csrc/elastic/buffer.hpp
@@ -649,6 +649,32 @@ public:
         }
     }
 
+    static int64_t get_comm_buffer_size(const int& num_max_tokens_per_rank,
+                                        const int& hidden, const int& num_sf_packs, const int& num_topk,
+                                        const int& elem_size,
+                                        const int& num_scaleout_ranks, const int& num_scaleup_ranks,
+                                        const bool& is_scaleup_nvlink,
+                                        const bool& allow_multiple_reduction) {
+        const auto num_dispatch_bytes = get_dispatch_buffer_size(
+            num_max_tokens_per_rank, hidden, num_sf_packs, num_topk, elem_size,
+            num_scaleout_ranks, num_scaleup_ranks,
+            is_scaleup_nvlink);
+        const auto num_combine_bytes = get_combine_buffer_size(
+            num_max_tokens_per_rank, hidden, num_topk,
+            num_scaleout_ranks, num_scaleup_ranks,
+            is_scaleup_nvlink, allow_multiple_reduction);
+        return math::align(std::max(num_dispatch_bytes, num_combine_bytes), symmetric::kNumAlignmentBytes);
+    }
+
+    static int64_t get_direct_recv_x_buffer_size(const int& num_max_tokens_per_rank,
+                                                 const int& hidden, const int& elem_size,
+                                                 const int& num_scaleout_ranks, const int& num_scaleup_ranks) {
+        const auto num_ranks = num_scaleup_ranks * num_scaleout_ranks;
+        return math::align<int64_t>(
+            static_cast<int64_t>(num_ranks) * num_max_tokens_per_rank * hidden * elem_size,
+            symmetric::kNumAlignmentBytes);
+    }
+
     static int64_t calculate_buffer_size(const int64_t& nccl_comm,
                                          const int& num_max_tokens_per_rank, const int& hidden,
                                          int num_topk, const bool& use_fp8_dispatch,
@@ -670,19 +696,21 @@ public:
         // Dispatch size
         const auto elem_size = use_fp8_dispatch ? sizeof(__nv_fp8_e4m3) : sizeof(nv_bfloat16);
         const auto num_sf_packs = use_fp8_dispatch ? math::ceil_div(hidden, 32) : 0; // An approximation for number of SF packs
-        const auto num_dispatch_bytes = get_dispatch_buffer_size(
-            num_max_tokens_per_rank, hidden, num_sf_packs, num_topk, elem_size,
-            num_scaleout_ranks, num_scaleup_ranks,
-            is_scaleup_nvlink);
-
-        // Combine layout
-        const auto num_combine_bytes = get_combine_buffer_size(
-            num_max_tokens_per_rank, hidden, num_topk,
+        auto num_comm_bytes = get_comm_buffer_size(
+            num_max_tokens_per_rank, hidden, num_sf_packs, num_topk,
+            elem_size,
             num_scaleout_ranks, num_scaleup_ranks,
             is_scaleup_nvlink, allow_multiple_reduction);
 
-        // Return the maximum of those layouts, aligned to 2 MB
-        return math::align(std::max(num_dispatch_bytes, num_combine_bytes), symmetric::kNumAlignmentBytes);
+        if (get_env<int>("EP_V2_EXPERIMENTAL_DIRECT_RECV_X", 0) != 0) {
+            num_comm_bytes += get_direct_recv_x_buffer_size(
+                num_max_tokens_per_rank, hidden, elem_size,
+                num_scaleout_ranks, num_scaleup_ranks);
+        }
+
+        // Return the maximum of dispatch/combine layouts, aligned to 2 MB.
+        // Direct recv_x appends a window-backed output region.
+        return num_comm_bytes;
     }
 
     static symmetric::cpu_handle_t create_cpu_handle(const int64_t& num_cpu_bytes) {
@@ -964,6 +992,28 @@ public:
                        num_max_tokens_per_rank, hidden, num_sf_packs, num_topk, x.element_size(),
                        nccl_context->num_scaleout_ranks, nccl_context->num_scaleup_ranks,
                        nccl_context->is_scaleup_nvlink) <= num_buffer_bytes);
+        const bool use_direct_recv_x = get_env<int>("EP_V2_EXPERIMENTAL_DIRECT_RECV_X", 0) != 0;
+        if (use_direct_recv_x) {
+            EP_HOST_ASSERT(not cached_mode and
+                           "EP_V2_EXPERIMENTAL_DIRECT_RECV_X currently supports non-cached dispatch only");
+            EP_HOST_ASSERT(not do_expand and
+                           "EP_V2_EXPERIMENTAL_DIRECT_RECV_X currently supports non-expanded dispatch only");
+            EP_HOST_ASSERT(not previous_event_before_epilogue.has_value() and
+                           "EP_V2_EXPERIMENTAL_DIRECT_RECV_X writes recv_x in dispatch and cannot honor previous_event_before_epilogue");
+        }
+        const auto direct_recv_x_buffer_offset = use_direct_recv_x ? get_comm_buffer_size(
+            num_max_tokens_per_rank, hidden, num_sf_packs, num_topk, x.element_size(),
+            nccl_context->num_scaleout_ranks, nccl_context->num_scaleup_ranks,
+            nccl_context->is_scaleup_nvlink, allow_multiple_reduction) : 0;
+        void* direct_recv_x_ptr = use_direct_recv_x ? math::advance_ptr(buffer, direct_recv_x_buffer_offset) : nullptr;
+        if (use_direct_recv_x) {
+            const auto direct_recv_x_bytes = get_direct_recv_x_buffer_size(
+                num_max_tokens_per_rank, hidden, x.element_size(),
+                nccl_context->num_scaleout_ranks, nccl_context->num_scaleup_ranks);
+            EP_HOST_ASSERT(direct_recv_x_buffer_offset + direct_recv_x_bytes <= num_gpu_buffer_bytes and
+                           "EP_V2_EXPERIMENTAL_DIRECT_RECV_X requires extra GPU buffer bytes; "
+                           "pass a larger num_bytes if the buffer was sized manually");
+        }
 
         // Ready and clean host workspace for this round
         const auto host_workspace_layout = layout::WorkspaceLayout(
@@ -1000,6 +1050,8 @@ public:
                         num_smem_bytes,
                         num_qps, num_gpu_timeout_cycles,
                         cached_mode, do_cpu_sync,
+                        use_direct_recv_x,
+                        direct_recv_x_ptr,
                         comm_stream);
 
         // Received token counters
@@ -1073,7 +1125,17 @@ public:
         // Allocate received tensors
         // `recv_src_metadata` includes source token indices and buffer slot indices
         const auto num_allocated_tokens = do_expand ? num_expanded_tokens : num_recv_tokens;
-        auto recv_x = torch::empty({num_allocated_tokens, hidden}, x.options());
+        torch::Tensor recv_x;
+        if (use_direct_recv_x) {
+            // Experimental: `recv_x` is carved from the registered NCCL symmetric window tail.
+            // Dispatch writes hidden states here directly and uses the epilogue only for metadata/top-k.
+            recv_x = torch::from_blob(
+                direct_recv_x_ptr,
+                {num_allocated_tokens, hidden},
+                x.options());
+        } else {
+            recv_x = torch::empty({num_allocated_tokens, hidden}, x.options());
+        }
         auto recv_sf = std::optional<torch::Tensor>();
         auto recv_topk_idx = std::optional<torch::Tensor>();
         auto recv_topk_weights = std::optional<torch::Tensor>();
@@ -1141,6 +1203,7 @@ public:
                                       jit::device_runtime->get_num_sms(),
                                       jit::device_runtime->get_num_smem_bytes(),
                                       num_channels,
+                                      use_direct_recv_x,
                                       do_expand, cached_mode,
                                       do_zero_padding,
                                       comm_stream);

--- a/csrc/kernels/elastic/dispatch.hpp
+++ b/csrc/kernels/elastic/dispatch.hpp
@@ -18,6 +18,7 @@ public:
         bool is_scaleup_nvlink;
         bool do_cpu_sync;
         bool reuse_slot_indices;
+        bool direct_recv_x;
         int num_notify_warps;
         int num_dispatch_warps; // For hybrid dispatch
         int num_scaleout_warps, num_forward_warps; // For direct dispatch
@@ -37,6 +38,7 @@ public:
         int* num_unaligned_recv_tokens_per_expert;
         int* dst_buffer_slot_idx;
         int* token_metadata_at_forward;
+        void* direct_recv_x_ptr;
         int num_tokens;
         int sf_token_stride, sf_hidden_stride;
         jit::NoRefPtr nccl_dev_comm;
@@ -52,10 +54,11 @@ public:
         std::string header_name, func_name;
         if (args.num_scaleout_ranks == 1) {
             header_name = "dispatch";
-            func_name = fmt::format("dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+            func_name = fmt::format("dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
                 args.is_scaleup_nvlink,
                 args.do_cpu_sync,
                 args.reuse_slot_indices,
+                args.direct_recv_x,
                 args.launch_args.grid_dim.first,
                 args.num_notify_warps, args.num_dispatch_warps,
                 args.num_scaleup_ranks,
@@ -65,9 +68,10 @@ public:
                 args.num_qps, args.num_timeout_cycles);
         } else {
             header_name = "hybrid_dispatch";
-            func_name = fmt::format("hybrid_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+            func_name = fmt::format("hybrid_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
                 args.do_cpu_sync,
                 args.reuse_slot_indices,
+                args.direct_recv_x,
                 args.launch_args.grid_dim.first,
                 args.num_notify_warps, args.num_scaleout_warps, args.num_forward_warps,
                 args.num_scaleout_ranks, args.num_scaleup_ranks,
@@ -99,6 +103,7 @@ static void __instantiate_kernel() {{
                 args.psum_num_recv_tokens_per_expert,
                 args.num_unaligned_recv_tokens_per_expert,
                 args.dst_buffer_slot_idx,
+                args.direct_recv_x_ptr,
                 args.num_tokens,
                 args.sf_token_stride, args.sf_hidden_stride,
                 args.nccl_dev_comm, args.nccl_window,
@@ -116,6 +121,7 @@ static void __instantiate_kernel() {{
                 args.num_unaligned_recv_tokens_per_expert,
                 args.dst_buffer_slot_idx,
                 args.token_metadata_at_forward,
+                args.direct_recv_x_ptr,
                 args.num_tokens,
                 args.sf_token_stride, args.sf_hidden_stride,
                 args.nccl_dev_comm, args.nccl_window,
@@ -162,10 +168,13 @@ static void launch_dispatch(void* x, void* sf,
                             const int& num_qps, const int64_t& num_timeout_cycles,
                             const bool& cached_mode,
                             const bool& do_cpu_sync,
+                            const bool& direct_recv_x,
+                            void* direct_recv_x_ptr,
                             const at::cuda::CUDAStream& stream) {
     // Cached mode does not support expert token counting
     if (cached_mode)
         EP_HOST_ASSERT(cumulative_local_expert_recv_stats == nullptr);
+    EP_HOST_ASSERT(not (cached_mode and direct_recv_x));
 
     // Utils
     const auto num_ranks = num_scaleout_ranks * num_scaleup_ranks;
@@ -200,6 +209,7 @@ static void launch_dispatch(void* x, void* sf,
         .is_scaleup_nvlink = is_scaleup_nvlink,
         .do_cpu_sync = do_cpu_sync,
         .reuse_slot_indices = reuse_slot_indices,
+        .direct_recv_x = direct_recv_x,
         .num_notify_warps = num_notify_warps,
         .num_dispatch_warps = num_dispatch_warps,
         .num_scaleout_warps = num_scaleout_warps, .num_forward_warps = num_forward_warps,
@@ -216,6 +226,7 @@ static void launch_dispatch(void* x, void* sf,
         .num_unaligned_recv_tokens_per_expert = num_unaligned_recv_tokens_per_expert,
         .dst_buffer_slot_idx = dst_buffer_slot_idx,
         .token_metadata_at_forward = token_metadata_at_forward,
+        .direct_recv_x_ptr = direct_recv_x_ptr,
         .num_tokens = num_tokens,
         .sf_token_stride = sf_token_stride, .sf_hidden_stride = sf_hidden_stride,
         .nccl_dev_comm = nccl_dev_comm, .nccl_window = nccl_window,
@@ -234,6 +245,7 @@ public:
     struct Args {
         // Templated arguments
         bool do_expand, cached_mode, do_zero_padding;
+        bool skip_recv_x_copy;
         int num_channels;
         int num_warps;
         int num_scaleout_ranks, num_scaleup_ranks;
@@ -264,10 +276,11 @@ public:
 using namespace deep_ep::elastic;
 
 static void __instantiate_kernel() {{
-    auto ptr = reinterpret_cast<void*>(&dispatch_copy_epilogue_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>);
+    auto ptr = reinterpret_cast<void*>(&dispatch_copy_epilogue_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>);
 }}
 )",
                            args.do_expand, args.cached_mode, args.do_zero_padding,
+                           args.skip_recv_x_copy,
                            args.launch_args.grid_dim.first, args.num_channels, args.num_warps,
                            args.num_scaleout_ranks, args.num_scaleup_ranks,
                            args.num_hidden_bytes, args.num_sf_packs,
@@ -306,6 +319,7 @@ static void launch_dispatch_copy_epilogue(void* buffer, void* workspace,
                                           const int& num_scaleout_ranks, const int& num_scaleup_ranks,
                                           const int& num_sms, const int& num_smem_bytes,
                                           const int& num_channels,
+                                          const bool& skip_recv_x_copy,
                                           const bool& do_expand, const bool& cached_mode,
                                           const bool& do_zero_padding,
                                           const at::cuda::CUDAStream& stream) {
@@ -317,6 +331,7 @@ static void launch_dispatch_copy_epilogue(void* buffer, void* workspace,
     // Generate, build and launch
     const DispatchCopyEpilogueRuntime::Args args = {
         .do_expand = do_expand, .cached_mode = cached_mode, .do_zero_padding = do_zero_padding,
+        .skip_recv_x_copy = skip_recv_x_copy,
         .num_channels = num_channels, .num_warps = num_warps,
         .num_scaleout_ranks = num_scaleout_ranks, .num_scaleup_ranks = num_scaleup_ranks,
         .num_hidden_bytes = num_hidden_bytes, .num_sf_packs = num_sf_packs,

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -251,6 +251,8 @@ class ElasticBuffer:
             group: the communication group.
             num_bytes: the total buffer size in bytes (GPU + CPU, excludes workspace), if set, overrides MoE-based calculation.
                 Must be aligned to 2 MB (``get_elastic_buffer_alignment()``).
+                The V2 direct-recv-x experiment reserves an additional receive tensor window after
+                the communication buffer when ``EP_V2_EXPERIMENTAL_DIRECT_RECV_X=1`` is enabled before construction.
             num_cpu_bytes: the number of CPU buffer bytes (e.g. for Engram storage). Must be aligned to 2 MB.
             num_max_tokens_per_rank: the maximum number of tokens per rank, used for buffer size calculation.
             hidden: the hidden dimension of each token.
@@ -920,8 +922,20 @@ class ElasticBuffer:
             recv_topk_weights: received expert weights (`None` if `topk_weights` was not provided).
             handle: the returned communication handle.
             event: the event after executing the kernel (valid only if `async_with_compute_stream` is set).
+
+        Experimental:
+            If ``EP_V2_EXPERIMENTAL_DIRECT_RECV_X=1`` is set, non-expanded dispatch returns ``recv_x`` from
+            the tail of DeepEP's NCCL symmetric window and writes hidden states directly into that output window.
+            The epilogue only materializes metadata/top-k/SF tensors. The compact path supports BF16 and FP8 for
+            both single-node and hybrid dispatch in the experimental kernel path. Cached and deterministic dispatch
+            are not supported in direct recv_x mode.
         """
         check_torch_deterministic()
+        use_direct_recv_x = os.environ.get('EP_V2_EXPERIMENTAL_DIRECT_RECV_X', '0') == '1'
+        if use_direct_recv_x and handle is not None:
+            raise RuntimeError('EP_V2_EXPERIMENTAL_DIRECT_RECV_X does not support cached dispatch')
+        if use_direct_recv_x and self.deterministic:
+            raise RuntimeError('EP_V2_EXPERIMENTAL_DIRECT_RECV_X does not support deterministic dispatch')
 
         # Automatic decide SM and QP count
         num_topk = (handle.topk_idx if topk_idx is None else topk_idx).shape[1]
@@ -1088,6 +1102,17 @@ class ElasticBuffer:
         assert num_qps <= self.num_allocated_qps, f'Allocated QPs are not enough'
 
         bias_0, bias_1 = ElasticBuffer._unpack_bias(bias)
+
+        extra_tensors = None
+        if x.shape[0] == 0:
+            x_backing = torch.empty((1, x.shape[1]), device=x.device, dtype=x.dtype)
+            x = x_backing[:0]
+            extra_tensors = (x_backing, x)
+            if topk_weights is not None and topk_weights.shape[0] == 0:
+                topk_weights_backing = torch.empty((1, topk_weights.shape[1]), device=topk_weights.device, dtype=topk_weights.dtype)
+                topk_weights = topk_weights_backing[:0]
+                extra_tensors = (x_backing, x, topk_weights_backing, topk_weights)
+
         combined_x, combined_topk_weights, event = \
             self.runtime.combine(x, topk_weights,
                                  bias_0, bias_1,
@@ -1104,4 +1129,4 @@ class ElasticBuffer:
                                  async_with_compute_stream,
                                  allocate_on_comm_stream,
                                  handle.do_expand)
-        return combined_x, combined_topk_weights, EventOverlap(event)
+        return combined_x, combined_topk_weights, EventOverlap(event, extra_tensors)

--- a/deep_ep/include/deep_ep/impls/dispatch.cuh
+++ b/deep_ep/include/deep_ep/impls/dispatch.cuh
@@ -17,6 +17,7 @@ namespace deep_ep::elastic {
 template <bool kIsScaleupNVLink,
           bool kDoCPUSync,
           bool kReuseSlotIndices,
+          bool kDirectRecvX,
           int kNumSMs,
           int kNumNotifyWarps, int kNumDispatchWarps,
           int kNumRanks,
@@ -37,6 +38,7 @@ dispatch_impl(
     int* psum_num_recv_tokens_per_expert,
     int* num_unaligned_recv_tokens_per_expert,
     int* dst_buffer_slot_idx,
+    void* direct_recv_x,
     const int num_tokens,
     const int sf_token_stride, const int sf_hidden_stride,
     const ncclDevComm_t nccl_dev_comm, const ncclWindow_t nccl_window, void* buffer,
@@ -58,7 +60,8 @@ dispatch_impl(
     // The kernel uses a fixed space of dynamic shared memory (no static shared memory)
     extern __shared__ __align__(ptx::kNumTMAAlignBytes) int8_t smem[];
     constexpr int kNumSmemBytesForNotify = kNumNotifyThreads > 0 ?
-        math::constexpr_align(kNumRanks + kNumExperts, kNumNotifyThreads) * sizeof(int) : 0;
+        math::constexpr_align(kNumRanks + kNumExperts, kNumNotifyThreads) *
+        sizeof(int) : 0;
     EP_STATIC_ASSERT(kNumSmemBytesForNotify % ptx::kNumTMAAlignBytes == 0, "Invalid TMA alignment");
 
     // Named barrier indices
@@ -74,6 +77,8 @@ dispatch_impl(
     comm::gpu_barrier<kIsScaleupNVLink, 1, kNumRanks,
                       kNumSMs, kNumThreads, kNumQPs, kNumTimeoutCycles, comm::kDispatchTag0, false, false, true>(
         gin, workspace_layout, 0, rank_idx, sm_idx, thread_idx);
+
+    bool pending_direct_recv_x_hidden_tma_store = false;
 
     // Different warp roles
     if (warp_idx < kNumNotifyWarps) {
@@ -212,7 +217,8 @@ dispatch_impl(
                 if (num_unaligned_recv_tokens_per_expert != nullptr)
                     num_unaligned_recv_tokens_per_expert[i] = sum;
 
-                expert_count[i] = math::align(sum, kExpertAlignment);
+                const auto aligned_sum = math::align(sum, kExpertAlignment);
+                expert_count[i] = aligned_sum;
 
                 // Update statistics counters
                 if (cumulative_local_expert_recv_stats != nullptr)
@@ -241,8 +247,9 @@ dispatch_impl(
                     const auto sum = psum + ptx::warp_inclusive_sum(value, lane_idx);
 
                     // Store into global memory
-                    if (idx < n + is_exclusive)
+                    if (idx < n + is_exclusive) {
                         out[idx] = sum;
+                    }
 
                     // Update `psum` by using the last lane's value
                     psum = ptx::exchange(sum, 31);
@@ -255,17 +262,40 @@ dispatch_impl(
                 // Exclusive prefix sum for later expanding
                 do_psum(expert_count, psum_num_recv_tokens_per_expert, kNumExpertsPerRank, 1);
             }
+
+            if constexpr (kDirectRecvX) {
+                // Send this receiver's compact output base for each source rank back to the source.
+                // Source dispatch warps use it to write hidden states directly into compact recv_x.
+                for (int i = thread_idx; i < kNumRanks; i += kNumNotifyThreads) {
+                    const auto compact_rank_base = i == 0 ? 0 : psum_num_recv_tokens_per_scaleup_rank[i - 1];
+                    gin.put_value<team_t>(
+                        workspace_layout.get_scaleout_channel_signaled_tail_ptr(rank_idx, 0),
+                        math::encode_decode_positive(static_cast<int64_t>(compact_rank_base)),
+                        i,
+                        ncclGinOptFlagsAggregateRequests);
+                }
+                gin.flush();
+            }
+
         }
+
     } else {
         const int dispatch_warp_idx = warp_idx - kNumNotifyWarps;
 
         // Buffer layouts
         const auto token_layout = layout::TokenLayout(kNumHiddenBytes, kNumSFPacks * sizeof(sf_pack_t), kNumTopk, true);
         const auto tma_buffer = layout::BufferLayout<true>(token_layout, kNumDispatchWarps, 1,
-            math::advance_ptr<int>(smem, kNumSmemBytesForNotify)).get_rank_buffer(dispatch_warp_idx).get_token_buffer(0);
+            math::advance_ptr<int>(smem, kNumSmemBytesForNotify))
+            .get_rank_buffer(dispatch_warp_idx).get_token_buffer(0);
         auto recv_buffer = layout::BufferLayout<false>(token_layout, kNumRanks, kNumMaxTokensPerRank, buffer);
         auto send_buffer = layout::BufferLayout<false>(token_layout, 1, kNumMaxTokensPerRank, recv_buffer.get_buffer_end_ptr());
         recv_buffer = recv_buffer.get_rank_buffer(rank_idx);
+        constexpr int kNumMetadataBytes = math::constexpr_align(
+            kNumTopk * (int(sizeof(int)) + int(sizeof(float))) + (1 + kNumTopk) * int(sizeof(int)),
+            ptx::kNumTMAAlignBytes);
+        constexpr int kNumSidecarBytes =
+            math::constexpr_align(kNumSFPacks * int(sizeof(sf_pack_t)), ptx::kNumTMAAlignBytes) +
+            kNumMetadataBytes;
 
         // Init TMA
         ptx::arrival_phase phase = 0;
@@ -274,14 +304,18 @@ dispatch_impl(
             ptx::mbarrier_init_with_fence(mbarrier_ptr, 1);
         __syncwarp();
 
-        // Iterate all tokens
         const auto token_start = dispatch_warp_idx * kNumSMs + sm_idx;
         const auto token_stride = kNumDispatchWarps * kNumSMs;
+        // Iterate all tokens
         for (int token_idx = token_start; token_idx < num_tokens; token_idx += token_stride) {
             const auto token_i64_idx = static_cast<int64_t>(token_idx);
 
-            // Wait TMA store arrivals
+            // Wait TMA store arrivals before reusing the per-warp staging buffer.
+            // In direct-recv-x NVLink mode, the previous iteration may leave hidden recv_x
+            // stores outstanding after sidecar has been flushed for PDL, so this wait is
+            // the hidden-store completion point instead of the final epilogue barrier.
             ptx::tma_store_wait();
+            pending_direct_recv_x_hidden_tma_store = false;
             __syncwarp();
 
             // Issue data TMA
@@ -313,18 +347,21 @@ dispatch_impl(
 
             // Load top-k indices and weights
             EP_STATIC_ASSERT(kNumTopk <= 32, "Insufficient lanes for loading top-k indices");
+            int stored_dst_expert_idx = -1;
             int stored_dst_rank_idx = -1;
             if (lane_idx < kNumTopk) {
                 const auto uncasted_dst_expert_idx = __ldg(topk_idx + token_idx * kNumTopk + lane_idx);
-                const auto dst_expert_idx = static_cast<int>(uncasted_dst_expert_idx);
-                stored_dst_rank_idx = dst_expert_idx >= 0 ? dst_expert_idx / kNumExpertsPerRank : -1;
-                tma_buffer.get_topk_idx_ptr()[lane_idx] = dst_expert_idx;
+                stored_dst_expert_idx = static_cast<int>(uncasted_dst_expert_idx);
+                stored_dst_rank_idx = stored_dst_expert_idx >= 0 ? stored_dst_expert_idx / kNumExpertsPerRank : -1;
+                tma_buffer.get_topk_idx_ptr()[lane_idx] = stored_dst_expert_idx;
                 if (topk_weights != nullptr)
                     tma_buffer.get_topk_weights_ptr()[lane_idx] = __ldg(topk_weights + token_idx * kNumTopk + lane_idx);
                 if (copied_topk_idx != nullptr)
                     copied_topk_idx[token_idx * kNumTopk + lane_idx] = uncasted_dst_expert_idx;
             }
             __syncwarp();
+
+            int direct_recv_x_idx = -1;
 
             // Add source metadata (rank index and token index)
             // Please ensure no TMA buffer shared memory writes after this part
@@ -351,6 +388,34 @@ dispatch_impl(
             }
             __syncwarp();
 
+            // In the direct-recv-x experiment, the receiver publishes the source-rank base
+            // for its compact recv_x layout. The sender combines that base with the
+            // rank-major slot index it already owns.
+            if constexpr (kDirectRecvX) {
+                if (stored_dst_slot_idx >= 0) {
+                    const auto direct_recv_x_base_ptr =
+                        workspace_layout.get_scaleout_channel_signaled_tail_ptr(stored_dst_rank_idx, 0);
+                    int decoded_base = -1;
+                    comm::timeout_while<kNumTimeoutCycles>([&](const bool& is_last_check) {
+                        const auto decoded_base_i64 = math::encode_decode_positive(
+                            ptx::ld_acquire_sys<int64_t>(direct_recv_x_base_ptr));
+                        decoded_base = static_cast<int>(decoded_base_i64);
+                        if (math::is_decoded_positive_ready(decoded_base_i64))
+                            return true;
+
+                        if (is_last_check) {
+                            printf("DeepEP direct recv_x prefix timeout, rank: %d, dst rank: %d, "
+                                   "slot: %d, decoded base: %d\n",
+                                   rank_idx, stored_dst_rank_idx, stored_dst_slot_idx, decoded_base);
+                        }
+                        return false;
+                    });
+                    EP_DEVICE_ASSERT(decoded_base >= 0);
+                    direct_recv_x_idx = decoded_base + stored_dst_slot_idx;
+                }
+            }
+            __syncwarp();
+
             // Wait TMA load arrival
             // NOTES: this arrive must be after the `ptx::cp_async_mbarrier_arrive`
             if (ptx::elect_one_sync()) {
@@ -360,7 +425,8 @@ dispatch_impl(
             __syncwarp();
 
             // TMA store to send buffer
-            auto send_buffer_ptr = send_buffer.get_token_buffer(token_idx).get_base_ptr();
+            auto send_buffer_token = send_buffer.get_token_buffer(token_idx);
+            auto send_buffer_ptr = send_buffer_token.get_base_ptr();
             if constexpr (not kIsScaleupNVLink) {
                 if (ptx::elect_one_sync())
                     ptx::tma_store_1d(send_buffer_ptr, tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
@@ -370,11 +436,44 @@ dispatch_impl(
 
             // Issue TMA NVLink stores
             EP_STATIC_ASSERT(kNumTopk <= 32, "Invalid top-k selection");
-            const auto dst_ptr = stored_dst_slot_idx >= 0 ?
-                gin.get_sym_ptr<team_t>(recv_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(), stored_dst_rank_idx) :
-                nullptr;
-            if (dst_ptr != nullptr)
-                ptx::tma_store_1d(dst_ptr, tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
+            if constexpr (kDirectRecvX) {
+                void* dst_sidecar_ptr = nullptr;
+                if (stored_dst_slot_idx >= 0) {
+                    const auto dst_token = recv_buffer.get_token_buffer(stored_dst_slot_idx);
+                    dst_sidecar_ptr = gin.get_sym_ptr<team_t>(dst_token.get_sf_ptr(), stored_dst_rank_idx);
+                }
+                // Direct-recv-x still lets the copy epilogue read SF and metadata/top-k from staging.
+                // Keep this in a separate TMA group from the hidden direct store so the PDL
+                // copy epilogue can wait only for sidecar visibility.
+                if (dst_sidecar_ptr != nullptr)
+                    ptx::tma_store_1d(dst_sidecar_ptr, tma_buffer.get_sf_ptr(), kNumSidecarBytes);
+                if constexpr (kIsScaleupNVLink)
+                    ptx::tma_store_commit();
+
+                // Write hidden states to direct_recv_x only when prefix sum is valid
+                const auto dst_x_ptr = direct_recv_x_idx >= 0 ?
+                    gin.get_sym_ptr<team_t>(
+                        math::advance_ptr(direct_recv_x, static_cast<int64_t>(direct_recv_x_idx) * kNumHiddenBytes),
+                        stored_dst_rank_idx) :
+                        nullptr;
+                if (dst_x_ptr != nullptr) {
+                    ptx::tma_store_1d(dst_x_ptr, tma_buffer.get_hidden_ptr(), kNumHiddenBytes);
+                    if constexpr (kIsScaleupNVLink)
+                        pending_direct_recv_x_hidden_tma_store = true;
+                }
+                if constexpr (kIsScaleupNVLink) {
+                    pending_direct_recv_x_hidden_tma_store =
+                        ptx::gather(pending_direct_recv_x_hidden_tma_store) != 0;
+                    __syncwarp();
+                }
+            } else {
+                const auto dst_ptr = stored_dst_slot_idx >= 0 ?
+                    gin.get_sym_ptr<team_t>(recv_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(), stored_dst_rank_idx) :
+                    nullptr;
+                if (dst_ptr != nullptr) {
+                    ptx::tma_store_1d(dst_ptr, tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
+                }
+            }
             ptx::tma_store_commit();
             __syncwarp();
 
@@ -385,27 +484,84 @@ dispatch_impl(
                 __syncwarp();
 
                 // NOTES: we should skip the NVLink accessible ranks
-                if (stored_dst_slot_idx >= 0 and dst_ptr == nullptr) {
-                    gin.put<team_t>(recv_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(),
-                                    send_buffer_ptr, tma_buffer.get_num_bytes<false>(), stored_dst_rank_idx);
+                if constexpr (kDirectRecvX) {
+                    const auto dst_x_ptr = direct_recv_x_idx >= 0 ?
+                        gin.get_sym_ptr<team_t>(
+                            math::advance_ptr(direct_recv_x, static_cast<int64_t>(direct_recv_x_idx) * kNumHiddenBytes),
+                            stored_dst_rank_idx) :
+                        nullptr;
+                    if (stored_dst_slot_idx >= 0 and dst_x_ptr == nullptr and direct_recv_x_idx >= 0) {
+                        gin.put<team_t>(
+                            math::advance_ptr(direct_recv_x, static_cast<int64_t>(direct_recv_x_idx) * kNumHiddenBytes),
+                            send_buffer_token.get_hidden_ptr(),
+                            kNumHiddenBytes, stored_dst_rank_idx,
+                            ncclGinOptFlagsAggregateRequests);
+                        gin.put<team_t>(
+                            recv_buffer.get_token_buffer(stored_dst_slot_idx).get_sf_ptr(),
+                            send_buffer_token.get_sf_ptr(),
+                            kNumSidecarBytes, stored_dst_rank_idx,
+                            ncclGinOptFlagsAggregateRequests);
+                    } else if (stored_dst_slot_idx >= 0 and direct_recv_x_idx < 0) {
+                        // Fallback: timeout on prefix sum, write SF/metadata only via RDMA
+                        gin.put<team_t>(
+                            recv_buffer.get_token_buffer(stored_dst_slot_idx).get_sf_ptr(),
+                            send_buffer_token.get_sf_ptr(),
+                            kNumSidecarBytes, stored_dst_rank_idx,
+                            ncclGinOptFlagsAggregateRequests);
+                    }
+                } else {
+                    const auto dst_ptr = stored_dst_slot_idx >= 0 ?
+                        gin.get_sym_ptr<team_t>(recv_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(), stored_dst_rank_idx) :
+                        nullptr;
+                    if (stored_dst_slot_idx >= 0 and dst_ptr == nullptr) {
+                        gin.put<team_t>(recv_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(),
+                                        send_buffer_ptr, tma_buffer.get_num_bytes<false>(), stored_dst_rank_idx);
+                    }
                 }
                 __syncwarp();
             }
         }
     }
 
-    // Barrier to ensure data arrival
-    comm::gpu_barrier<kIsScaleupNVLink, 1, kNumRanks,
-                      kNumSMs, kNumThreads, kNumQPs, kNumTimeoutCycles, comm::kDispatchTag1, true, true, false>(
-        gin, workspace_layout, 0, rank_idx, sm_idx, thread_idx);
 
-    // Trigger the copy epilogue kernel
+    // Barrier to ensure sidecar data arrival for the copy epilogue.
+    // Direct-recv-x hidden stores target recv_x directly, and the copy epilogue skips
+    // hidden copy, so only the sidecar TMA group must be flushed before PDL. If this
+    // warp did not issue a final hidden store, there is no later group to keep pending.
+    if constexpr (kDirectRecvX and kIsScaleupNVLink) {
+        if (pending_direct_recv_x_hidden_tma_store)
+            ptx::tma_store_wait<1>();
+        else
+            ptx::tma_store_wait();
+        __syncwarp();
+        comm::gpu_barrier<kIsScaleupNVLink, 1, kNumRanks,
+                          kNumSMs, kNumThreads, kNumQPs, kNumTimeoutCycles, comm::kDispatchTag1, false, true, false>(
+            gin, workspace_layout, 0, rank_idx, sm_idx, thread_idx);
+    } else {
+        comm::gpu_barrier<kIsScaleupNVLink, 1, kNumRanks,
+                          kNumSMs, kNumThreads, kNumQPs, kNumTimeoutCycles, comm::kDispatchTag1, true, true, false>(
+            gin, workspace_layout, 0, rank_idx, sm_idx, thread_idx);
+    }
+
+
+    // Trigger the copy epilogue kernel after sidecar is visible. Hidden direct stores
+    // may still be outstanding and can overlap with the epilogue, which does not copy hidden.
     cudaTriggerProgrammaticLaunchCompletion();
+
+    if constexpr (kDirectRecvX and kIsScaleupNVLink) {
+        if (pending_direct_recv_x_hidden_tma_store)
+            ptx::tma_store_wait();
+        __syncwarp();
+    }
 
     // Clean atomic counters
     EP_STATIC_ASSERT(kNumRanks <= kNumThreads, "Insufficient threads");
     if (not kReuseSlotIndices and sm_idx == 0 and thread_idx < kNumRanks)
         workspace_layout.get_scaleup_atomic_sender_counter()[thread_idx] = 0;
+    if constexpr (kDirectRecvX) {
+        if (sm_idx == 0 and thread_idx < kNumRanks)
+            workspace_layout.get_scaleout_channel_signaled_tail_ptr(thread_idx, 0)[0] = 0;
+    }
 }
 
 }  // namespace deep_ep::elastic

--- a/deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh
+++ b/deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh
@@ -9,6 +9,7 @@
 namespace deep_ep::elastic {
 
 template <bool kDoExpand, bool kCachedMode, bool kDoZeroPadding,
+          bool kSkipRecvXCopy,
           // NOTES: this channel concept only applies for scale-out ranks
           int kNumSMs, int kNumChannels, int kNumWarps,
           int kNumScaleoutRanks, int kNumScaleupRanks,
@@ -44,9 +45,16 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
     // Buffer layouts
     extern __shared__ __align__(ptx::kNumTMAAlignBytes) int8_t smem[];
     const auto token_layout = layout::TokenLayout(kNumHiddenBytes, kNumSFPacks * sizeof(sf_pack_t), kNumTopk, true);
+    constexpr int kNumMetadataBytes = math::constexpr_align(
+        kNumTopk * (int(sizeof(int)) + int(sizeof(float))) + (1 + kNumTopk) * int(sizeof(int)),
+        ptx::kNumTMAAlignBytes);
+    constexpr int kNumSidecarBytes =
+        math::constexpr_align(kNumSFPacks * int(sizeof(sf_pack_t)), ptx::kNumTMAAlignBytes) +
+        kNumMetadataBytes;
     const auto tma_buffer = layout::BufferLayout<true>(token_layout, kNumWarps, 1, smem)
         .get_rank_buffer(warp_idx).get_token_buffer(0);
     const auto scaleup_buffer = layout::BufferLayout<false>(token_layout, kNumScaleupRanks, kNumScaleoutRanks * kNumMaxTokensPerRank, buffer);
+    const auto workspace_layout = layout::WorkspaceLayout(workspace, kNumScaleoutRanks, kNumScaleupRanks, kNumExperts);
 
     // Init TMA
     ptx::arrival_phase phase = 0;
@@ -78,7 +86,8 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
             current_rank_start = current_rank_end;
             current_rank_end = ptx::exchange(stored_psum_num_recv_tokens, stored_lane_idx);
         }
-        const auto buffer_token = scaleup_buffer.get_rank_buffer(current_rank_idx).get_token_buffer(i - current_rank_start);
+        const auto current_rank_token_idx = i - current_rank_start;
+        const auto buffer_token = scaleup_buffer.get_rank_buffer(current_rank_idx).get_token_buffer(current_rank_token_idx);
 
         // Wait buffer releases
         ptx::tma_store_wait();
@@ -87,9 +96,15 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
         // Issue TMA loads
         // Including all stuffs: data, SF, top-k metadata
         if (ptx::elect_one_sync()) {
-            ptx::tma_load_1d(tma_buffer.get_base_ptr(), buffer_token.get_base_ptr(),
-                             mbarrier_ptr, tma_buffer.get_num_bytes<false>());
-            ptx::mbarrier_arrive_and_set_tx(mbarrier_ptr, tma_buffer.get_num_bytes<false>());
+            if constexpr (kSkipRecvXCopy) {
+                ptx::tma_load_1d(tma_buffer.get_sf_ptr(), buffer_token.get_sf_ptr(),
+                                 mbarrier_ptr, kNumSidecarBytes);
+                ptx::mbarrier_arrive_and_set_tx(mbarrier_ptr, kNumSidecarBytes);
+            } else {
+                ptx::tma_load_1d(tma_buffer.get_base_ptr(), buffer_token.get_base_ptr(),
+                                 mbarrier_ptr, tma_buffer.get_num_bytes<false>());
+                ptx::mbarrier_arrive_and_set_tx(mbarrier_ptr, tma_buffer.get_num_bytes<false>());
+            }
         }
         __syncwarp();
 
@@ -135,10 +150,12 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
         }
 
         // Issue TMA stores for data
-        if (kDoExpand ? (dst_tensor_idx >= 0) : ptx::elect_one_sync()) {
-            ptx::tma_store_1d(math::advance_ptr(recv_x, static_cast<int64_t>(dst_tensor_idx) * kNumHiddenBytes),
-                              tma_buffer.get_hidden_ptr(), kNumHiddenBytes);
-            ptx::tma_store_commit();
+        if constexpr (not kSkipRecvXCopy) {
+            if (kDoExpand ? (dst_tensor_idx >= 0) : ptx::elect_one_sync()) {
+                ptx::tma_store_1d(math::advance_ptr(recv_x, static_cast<int64_t>(dst_tensor_idx) * kNumHiddenBytes),
+                                  tma_buffer.get_hidden_ptr(), kNumHiddenBytes);
+                ptx::tma_store_commit();
+            }
         }
         __syncwarp();
 
@@ -207,11 +224,11 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
         }
     }
 
+
     // Maintain linked list's ending
     // Or you can understand it as writing the tail at once
     if constexpr (kDoCreateLinkedList) {
         constexpr int kNumScaleupRanksPerLane = math::constexpr_ceil_div(kNumScaleupRanks, 32);
-        const auto workspace_layout = layout::WorkspaceLayout(workspace, kNumScaleoutRanks, kNumScaleupRanks, kNumExperts);
         for (int i = global_warp_idx; i < kNumChannels; i += kNumSMs * kNumWarps) {
             #pragma unroll
             for (int j = 0; j < kNumScaleupRanksPerLane; ++ j) {
@@ -320,6 +337,7 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
             pad_idx += kNumSMs * kNumWarps;
         }
     }
+
 }
 
 }  // namespace deep_ep::elastic

--- a/deep_ep/include/deep_ep/impls/hybrid_dispatch.cuh
+++ b/deep_ep/include/deep_ep/impls/hybrid_dispatch.cuh
@@ -12,6 +12,7 @@ namespace deep_ep::elastic {
 
 template <bool kDoCPUSync,
           bool kReuseSlotIndices,
+          bool kDirectRecvX,
           int kNumSMs,
           int kNumNotifyWarps, int kNumScaleoutWarps, int kNumForwardWarps,
           int kNumScaleoutRanks, int kNumScaleupRanks,
@@ -40,6 +41,7 @@ hybrid_dispatch_impl(
     int* num_unaligned_recv_tokens_per_expert,
     int* dst_buffer_slot_idx,
     int* token_metadata_at_forward,
+    void* direct_recv_x,
     const int num_tokens,
     const int sf_token_stride, const int sf_hidden_stride,
     // TODO(NCCL): so many params, plans to optimize?
@@ -85,6 +87,12 @@ hybrid_dispatch_impl(
 
     // The golden layout during the whole process for both scale-out and forward warps
     const auto token_layout = layout::TokenLayout(kNumHiddenBytes, kNumSFPacks * sizeof(sf_pack_t), kNumTopk, true);
+    constexpr int kNumMetadataBytes = math::constexpr_align(
+        kNumTopk * (int(sizeof(int)) + int(sizeof(float))) + (1 + kNumTopk) * int(sizeof(int)),
+        ptx::kNumTMAAlignBytes);
+    constexpr int kNumSidecarBytes =
+        math::constexpr_align(kNumSFPacks * int(sizeof(sf_pack_t)), ptx::kNumTMAAlignBytes) +
+        kNumMetadataBytes;
     const auto tma_buffer = layout::BufferLayout<true>(token_layout, kNumScaleoutWarps + kNumForwardWarps, 1,
             math::advance_ptr<int>(smem, kNumSmemBytesForNotify)).get_rank_buffer(warp_idx - kNumNotifyWarps).get_token_buffer(0);
 
@@ -324,6 +332,19 @@ hybrid_dispatch_impl(
             } else if (warp_idx == 1) {
                 // Exclusive prefix sum for later expanding
                 do_psum(expert_count, psum_num_recv_tokens_per_expert, kNumExpertsPerRank, 1);
+            }
+
+            if constexpr (kDirectRecvX) {
+                int prefix = 0;
+                #pragma unroll
+                for (int i = 0; i < kNumScaleupRanks; ++ i) {
+                    if (thread_idx == i)
+                        gin.put_value<ncclTeamTagLsa>(
+                            workspace_layout.get_scaleup_rank_count_ptr<true>() + scaleup_rank_idx,
+                            math::encode_decode_positive(static_cast<int64_t>(prefix)), i);
+                    prefix += rank_count[i];
+                }
+                __syncwarp();
             }
         }
     } else if (warp_idx < kNumNotifyWarps + kNumScaleoutWarps) {
@@ -591,10 +612,51 @@ hybrid_dispatch_impl(
 
                 // Issue TMAs
                 if (stored_dst_slot_idx >= 0) {
-                    const auto dst_ptr = gin.get_sym_ptr<ncclTeamTagLsa>(
-                        scaleup_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(),
-                        stored_dst_scaleup_rank_idx);
-                    ptx::tma_store_1d(dst_ptr, tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
+                    int direct_recv_x_idx = -1;
+                    if constexpr (kDirectRecvX) {
+                        const auto direct_recv_x_base_ptr =
+                            workspace_layout.get_scaleup_rank_count_ptr<true>() + stored_dst_scaleup_rank_idx;
+                        int decoded_base = -1;
+                        comm::timeout_while<kNumTimeoutCycles>([&](const bool& is_last_check) {
+                            if (direct_recv_x_base_ptr == nullptr)
+                                return false;
+                            const auto decoded_base_i64 = math::encode_decode_positive(
+                                ptx::ld_acquire_sys<int64_t>(direct_recv_x_base_ptr));
+                            decoded_base = static_cast<int>(decoded_base_i64);
+                            if (math::is_decoded_positive_ready(decoded_base_i64))
+                                return true;
+
+                            if (is_last_check) {
+                                printf("DeepEP hybrid direct recv_x prefix timeout, "
+                                       "scale-out: %d/%d, scale-up: %d/%d, "
+                                       "channel: %d, src scale-up: %d, dst scale-up: %d, slot: %d, decoded base: %d\n",
+                                       scaleout_rank_idx, kNumScaleoutRanks, scaleup_rank_idx, kNumScaleupRanks,
+                                       channel_idx, scaleup_rank_idx, stored_dst_scaleup_rank_idx, stored_dst_slot_idx, decoded_base);
+                            }
+                            return false;
+                        });
+                        EP_DEVICE_ASSERT(decoded_base >= 0);
+                        direct_recv_x_idx = decoded_base + stored_dst_slot_idx;
+                    }
+
+                    const auto dst_token = scaleup_buffer.get_token_buffer(stored_dst_slot_idx);
+                    if constexpr (kDirectRecvX) {
+                        const auto dst_sidecar_ptr = gin.get_sym_ptr<ncclTeamTagLsa>(
+                            dst_token.get_sf_ptr(), stored_dst_scaleup_rank_idx);
+                        const auto dst_x_ptr = direct_recv_x_idx >= 0 ?
+                            gin.get_sym_ptr<ncclTeamTagLsa>(
+                                math::advance_ptr(direct_recv_x, static_cast<int64_t>(direct_recv_x_idx) * kNumHiddenBytes),
+                                stored_dst_scaleup_rank_idx) :
+                            nullptr;
+                        if (dst_sidecar_ptr != nullptr)
+                            ptx::tma_store_1d(dst_sidecar_ptr, tma_buffer.get_sf_ptr(), kNumSidecarBytes);
+                        if (dst_x_ptr != nullptr)
+                            ptx::tma_store_1d(dst_x_ptr, tma_buffer.get_hidden_ptr(), kNumHiddenBytes);
+                    } else {
+                        const auto dst_ptr = gin.get_sym_ptr<ncclTeamTagLsa>(
+                            dst_token.get_base_ptr(), stored_dst_scaleup_rank_idx);
+                        ptx::tma_store_1d(dst_ptr, tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
+                    }
                     ptx::tma_store_commit();
                 }
                 __syncwarp();
@@ -672,6 +734,10 @@ hybrid_dispatch_impl(
     EP_STATIC_ASSERT(kNumScaleupRanks <= kNumThreads, "Insufficient threads");
     if (not kReuseSlotIndices and sm_idx == 0 and thread_idx < kNumScaleupRanks)
         workspace_layout.get_scaleup_atomic_sender_counter()[thread_idx] = 0;
+    if constexpr (kDirectRecvX) {
+        if (sm_idx == 0 and thread_idx < kNumScaleupRanks)
+            workspace_layout.get_scaleup_rank_count_ptr<true>()[thread_idx] = 0;
+    }
 }
 
 }  // namespace deep_ep::elastic

--- a/tests/elastic/test_ep.py
+++ b/tests/elastic/test_ep.py
@@ -19,15 +19,21 @@ from deep_ep.utils.testing import bench_kineto
 
 
 # noinspection PyUnusedLocal,PyShadowingNames
-def enumerate_ep_modes():
+def enumerate_ep_modes(expert_alignment=None, use_fp8_dispatch=None, num_bias=None):
     for do_handle_copy in (1, 0):
-        for expert_alignment in (128, 1):
-            for use_fp8_dispatch in (1, 0):
-                for num_bias in (0, 1, 2):
+        for ea in (128, 1):
+            if expert_alignment is not None and ea != expert_alignment:
+                continue
+            for fp8 in (1, 0):
+                if use_fp8_dispatch is not None and fp8 != use_fp8_dispatch:
+                    continue
+                for nb in (0, 1, 2):
+                    if num_bias is not None and nb != num_bias:
+                        continue
                     for with_previous_event in (0, 1):
                         for async_with_compute_stream in (0, 1):
                             for allocate_on_comm_stream in ((1, ) if with_previous_event else (0, 1)):
-                                yield (do_handle_copy, expert_alignment, use_fp8_dispatch, num_bias,
+                                yield (do_handle_copy, ea, fp8, nb,
                                        with_previous_event, async_with_compute_stream, allocate_on_comm_stream)
 
 
@@ -55,6 +61,12 @@ def fold_expanded(expanded: Union[Tuple[torch.Tensor], torch.Tensor],
     return folded
 
 
+def clone_recv_x(recv_x: Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]):
+    if isinstance(recv_x, tuple):
+        return tuple(t.clone() for t in recv_x)
+    return recv_x.clone()
+
+
 # noinspection PyUnboundLocalVariable,PyShadowingNames
 def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespace):
     # Settings
@@ -68,7 +80,8 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
                f' > Ranks: {num_scaleout_ranks} x {num_scaleup_ranks}\n'
                f' > Experts: {num_topk}/{num_experts}\n'
                f' > Tokens: {num_tokens} (max: {num_max_tokens_per_rank}), hidden: {hidden}\n'
-               f' > #SM: {num_sms}, #QPs: {num_qps}/{buffer.num_allocated_qps}\n',
+               f' > #SM: {num_sms}, #QPs: {num_qps}/{buffer.num_allocated_qps}\n'
+               f' > Mode: {"DRV_X" if os.environ.get("EP_V2_EXPERIMENTAL_DIRECT_RECV_X", "0") == "1" else "baseline"}',
                once_in_node=True)
 
     # Construct expert selections first (may have an unbalanced ratio here)
@@ -83,7 +96,14 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
     # Run all tests
     dist_print('Running all test cases:', once_in_node=True)
     for (do_handle_copy, expert_alignment, use_fp8_dispatch, num_bias,
-         with_previous_event, async_with_compute_stream, allocate_on_comm_stream) in enumerate_ep_modes():
+         with_previous_event, async_with_compute_stream, allocate_on_comm_stream) in enumerate_ep_modes(
+             expert_alignment=args.expert_alignment, use_fp8_dispatch=args.use_fp8_dispatch, num_bias=args.num_bias):
+        use_direct_recv_x = os.environ.get('EP_V2_EXPERIMENTAL_DIRECT_RECV_X', '0') == '1'
+        run_expanded_dispatch = not use_direct_recv_x
+        # DRV_X restrictions: no cached handle, no previous event, no deterministic dispatch
+        if use_direct_recv_x and (do_handle_copy or with_previous_event or args.deterministic):
+            continue
+
         dist_print(f' > Testing with '
                    f'{do_handle_copy=}, {expert_alignment=}, {use_fp8_dispatch=}, {num_bias=}, '
                    f'{with_previous_event=}, {async_with_compute_stream=}, {allocate_on_comm_stream=} ...',
@@ -151,36 +171,49 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
             do_handle_copy=do_handle_copy, do_cpu_sync=args.do_cpu_sync)
         recv_x, recv_topk_idx, recv_topk_weights, handle, dispatch_event = \
             launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, dispatch_args)
+        # Direct recv modes return a view into the symmetric window tail. Later dispatches and
+        # perf benches reuse that window, so preserve the compact result for correctness checks.
+        if use_direct_recv_x:
+            recv_x = clone_recv_x(recv_x)
         recv_x_bf16 = get_recv_x_bf16(recv_x)
 
         # Expanding mode
-        expanded_dispatch_args = dispatch_args | dict(do_expand=True, use_tma_aligned_col_major_sf=True)
-        expanded_recv_x, expanded_recv_topk_idx, expanded_recv_topk_weights, expanded_handle, expanded_dispatch_event = \
-            launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, expanded_dispatch_args)
-        expanded_recv_x_bf16 = get_recv_x_bf16(expanded_recv_x)
+        if run_expanded_dispatch:
+            expanded_dispatch_args = dispatch_args | dict(do_expand=True, use_tma_aligned_col_major_sf=True)
+            expanded_recv_x, expanded_recv_topk_idx, expanded_recv_topk_weights, expanded_handle, expanded_dispatch_event = \
+                launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, expanded_dispatch_args)
+            if use_direct_recv_x:
+                expanded_recv_x = clone_recv_x(expanded_recv_x)
+            expanded_recv_x_bf16 = get_recv_x_bf16(expanded_recv_x)
 
         # Cached mode
-        cached_dispatch_args = dict(
-            x=x,
-            num_sms=num_sms, num_qps=num_qps,
-            async_with_compute_stream=async_with_compute_stream,
-            allocate_on_comm_stream=allocate_on_comm_stream,
-            handle=handle)
-        cached_recv_x, cached_recv_topk_idx, cached_recv_topk_weights, cached_handle, cached_dispatch_event = \
-            launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, cached_dispatch_args)
+        if not use_direct_recv_x:
+            cached_dispatch_args = dict(
+                x=x,
+                num_sms=num_sms, num_qps=num_qps,
+                async_with_compute_stream=async_with_compute_stream,
+                allocate_on_comm_stream=allocate_on_comm_stream,
+                handle=handle)
+            cached_recv_x, cached_recv_topk_idx, cached_recv_topk_weights, cached_handle, cached_dispatch_event = \
+                launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, cached_dispatch_args)
+            if use_direct_recv_x:
+                cached_recv_x = clone_recv_x(cached_recv_x)
 
         # Cached expanding mode with zero padding
-        cached_expanded_dispatch_args = cached_dispatch_args | dict(
-            topk_weights=topk_weights, do_expand=True, use_tma_aligned_col_major_sf=True,
-            do_zero_padding=True, handle=expanded_handle)
-        cached_expanded_recv_x, _, cached_expanded_recv_topk_weights, _, _ = \
-            launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, cached_expanded_dispatch_args)
-
+        if run_expanded_dispatch:
+            cached_expanded_dispatch_args = cached_dispatch_args | dict(
+                topk_weights=topk_weights, do_expand=True, use_tma_aligned_col_major_sf=True,
+                do_zero_padding=True, handle=expanded_handle)
+            cached_expanded_recv_x, _, cached_expanded_recv_topk_weights, _, _ = \
+                launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, cached_expanded_dispatch_args)
+            if use_direct_recv_x:
+                cached_expanded_recv_x = clone_recv_x(cached_expanded_recv_x)
         # Count the number of received tokens
         num_recv_tokens = handle.psum_num_recv_tokens_per_scaleup_rank[-1].item()
-        assert num_recv_tokens == expanded_handle.psum_num_recv_tokens_per_scaleup_rank[-1].item(), \
-               'Expand should not affect the number of received tokens.'
-        num_expanded_tokens = expanded_handle.psum_num_recv_tokens_per_expert[-1].item()
+        if run_expanded_dispatch:
+            assert num_recv_tokens == expanded_handle.psum_num_recv_tokens_per_scaleup_rank[-1].item(), \
+                   'Expand should not affect the number of received tokens.'
+            num_expanded_tokens = expanded_handle.psum_num_recv_tokens_per_expert[-1].item()
 
         # Construction the input data for DeepEP combine
         src_token_global_idx = handle.recv_src_metadata[:num_recv_tokens, 0]
@@ -194,16 +227,18 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
         input_for_combine = torch.empty_like(recv_x_bf16, dtype=torch.bfloat16, device='cuda')
         input_for_combine[:num_recv_tokens] = local_reduced_y
 
-        expanded_src_token_global_idx = expanded_handle.recv_src_metadata[:num_recv_tokens, 0]
-        if not args.skip_check:
-            sorted_expanded_src_token_global_idx = torch.sort(expanded_src_token_global_idx).values
-            assert torch.equal(ref_recv_src_token_idx, sorted_expanded_src_token_global_idx), \
-                f'{ref_recv_src_token_idx=}, {sorted_expanded_src_token_global_idx=}'
-        local_y_expand = generate_pre_combine_data(expanded_src_token_global_idx, num_max_tokens_per_rank, num_topk, hidden)  # [num_recv_tokens, topk, hidden]
-        # We put an extra row to conveniently handle the -1 index
-        input_for_expand_combine = torch.empty((expanded_recv_x_bf16.shape[0] + 1, hidden), dtype=torch.bfloat16, device='cuda')
-        input_for_expand_combine[expanded_handle.recv_src_metadata[:num_recv_tokens, 2:].flatten()] = local_y_expand.view(-1, hidden)
-        input_for_expand_combine = input_for_expand_combine[:-1, ...]
+        # Expanded combine data
+        if run_expanded_dispatch:
+            expanded_src_token_global_idx = expanded_handle.recv_src_metadata[:num_recv_tokens, 0]
+            if not args.skip_check:
+                sorted_expanded_src_token_global_idx = torch.sort(expanded_src_token_global_idx).values
+                assert torch.equal(ref_recv_src_token_idx, sorted_expanded_src_token_global_idx), \
+                    f'{ref_recv_src_token_idx=}, {sorted_expanded_src_token_global_idx=}'
+            local_y_expand = generate_pre_combine_data(expanded_src_token_global_idx, num_max_tokens_per_rank, num_topk, hidden)  # [num_recv_tokens, topk, hidden]
+            # We put an extra row to conveniently handle the -1 index
+            input_for_expand_combine = torch.empty((expanded_recv_x_bf16.shape[0] + 1, hidden), dtype=torch.bfloat16, device='cuda')
+            input_for_expand_combine[expanded_handle.recv_src_metadata[:num_recv_tokens, 2:].flatten()] = local_y_expand.view(-1, hidden)
+            input_for_expand_combine = input_for_expand_combine[:-1, ...]
 
         # Do combine
         combine_args = dict(
@@ -217,18 +252,19 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
             launch(buffer, 'combine', with_previous_event, async_with_compute_stream, combine_args)
 
         # Reduced combine
-        reduced_combine_args = dict(
-            x=input_for_expand_combine, bias=bias,
-            handle=expanded_handle,
-            num_sms=num_sms, num_qps=num_qps,
-            async_with_compute_stream=async_with_compute_stream,
-            allocate_on_comm_stream=allocate_on_comm_stream,
-        )
-        # NOTES: expand mode requires `allow_multiple_reduction = True` to support topk_weights
-        if args.allow_multiple_reduction:
-            reduced_combine_args['topk_weights'] = expanded_recv_topk_weights
-        reduced_combined_x, reduced_combined_topk_weights, reduced_combine_event = \
-            launch(buffer, 'combine', with_previous_event, async_with_compute_stream, reduced_combine_args)
+        if run_expanded_dispatch:
+            reduced_combine_args = dict(
+                x=input_for_expand_combine, bias=bias,
+                handle=expanded_handle,
+                num_sms=num_sms, num_qps=num_qps,
+                async_with_compute_stream=async_with_compute_stream,
+                allocate_on_comm_stream=allocate_on_comm_stream,
+            )
+            # NOTES: expand mode requires `allow_multiple_reduction = True` to support topk_weights
+            if args.allow_multiple_reduction:
+                reduced_combine_args['topk_weights'] = expanded_recv_topk_weights
+            reduced_combined_x, reduced_combined_topk_weights, reduced_combine_event = \
+                launch(buffer, 'combine', with_previous_event, async_with_compute_stream, reduced_combine_args)
 
         assert not (args.dump_profile_traces and args.skip_perf_test), '`--skip-perf-test` should not be specified when `--dump-profile-traces` is provided'
         if not args.skip_perf_test:
@@ -263,25 +299,27 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
                     f'copy: {2 * num_recv_tokens * num_bytes_per_dispatch_token / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
 
             # Test expanded dispatch performance
-            num_bytes_per_dispatch_token_meta = safe_div(count_bytes(expanded_handle.recv_src_metadata), expanded_handle.recv_src_metadata.size(0))
-            t, copy_t = bench_kineto(lambda: buffer.dispatch(**expanded_dispatch_args),
-                                    kernel_names=('dispatch_impl', 'dispatch_copy_epilogue_impl'),
-                                    barrier_comm_profiling=True, barrier=buffer.barrier, trace_path=get_trace_path('expanded_dispatch'))
-            dist_print(f'   - EP: {buffer.rank_idx:3}/{buffer.num_ranks} | '
-                    f'expanded dispatch: '
-                    f'{num_scaleout_bytes / t / 1e9:.0f} GB/s (SO), '
-                    f'{num_scaleup_bytes / t / 1e9:.0f} GB/s (SU), {t * 1e6:.3f} us, {num_scaleup_bytes:.0f} bytes | '
-                    f'copy: {(num_recv_tokens * (num_bytes_per_dispatch_token_meta + num_bytes_per_dispatch_token) + num_expanded_tokens * num_bytes_per_dispatch_token) / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
+            if run_expanded_dispatch:
+                num_bytes_per_dispatch_token_meta = safe_div(count_bytes(expanded_handle.recv_src_metadata), expanded_handle.recv_src_metadata.size(0))
+                t, copy_t = bench_kineto(lambda: buffer.dispatch(**expanded_dispatch_args),
+                                        kernel_names=('dispatch_impl', 'dispatch_copy_epilogue_impl'),
+                                        barrier_comm_profiling=True, barrier=buffer.barrier, trace_path=get_trace_path('expanded_dispatch'))
+                dist_print(f'   - EP: {buffer.rank_idx:3}/{buffer.num_ranks} | '
+                        f'expanded dispatch: '
+                        f'{num_scaleout_bytes / t / 1e9:.0f} GB/s (SO), '
+                        f'{num_scaleup_bytes / t / 1e9:.0f} GB/s (SU), {t * 1e6:.3f} us, {num_scaleup_bytes:.0f} bytes | '
+                        f'copy: {(num_recv_tokens * (num_bytes_per_dispatch_token_meta + num_bytes_per_dispatch_token) + num_expanded_tokens * num_bytes_per_dispatch_token) / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
 
             # Test cached dispatch performance
-            t, copy_t = bench_kineto(lambda: buffer.dispatch(**cached_dispatch_args),
-                                    kernel_names=('dispatch_impl', 'dispatch_copy_epilogue_impl'),
-                                    barrier_comm_profiling=True, barrier=buffer.barrier, trace_path=get_trace_path('cached_dispatch'))
-            dist_print(f'   # EP: {buffer.rank_idx:3}/{buffer.num_ranks} | '
-                    f'cached dispatch: '
-                    f'{num_scaleout_bytes / t / 1e9:.0f} GB/s (SO), '
-                    f'{num_scaleup_bytes / t / 1e9:.0f} GB/s (SU), {t * 1e6:.3f} us, {num_scaleup_bytes:.0f} bytes | '
-                    f'copy: {2 * num_scaleup_bytes / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
+            if not use_direct_recv_x:
+                t, copy_t = bench_kineto(lambda: buffer.dispatch(**cached_dispatch_args),
+                                        kernel_names=('dispatch_impl', 'dispatch_copy_epilogue_impl'),
+                                        barrier_comm_profiling=True, barrier=buffer.barrier, trace_path=get_trace_path('cached_dispatch'))
+                dist_print(f'   # EP: {buffer.rank_idx:3}/{buffer.num_ranks} | '
+                        f'cached dispatch: '
+                        f'{num_scaleout_bytes / t / 1e9:.0f} GB/s (SO), '
+                        f'{num_scaleup_bytes / t / 1e9:.0f} GB/s (SU), {t * 1e6:.3f} us, {num_scaleup_bytes:.0f} bytes | '
+                        f'copy: {2 * num_scaleup_bytes / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
 
             # Test combine performance
             num_bytes_per_combine_token = safe_div(count_bytes(recv_x_bf16, recv_topk_weights), recv_x_bf16.size(0))
@@ -346,15 +384,16 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
                     f'reduce: {(num_bias_bytes + num_reduction_read_bytes + num_reduction_write_bytes) / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
 
             # Test reduced combine performance
-            num_scaleout_bytes, num_scaleup_bytes, num_reduction_read_bytes = get_combine_bytes(True)
-            t, copy_t = bench_kineto(lambda: buffer.combine(**reduced_combine_args),
-                                    kernel_names=('combine_impl', 'combine_reduce_epilogue_impl'),
-                                    barrier_comm_profiling=True, barrier=buffer.barrier, trace_path=get_trace_path('reduced_combine'))
-            dist_print(f'   + EP: {buffer.rank_idx:3}/{buffer.num_ranks} | '
-                    f'reduced combine: '
-                    f'{num_scaleout_bytes / t / 1e9:.0f} GB/s (SO), '
-                    f'{num_scaleup_bytes / t / 1e9:.0f} GB/s (SU), {t * 1e6:.3f} us, {num_scaleup_bytes:.0f} bytes | '
-                    f'reduce: {(num_bias_bytes + num_reduction_read_bytes + num_reduction_write_bytes) / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
+            if run_expanded_dispatch:
+                num_scaleout_bytes, num_scaleup_bytes, num_reduction_read_bytes = get_combine_bytes(True)
+                t, copy_t = bench_kineto(lambda: buffer.combine(**reduced_combine_args),
+                                        kernel_names=('combine_impl', 'combine_reduce_epilogue_impl'),
+                                        barrier_comm_profiling=True, barrier=buffer.barrier, trace_path=get_trace_path('reduced_combine'))
+                dist_print(f'   + EP: {buffer.rank_idx:3}/{buffer.num_ranks} | '
+                        f'reduced combine: '
+                        f'{num_scaleout_bytes / t / 1e9:.0f} GB/s (SO), '
+                        f'{num_scaleup_bytes / t / 1e9:.0f} GB/s (SU), {t * 1e6:.3f} us, {num_scaleup_bytes:.0f} bytes | '
+                        f'reduce: {(num_bias_bytes + num_reduction_read_bytes + num_reduction_write_bytes) / copy_t / 1e9:.0f} GB/s, {copy_t * 1e6:.3f} us')
             dist_print(once_in_node=True)
 
         # Checks
@@ -362,27 +401,33 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
         if not args.skip_check:
             # Handle copy checks
             assert (topk_idx.data_ptr() != handle.topk_idx.data_ptr()) == do_handle_copy
-            assert (topk_idx.data_ptr() != cached_handle.topk_idx.data_ptr()) == do_handle_copy
-            assert handle.topk_idx.data_ptr() == cached_handle.topk_idx.data_ptr()
+            if not use_direct_recv_x:
+                assert (topk_idx.data_ptr() != cached_handle.topk_idx.data_ptr()) == do_handle_copy
+                assert handle.topk_idx.data_ptr() == cached_handle.topk_idx.data_ptr()
 
             # Make the valid part of the whole tensor for no CPU sync mode
             if not args.do_cpu_sync:
                 if use_fp8_dispatch:
                     recv_x = (recv_x[0][:num_recv_tokens], recv_x[1][:num_recv_tokens])
-                    cached_recv_x = (cached_recv_x[0][:num_recv_tokens], cached_recv_x[1][:num_recv_tokens])
+                    if not use_direct_recv_x:
+                        cached_recv_x = (cached_recv_x[0][:num_recv_tokens], cached_recv_x[1][:num_recv_tokens])
                 else:
                     recv_x = recv_x[:num_recv_tokens]
-                    cached_recv_x = cached_recv_x[:num_recv_tokens]
+                    if not use_direct_recv_x:
+                        cached_recv_x = cached_recv_x[:num_recv_tokens]
                 recv_x_bf16 = recv_x_bf16[:num_recv_tokens]
                 recv_topk_idx = recv_topk_idx[:num_recv_tokens]
                 recv_topk_weights = recv_topk_weights[:num_recv_tokens]
-                cached_recv_topk_idx = cached_recv_topk_idx[:num_recv_tokens]
+                if not use_direct_recv_x:
+                    cached_recv_topk_idx = cached_recv_topk_idx[:num_recv_tokens]
                 handle.recv_src_metadata = handle.recv_src_metadata[:num_recv_tokens]
-                expanded_handle.recv_src_metadata = expanded_handle.recv_src_metadata[:num_recv_tokens]
+                if run_expanded_dispatch:
+                    expanded_handle.recv_src_metadata = expanded_handle.recv_src_metadata[:num_recv_tokens]
 
-            expanded_indices = expanded_handle.recv_src_metadata[:, 2:]
-            expanded_mask = expanded_indices >= 0
-            valid_expanded_indices = expanded_indices[expanded_mask]
+            if run_expanded_dispatch:
+                expanded_indices = expanded_handle.recv_src_metadata[:, 2:]
+                expanded_mask = expanded_indices >= 0
+                valid_expanded_indices = expanded_indices[expanded_mask]
 
             # Make sure deterministic mode works by doing the dispatch twice
             if args.deterministic:
@@ -390,18 +435,20 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
                     launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, dispatch_args)
                 if not args.do_cpu_sync:
                     assert num_recv_tokens == handle_twice.psum_num_recv_tokens_per_scaleup_rank[-1].item()
+                    handle_twice.recv_src_metadata = handle_twice.recv_src_metadata[:num_recv_tokens]
                 recv_x_twice_bf16 = get_recv_x_bf16(recv_x_twice)
-                assert torch.equal(recv_x_bf16, recv_x_twice_bf16)
+                assert torch.equal(recv_x_bf16, recv_x_twice_bf16[:num_recv_tokens])
                 assert torch.equal(recv_topk_idx, recv_topk_idx_twice[:num_recv_tokens])
                 assert torch.equal(recv_topk_weights, recv_topk_weights_twice[:num_recv_tokens])
-                assert torch.equal(handle.recv_src_metadata[:, :1], handle_twice.recv_src_metadata[:num_recv_tokens, :1])
+                assert torch.equal(handle.recv_src_metadata[:, :2], handle_twice.recv_src_metadata[:, :2])
 
-                expanded_recv_x_twice, expanded_recv_topk_idx_twice, expanded_recv_topk_weights_twice, expanded_handle_twice, expanded_dispatch_event_twice = \
-                    launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, expanded_dispatch_args)
-                expanded_recv_x_twice_bf16 = get_recv_x_bf16(expanded_recv_x_twice)
-                assert torch.equal(expanded_recv_x_bf16[valid_expanded_indices], expanded_recv_x_twice_bf16[valid_expanded_indices])
-                if expert_alignment == 1:
-                    assert torch.equal(expanded_recv_topk_weights, expanded_recv_topk_weights_twice)  # Only check for `topk_weight` if `expert_alignment == 1`, since its padding isn't initialized
+                if run_expanded_dispatch:
+                    expanded_recv_x_twice, expanded_recv_topk_idx_twice, expanded_recv_topk_weights_twice, expanded_handle_twice, expanded_dispatch_event_twice = \
+                        launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, expanded_dispatch_args)
+                    expanded_recv_x_twice_bf16 = get_recv_x_bf16(expanded_recv_x_twice)
+                    assert torch.equal(expanded_recv_x_bf16[valid_expanded_indices], expanded_recv_x_twice_bf16[valid_expanded_indices])
+                    if expert_alignment == 1:
+                        assert torch.equal(expanded_recv_topk_weights, expanded_recv_topk_weights_twice)  # Only check for `topk_weight` if `expert_alignment == 1`, since its padding isn't initialized
 
             # Test cumulative stats counter
             cumulative_local_expert_recv_stats = torch.zeros((num_local_experts, ), dtype=torch.int, device='cuda')
@@ -409,38 +456,43 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
             launch(buffer, 'dispatch', with_previous_event, async_with_compute_stream, dispatch_args)
 
             # Expanded checks
-            assert expanded_recv_topk_idx is None
-            assert expanded_handle.recv_src_metadata.size(0) == num_recv_tokens
-            expanded_safe_indices = expanded_indices.clone()
-            expanded_safe_indices[~expanded_mask] = 0
+            if run_expanded_dispatch:
+                assert expanded_recv_topk_idx is None
+                assert expanded_handle.recv_src_metadata.size(0) == num_recv_tokens
+                expanded_indices = expanded_handle.recv_src_metadata[:, 2:]
+                expanded_mask = expanded_indices >= 0
+                valid_expanded_indices = expanded_indices[expanded_mask]
+                expanded_safe_indices = expanded_indices.clone()
+                expanded_safe_indices[~expanded_mask] = 0
 
-            # Cached expand checks: compare valid token slots and verify padding is zeroed
-            cached_expanded_recv_x_bf16 = get_recv_x_bf16(cached_expanded_recv_x)
+                if not use_direct_recv_x:
+                    # Cached expand checks: compare valid token slots and verify padding is zeroed
+                    cached_expanded_recv_x_bf16 = get_recv_x_bf16(cached_expanded_recv_x)
+                    assert torch.equal(expanded_recv_x_bf16[valid_expanded_indices], cached_expanded_recv_x_bf16[valid_expanded_indices])
+                    assert torch.equal(expanded_recv_topk_weights[valid_expanded_indices], cached_expanded_recv_topk_weights[valid_expanded_indices])
 
-            assert torch.equal(expanded_recv_x_bf16[valid_expanded_indices], cached_expanded_recv_x_bf16[valid_expanded_indices])
-            assert torch.equal(expanded_recv_topk_weights[valid_expanded_indices], cached_expanded_recv_topk_weights[valid_expanded_indices])
+                    # Zero padding checks
+                    for expert_idx in range(num_local_experts):
+                        start = expanded_handle.psum_num_recv_tokens_per_expert[expert_idx].item()
+                        end = align(start, expert_alignment)
+                        assert (cached_expanded_recv_x_bf16[start:end] == 0).all()
+                        assert (cached_expanded_recv_topk_weights[start:end] == 0).all()
 
-            # Zero padding checks
-            for expert_idx in range(num_local_experts):
-                start = expanded_handle.psum_num_recv_tokens_per_expert[expert_idx].item()
-                end = align(start, expert_alignment)
-                assert (cached_expanded_recv_x_bf16[start:end] == 0).all()
-                assert (cached_expanded_recv_topk_weights[start:end] == 0).all()
-
-            # Fold expanded
-            expanded_recv_x = fold_expanded(expanded_recv_x, expanded_safe_indices, expanded_mask)
-            expanded_recv_topk_weights = expanded_recv_topk_weights[expanded_safe_indices]
+                # Fold expanded
+                expanded_recv_x = fold_expanded(expanded_recv_x, expanded_safe_indices, expanded_mask)
+                expanded_recv_topk_weights = expanded_recv_topk_weights[expanded_safe_indices]
 
             # Cached checks
-            if use_fp8_dispatch:
-                assert torch.equal(recv_x[0], cached_recv_x[0])
-                assert torch.equal(recv_x[1], cached_recv_x[1])
-            else:
-                assert torch.equal(recv_x, cached_recv_x)
-            assert torch.equal(recv_topk_idx, cached_recv_topk_idx)
-            assert torch.equal(handle.dst_buffer_slot_idx, cached_handle.dst_buffer_slot_idx)
-            assert torch.equal(handle.psum_num_recv_tokens_per_scaleup_rank, cached_handle.psum_num_recv_tokens_per_scaleup_rank)
-            assert handle.num_recv_tokens_per_expert_list == cached_handle.num_recv_tokens_per_expert_list
+            if not use_direct_recv_x:
+                if use_fp8_dispatch:
+                    assert torch.equal(recv_x[0], cached_recv_x[0])
+                    assert torch.equal(recv_x[1], cached_recv_x[1])
+                else:
+                    assert torch.equal(recv_x, cached_recv_x)
+                assert torch.equal(recv_topk_idx, cached_recv_topk_idx)
+                assert torch.equal(handle.dst_buffer_slot_idx, cached_handle.dst_buffer_slot_idx)
+                assert torch.equal(handle.psum_num_recv_tokens_per_scaleup_rank, cached_handle.psum_num_recv_tokens_per_scaleup_rank)
+                assert handle.num_recv_tokens_per_expert_list == cached_handle.num_recv_tokens_per_expert_list
 
             # Check dispatch expert count
             assert recv_x_bf16.size() == ref_recv_x_bf16.size(), f'{recv_x_bf16.size()=}, {ref_recv_x_bf16.size()=}'
@@ -452,14 +504,16 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
                     f'{i}, {ref_count}, {cumulative_local_expert_recv_stats[i].item()}'
                 assert aligned_ref_count == handle.num_recv_tokens_per_expert_list[i]
             psum_num_recv_tokens_per_expert_list = [0] + handle.psum_num_recv_tokens_per_expert.tolist()
-            expanded_psum_num_recv_tokens_per_expert_list = [0] + expanded_handle.psum_num_recv_tokens_per_expert.tolist()
+            if run_expanded_dispatch:
+                expanded_psum_num_recv_tokens_per_expert_list = [0] + expanded_handle.psum_num_recv_tokens_per_expert.tolist()
             for i in range(num_local_experts):
                 ref_count = (ref_recv_topk_idx == i).sum().item()
                 count = psum_num_recv_tokens_per_expert_list[i + 1] - psum_num_recv_tokens_per_expert_list[i]
-                expanded_count = (expanded_psum_num_recv_tokens_per_expert_list[i + 1] -
-                                  align(expanded_psum_num_recv_tokens_per_expert_list[i], expert_alignment))
                 assert align(ref_count, expert_alignment) == count, f'{buffer.rank_idx=}, {i=}, {ref_count=}, {count=}'
-                assert ref_count == expanded_count, f'{ref_count=}, {expanded_count=}'
+                if run_expanded_dispatch:
+                    expanded_count = (expanded_psum_num_recv_tokens_per_expert_list[i + 1] -
+                                      align(expanded_psum_num_recv_tokens_per_expert_list[i], expert_alignment))
+                    assert ref_count == expanded_count, f'{ref_count=}, {expanded_count=}'
 
             # Check dispatch scale-up received token psum
             psum_num_recv_tokens_per_scaleup_rank_list = [0] + handle.psum_num_recv_tokens_per_scaleup_rank.tolist()
@@ -469,10 +523,10 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
                 assert count == ref_count, f'{ref_count=}, {count=}'
 
             # Check dispatch data
-            for check_recv_x, check_recv_topk_idx, check_recv_topk_weights, check_handle in (
-                (expanded_recv_x, None, expanded_recv_topk_weights, expanded_handle),  # Expanded
-                (recv_x, recv_topk_idx, recv_topk_weights, handle),  # Unexpanded
-            ):
+            check_tuples = [(recv_x, recv_topk_idx, recv_topk_weights, handle)]
+            if run_expanded_dispatch:
+                check_tuples.append((expanded_recv_x, None, expanded_recv_topk_weights, expanded_handle))
+            for check_recv_x, check_recv_topk_idx, check_recv_topk_weights, check_handle in check_tuples:
                 for i in range(buffer.num_ranks):
                     rank_start_idx = sum(ref_num_recv_tokens_per_rank[:i])
                     rank_end_idx = rank_start_idx + ref_num_recv_tokens_per_rank[i]
@@ -502,11 +556,12 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
             # Combined data should also be bitwise-identical
             assert torch.equal(combined_x, ref_combined_y), \
                 f'Diff: {calc_diff(combined_x, ref_combined_y)}'
-            assert torch.equal(reduced_combined_x, ref_reduced_combined_y), \
-                f'Diff: {calc_diff(reduced_combined_x, ref_reduced_combined_y)}'
+            if run_expanded_dispatch:
+                assert torch.equal(reduced_combined_x, ref_reduced_combined_y), \
+                    f'Diff: {calc_diff(reduced_combined_x, ref_reduced_combined_y)}'
             assert torch.equal(combined_topk_weights, topk_weights), \
                 f'{calc_diff(combined_topk_weights, topk_weights)}'
-            if args.allow_multiple_reduction:
+            if run_expanded_dispatch and args.allow_multiple_reduction:
                 assert torch.equal(reduced_combined_topk_weights, topk_weights), \
                     f'{calc_diff(reduced_combined_topk_weights, topk_weights)}'
 
@@ -519,10 +574,15 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
 # noinspection PyUnboundLocalVariable,PyShadowingNames
 @torch.inference_mode()
 def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    # Set experimental direct-recv env vars before any DeepEP imports/construction
+    if args.direct_recv_x:
+        os.environ['EP_V2_EXPERIMENTAL_DIRECT_RECV_X'] = '1'
+
     rank_idx, num_ranks, group = init_dist(local_rank, num_local_ranks, seed=args.seed)
     def construct_elastic_buffer():
         return deep_ep.ElasticBuffer(group,
                                      num_max_tokens_per_rank=args.num_tokens, hidden=args.hidden,
+                                     num_topk=args.num_topk,
                                      deterministic=args.deterministic,
                                      allow_hybrid_mode=args.allow_hybrid_mode,
                                      allow_multiple_reduction=args.allow_multiple_reduction,
@@ -584,7 +644,13 @@ if __name__ == '__main__':
     parser.add_argument('--allow-hybrid-mode', type=int, default=1, help='Whether to allow hybrid mode')
     parser.add_argument('--allow-multiple-reduction', type=int, default=1, help='Whether to allow multiple reductions')
     parser.add_argument('--prefer-overlap-with-compute', type=int, default=0, help='Whether to prefer overlap with compute')
+    parser.add_argument('--direct-recv-x', action='store_true', help='Enable EP_V2_EXPERIMENTAL_DIRECT_RECV_X (non-cached, non-expanded)')
     parser.add_argument('--deterministic', action='store_true', help='Use deterministic algorithm')
+
+    # Mode filter settings (None = test all values for that dimension)
+    parser.add_argument('--expert-alignment', type=int, default=None, choices=[1, 128], help='Filter: only test this expert alignment')
+    parser.add_argument('--use-fp8-dispatch', type=int, default=None, choices=[0, 1], help='Filter: only test FP8 (1) or BF16 (0) dispatch')
+    parser.add_argument('--num-bias', type=int, default=None, choices=[0, 1, 2], help='Filter: only test this number of bias tensors')
 
     # Test settings
     parser.add_argument('--seed', type=int, default=0, help='Default seed for pressure tests')


### PR DESCRIPTION
# Add Direct Recv X dispatch path

## Summary

This PR adds an experimental **Direct Recv X** path for compact EP dispatch.

The optimization removes the extra local hidden-state copy in the dispatch copy epilogue. In the original path, hidden states are first written into the NCCL symmetric staging buffer, then copied again into the final `recv_x` tensor by the epilogue. With Direct Recv X enabled, dispatch writes hidden states directly into the final compact `recv_x` window, while metadata and top-k tensors continue to use the existing staging + epilogue path.

Direct Recv X is enabled by:

```bash
EP_V2_EXPERIMENTAL_DIRECT_RECV_X=1
```

This PR also includes a small SM90 / H800 JIT compilation fix for an SM100-only shared-memory bulk-store instruction.

## Background

The original dispatch path has two buffer layers:

```text
                 dispatch kernel                      copy epilogue
src x/topk  ------------------------------> staging -----------------> recv_x/topk
            write hidden + metadata/top-k              read staging, write final tensors
```

`staging` is NCCL symmetric / window memory and can be accessed by the communication path directly.

`recv_x` is a normal PyTorch tensor. It is materialized after dispatch by `dispatch_copy_epilogue`.

This means hidden states always pay one extra local copy:

```text
staging.hidden -> recv_x.hidden
```

The copy cost grows linearly with token count and becomes more visible with wider hidden sizes.

## Direct Recv X design

The dispatch kernel already knows:

- which destination rank a token is sent to;
- which slot index the token occupies on the destination rank.

The receiver notify warp also knows how many tokens each source rank contributes. From those counts, it can compute the exclusive prefix base for each source rank in the compact `recv_x` layout.

Direct Recv X publishes this receiver-side prefix information back to the source rank:

```text
receiver:
  rank_count[source_rank] -> exclusive prefix
  publish prefix[source_rank] back to source

source dispatch warp:
  compact_idx = prefix[dst/source group] + dst_slot_idx
  write hidden directly to recv_x[compact_idx]
```

The hidden-state data path becomes:

```text
src rank x
  -> dispatch kernel
  -> target rank recv_x
```

The metadata / top-k path stays unchanged:

```text
metadata/top-k
  -> staging
  -> dispatch_copy_epilogue
  -> recv_topk_idx / recv_topk_weights / recv_src_metadata / channel_linked_list
```

So the epilogue no longer copies hidden states, but it still materializes the metadata and top-k outputs.

## Implementation

- Reserve a Direct Recv X output window at the tail of the DeepEP symmetric communication buffer when `EP_V2_EXPERIMENTAL_DIRECT_RECV_X=1`.
  - Size:
    ```text
    num_ranks * num_max_tokens_per_rank * hidden * elem_size
    ```

- Return `recv_x` as a view into this symmetric-window tail in Direct Recv X mode.

- Extend dispatch runtime arguments and kernels so dispatch can write hidden states directly into the receiver-side `recv_x` window.

- Let `dispatch_copy_epilogue` skip the hidden-state copy when Direct Recv X is enabled.
  - The epilogue still writes:
    - `recv_topk_idx`
    - `recv_topk_weights`
    - `recv_src_metadata`
    - `channel_linked_list`
    - FP8 scale-factor tensors

- Support both compact dispatch variants:
  - single-node / scaleup dispatch;
  - hybrid scaleout + scaleup dispatch.

- Keep the feature behind one experimental env flag:
  - `EP_V2_EXPERIMENTAL_DIRECT_RECV_X=1`

- Add guardrails for unsupported modes:
  - non-cached dispatch only;
  - non-expanded dispatch only;
  - deterministic dispatch is not supported;
  - `previous_event_before_epilogue` is rejected because `recv_x` is produced during dispatch instead of during the epilogue.

## H100 benchmark results

Configuration:

- GPU: H100
- Path: compact EP dispatch
- Direct mode: `EP_V2_EXPERIMENTAL_DIRECT_RECV_X=1`
- Metric: dispatch + copy epilogue latency

Parameter： 
- direct-recv-x
- num-sms 12
- num-topk 8
- prefer-overlap-with-compute 1

### EP8

| Tokens | Dtype | Dispatch non-direct / direct | Copy non-direct / direct | Total non-direct / direct | Total delta |
|---:|:---:|---:|---:|---:|---:|
| 4096 | FP8 | 545.6 / 536.6 us | 161.7 / 51.9 us | 707.3 / 588.5 us | -118.9 us, 16.8% faster |
| 8192 | FP8 | 1066.0 / 1042.4 us | 325.7 / 92.4 us | 1391.7 / 1134.8 us | -256.8 us, 18.5% faster |
| 4096 | BF16 | 1038.3 / 1076.7 us | 304.3 / 96.1 us | 1342.7 / 1172.8 us | -169.9 us, 12.7% faster |
| 8192 | BF16 | 2048.8 / 2124.8 us | 606.3 / 187.5 us | 2655.1 / 2312.4 us | -342.8 us, 12.9% faster |

### EP16

| Tokens | Dtype | Dispatch non-direct / direct | Copy non-direct / direct | Total non-direct / direct | Total delta |
|---:|:---:|---:|---:|---:|---:|
| 4096 | FP8 | 753.9 / 768.0 us | 166.5 / 34.6 us | 920.4 / 802.6 us | -117.8 us, 12.8% faster |
| 8192 | FP8 | 1416.9 / 1374.6 us | 339.3 / 35.4 us | 1756.3 / 1410.1 us | -346.2 us, 19.7% faster |
| 4096 | BF16 | 1341.8 / 1437.8 us | 289.6 / 103.7 us | 1631.4 / 1541.5 us | -89.9 us, 5.5% faster |
| 8192 | BF16 | 2600.5 / 2737.4 us | 588.0 / 195.4 us | 3188.5 / 2932.8 us | -255.7 us, 8.0% faster |

## Result summary

Direct Recv X substantially reduces the copy epilogue cost by removing the hidden-state copy from staging to `recv_x`.

End-to-end dispatch + copy improvement:

- EP8: 12.7% - 18.5% faster
- EP16: 5.5% - 19.7% faster

In some BF16 cases, the dispatch kernel itself becomes slightly slower because it now performs direct remote `recv_x` writes. The removed epilogue hidden copy still more than offsets that overhead, so total latency improves.