### PR TITLE
fix(test): remove dead num_worst_tokens test from internode file

### DIFF
--- a/tests/legacy/test_internode.py
+++ b/tests/legacy/test_internode.py
@@ -172,21 +172,6 @@ def test_main(args: argparse.Namespace,
                                 dim=1, keepdim=True).expand_as(recv_topk_weights)[recv_topk_idx.eq(-1)]
                             check_data(recv_topk_weights, recv_gbl_rank_prefix_sum)
 
-                    # Test `num_worst_tokens != 0`
-                    if with_topk:
-                        num_worst_tokens = num_tokens * num_ranks
-                        dispatch_args.update({'num_worst_tokens': num_worst_tokens})
-                        recv_worst_x, recv_worst_topk_idx, recv_worst_topk_weights, empty_list, _, event = buffer.dispatch(**dispatch_args)
-                        event.current_stream_wait() if async_mode else ()
-                        recv_worst_x = per_token_cast_back(*recv_worst_x) if isinstance(recv_worst_x, tuple) else recv_worst_x
-                        assert len(empty_list) == 0
-                        assert num_worst_tokens == recv_worst_x.size(0)
-                        assert num_worst_tokens == recv_worst_topk_idx.size(0)
-                        assert num_worst_tokens == recv_worst_topk_weights.size(0)
-                        assert torch.equal(recv_x, recv_worst_x[:recv_x.size(0)])
-                        assert torch.equal(recv_topk_idx, recv_worst_topk_idx[:recv_x.size(0)])
-                        assert torch.equal(recv_topk_weights_clone, recv_worst_topk_weights[:recv_x.size(0)])
-                        assert torch.all(recv_worst_topk_idx[recv_x.size(0):] == -1).item()
 
                     # Test cached dispatch (must without top-k staffs)
                     if not with_topk:


### PR DESCRIPTION
## Problem                                                               
                                                                        
`test_internode.py` included a copy-pasted `num_worst_tokens != 0`       
test block from `test_intranode.py`. This block was dead code —          
`Buffer::dispatch` asserts `num_worst_tokens == 0` for multi-RDMA-rank   
internode dispatch (`legacy.py:378-379`), so the test could never run.   
When triggered, it crashed the test suite.                               
                                                                        
## Fix                                                                   
                                                                        
Remove the block entirely from `test_internode.py`. Coverage is          
preserved in `test_intranode.py` where the feature is supported.         
                                                                        
## References                                                            
                                                                        
- Fixes #670                                                             
- `deep_ep/buffers/legacy.py:354-355`: "this flag is for intranode only" 
- `docs/legacy.md:172`: "this flag is for intranode only"