### PR TITLE
Fix LL dispatch RC QP assert for all-P2P topologies

### DIFF
--- a/csrc/kernels/legacy/internode_ll.cu
+++ b/csrc/kernels/legacy/internode_ll.cu
@@ -280,8 +280,21 @@ __global__ __launch_bounds__(1024, 1) void dispatch(void* packed_recv_x,
     } else if (warp_id == num_warps - 1) {
         EP_DEVICE_ASSERT(num_sms > 1);
         if (sm_id == 0) {
-            // The first SM is also responsible for checking QPs
-            EP_DEVICE_ASSERT(ibgda_get_state()->num_rc_per_pe >= num_local_experts);
+            // RC QPs are only needed for peers that are not directly reachable
+            // through P2P. NVSHMEM 3.6 zeroes num_rc_per_pe when its optional
+            // IBGDA transport is unavailable; all-local jobs still work because
+            // every send/count path below already falls back to the P2P pointer.
+            bool needs_ibgda = false;
+            for (int dst_rank = 0; dst_rank < num_ranks; ++dst_rank) {
+                if (dst_rank != rank and
+                    nvshmemi_get_p2p_ptr(
+                        reinterpret_cast<uint64_t>(rdma_recv_count), rank, dst_rank) == 0) {
+                    needs_ibgda = true;
+                    break;
+                }
+            }
+            EP_DEVICE_ASSERT(not needs_ibgda or
+                             ibgda_get_state()->num_rc_per_pe >= num_local_experts);
 
             // The first SM is also responsible for cleaning the next buffer
             #pragma unroll


### PR DESCRIPTION
## Summary

Low-latency dispatch currently asserts `num_rc_per_pe >= num_local_experts` unconditionally on SM 0. With NVSHMEM 3.6, optional IBGDA may leave `num_rc_per_pe == 0` even when every remote rank is directly reachable through P2P. That poisons single-host / all-local jobs (e.g. B200) even though every send/count path already falls back to the P2P pointer when `nvshmemi_get_p2p_ptr(...) != 0`.

Gate the RC QP requirement on per-peer P2P reachability: require RC QPs only if at least one non-self peer has no P2P pointer.

Related reports: #134, #488 (same `num_rc_per_pe` family; this PR specifically covers the LL dispatch all-P2P case).

## Change

In `csrc/kernels/legacy/internode_ll.cu` `dispatch`:
- Scan non-self peers with `nvshmemi_get_p2p_ptr(rdma_recv_count, rank, dst_rank)`
- Assert `num_rc_per_pe >= num_local_experts` only when `needs_ibgda` is true

## Test plan

- [ ] Single-node / all-local LL dispatch with IBGDA unavailable (`num_rc_per_pe == 0`) succeeds when all peers are P2P-reachable
- [ ] Multi-node / non-P2P topology still fails the assert when RC QPs are insufficient
- [ ] Existing LL dispatch correctness on NVLink all-local ranks


Made with [Cursor](https://cursor.com)