### PR TITLE
Fix legacy RC QP indexing for NVSHMEM 3.5.19+

### DIFF
--- a/csrc/kernels/backend/nvshmem.cu
+++ b/csrc/kernels/backend/nvshmem.cu
@@ -1,16 +1,48 @@
-#include <cstring>
-#include <optional>
-#include <vector>
+#include <nvshmem.h>
 
+#include <cstring>
 #include <deep_ep/common/compiled.cuh>
 #include <deep_ep/common/exception.cuh>
+#include <optional>
+#include <sstream>
+#include <vector>
 
-#include <nvshmem.h>
+#if !defined(NVSHMEM_VENDOR_MAJOR_VERSION) || !defined(NVSHMEM_VENDOR_MINOR_VERSION) || !defined(NVSHMEM_VENDOR_PATCH_VERSION)
+#error "NVSHMEM vendor version macros are required"
+#endif
 
 namespace deep_ep::nvshmem {
 
 nvshmem_team_t cpu_rdma_team = NVSHMEM_TEAM_INVALID;
 nvshmem_team_config_t cpu_rdma_team_config;
+
+namespace {
+
+constexpr bool uses_qp_major_rc_layout(const int major, const int minor, const int patch) {
+    return major > 3 or (major == 3 and minor > 5) or (major == 3 and minor == 5 and patch >= 19);
+}
+
+constexpr bool kCompileTimeUsesQpMajorRcLayout =
+    uses_qp_major_rc_layout(NVSHMEM_VENDOR_MAJOR_VERSION, NVSHMEM_VENDOR_MINOR_VERSION, NVSHMEM_VENDOR_PATCH_VERSION);
+
+static_assert(not uses_qp_major_rc_layout(3, 5, 18));
+static_assert(uses_qp_major_rc_layout(3, 5, 19));
+
+void check_rc_layout_compatibility() {
+    int runtime_major, runtime_minor, runtime_patch;
+    nvshmemx_vendor_get_version_info(&runtime_major, &runtime_minor, &runtime_patch);
+    if (kCompileTimeUsesQpMajorRcLayout == uses_qp_major_rc_layout(runtime_major, runtime_minor, runtime_patch))
+        return;
+
+    std::stringstream ss;
+    ss << "DeepEP was compiled with NVSHMEM " << NVSHMEM_VENDOR_MAJOR_VERSION << "." << NVSHMEM_VENDOR_MINOR_VERSION << "."
+       << NVSHMEM_VENDOR_PATCH_VERSION << ", but loaded NVSHMEM " << runtime_major << "." << runtime_minor << "." << runtime_patch
+       << "; these versions use incompatible IBGDA RC QP layouts. Recompile DeepEP "
+          "against the loaded NVSHMEM library.";
+    throw EPException("NVSHMEM", __FILE__, __LINE__, ss.str());
+}
+
+}  // namespace
 
 std::vector<uint8_t> get_unique_id() {
     nvshmemx_uniqueid_t unique_id;
@@ -50,6 +82,11 @@ int init(const std::vector<uint8_t>& root_unique_id_val,
          const int& rank,
          const int& num_ranks,
          const int& team_split_stride) {
+    // NVSHMEM's normal compatibility check allows an older device module to load
+    // against a newer host library. Reject that combination when it crosses the
+    // 3.5.19 RC QP layout transition used by the legacy IBGDA kernels.
+    check_rc_layout_compatibility();
+
     nvshmemx_uniqueid_t root_unique_id;
     nvshmemx_init_attr_t attr;
     std::memcpy(&root_unique_id, root_unique_id_val.data(), sizeof(nvshmemx_uniqueid_t));

--- a/csrc/kernels/legacy/ibgda_device.cuh
+++ b/csrc/kernels/legacy/ibgda_device.cuh
@@ -15,6 +15,10 @@
 
 #include "utils.cuh"
 
+#if !defined(NVSHMEM_VENDOR_MAJOR_VERSION) || !defined(NVSHMEM_VENDOR_MINOR_VERSION) || !defined(NVSHMEM_VENDOR_PATCH_VERSION)
+#error "NVSHMEM vendor version macros are required"
+#endif
+
 namespace deep_ep::legacy {
 
 EP_STATIC_ASSERT(NVSHMEMI_IBGDA_MIN_QP_DEPTH >= 64, "Invalid QP minimum depth");
@@ -84,7 +88,8 @@ __device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc(int p
 #if NVSHMEM_VENDOR_MAJOR_VERSION > 3 || (NVSHMEM_VENDOR_MAJOR_VERSION == 3 && NVSHMEM_VENDOR_MINOR_VERSION > 5) || \
     (NVSHMEM_VENDOR_MAJOR_VERSION == 3 && NVSHMEM_VENDOR_MINOR_VERSION == 5 && NVSHMEM_VENDOR_PATCH_VERSION >= 19)
     // Since 3.5.19, NVSHMEM stores RC QPs in QP-major, PE-interleaved order.
-    return &state->globalmem.rcs[qp * nvshmemi_device_state_d.npes + pe];
+    const auto num_pes = nvshmemi_device_state_d.npes;
+    return &state->globalmem.rcs[qp * num_pes + pe];
 #else
     // Older NVSHMEM releases store RC QPs in PE-major order.
     return &state->globalmem.rcs[pe * num_rcs + qp];

--- a/csrc/kernels/legacy/ibgda_device.cuh
+++ b/csrc/kernels/legacy/ibgda_device.cuh
@@ -7,12 +7,11 @@
 //  - nvshmem/src/include/non_abi/device/pt-to-pt/ibgda_device.cuh
 #pragma once
 
-
-#include <nvshmem.h>
 #include <device_host_transport/nvshmem_common_ibgda.h>
-#include <non_abi/device/threadgroup/nvshmemi_common_device_defines.cuh>
+#include <nvshmem.h>
 
 #include <deep_ep/common/exception.cuh>
+#include <non_abi/device/threadgroup/nvshmemi_common_device_defines.cuh>
 
 #include "utils.cuh"
 
@@ -80,9 +79,16 @@ __device__ static __forceinline__ nvshmemi_ibgda_device_state_t* ibgda_get_state
 
 __device__ static __forceinline__ nvshmemi_ibgda_device_qp_t* ibgda_get_rc(int pe, int id) {
     auto state = ibgda_get_state();
-    const auto num_rc_per_pe = ibgda_get_state()->num_rc_per_pe;
-    return &state->globalmem
-                .rcs[pe * num_rc_per_pe * state->num_devices_initialized + id % (num_rc_per_pe * state->num_devices_initialized)];
+    const auto num_rcs = state->num_rc_per_pe * state->num_devices_initialized;
+    const auto qp = id % num_rcs;
+#if NVSHMEM_VENDOR_MAJOR_VERSION > 3 || (NVSHMEM_VENDOR_MAJOR_VERSION == 3 && NVSHMEM_VENDOR_MINOR_VERSION > 5) || \
+    (NVSHMEM_VENDOR_MAJOR_VERSION == 3 && NVSHMEM_VENDOR_MINOR_VERSION == 5 && NVSHMEM_VENDOR_PATCH_VERSION >= 19)
+    // Since 3.5.19, NVSHMEM stores RC QPs in QP-major, PE-interleaved order.
+    return &state->globalmem.rcs[qp * nvshmemi_device_state_d.npes + pe];
+#else
+    // Older NVSHMEM releases store RC QPs in PE-major order.
+    return &state->globalmem.rcs[pe * num_rcs + qp];
+#endif
 }
 
 __device__ static __forceinline__ void ibgda_lock_acquire(int* lock) {


### PR DESCRIPTION
## Background

The legacy IBGDA path currently indexes `globalmem.rcs` as PE-major. That matches NVSHMEM 3.4.5 and earlier, but NVSHMEM changed RC QP allocation to QP-major, PE-interleaved order in NVIDIA/nvshmem@ce9d4872522775c50ee536a7044bc36c688db2b9. The change is included in NVSHMEM 3.5.19 and later.

With NVSHMEM 3.7.2, the old expression can select another PE RC QP. All ranks may initialize successfully, then the first cross-node dispatch stops making progress and can eventually surface a CUDA fault.

## Change

- Calculate the queue number once.
- Use `queue * npes + pe` for NVSHMEM 3.5.19 and later.
- Preserve `pe * queues_per_pe + queue` for older supported NVSHMEM releases.
- Select the device layout at compile time using NVSHMEM vendor version macros.
- Query the loaded host-library version before NVSHMEM initialization and reject compile/runtime combinations that cross the 3.5.19 layout transition. This closes the compatibility gap left by the normal NVSHMEM check, which permits an older device module with a newer host library.
- Fail compilation if the required vendor version macros are unavailable instead of silently selecting the old layout.

## Validation

- Built the first current-main change (`d268280`) successfully for SM 10.3 with CUDA 13, NVSHMEM 3.7.2, and NCCL 2.30.7; `cuobjdump` confirms `arch = sm_103`.
- Verified from official NVSHMEM 3.4.5, 3.5.19, and 3.7.2 headers that `nvshmemx_vendor_get_version_info` and all three vendor version macros are available.
- Added compile-time boundary assertions for 3.5.18 (old layout) and 3.5.19 (new layout); the same classifier also passed a local C++17 boundary check.
- Applied the equivalent device-index fix to DeepEP v1.2.1 built for SM 10.3 with CUDA 13 and NVSHMEM 3.7.2.
- Passed multi-node EP32 differential checks for dispatch/combine forward output, input gradients, and route-probability gradients.
- Passed two simultaneous EP32 groups and ten consecutive finite full-model optimization steps without a dispatch timeout, CUDA illegal-access error, NCCL error, process restart, or Xid.
- The longer CP1 diagnostic stopped before step 10 on a model-loss `torch.OutOfMemoryError` while materializing FP32 vocabulary logits. The failure was outside DeepEP/NVSHMEM; no transport or device-fault signature preceded it.
- Formatted both touched files with clang-format 15.0.7.