### PR TITLE
fix(build): inherit PyTorch C++ standard for hybrid EP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ def get_extension_hybrid_ep_cpp():
     # Basic compile arguments
     compile_args = {
         "nvcc": [
-            "-std=c++17",
             "-Xcompiler",
             "-fPIC",
             "--expt-relaxed-constexpr",

--- a/tests/test_setup_compile_flags.py
+++ b/tests/test_setup_compile_flags.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+import ast
+import re
+import unittest
+from pathlib import Path
+
+
+SETUP_PATH = Path(__file__).resolve().parents[1] / "setup.py"
+
+
+def get_literal_nvcc_flags(function_name: str) -> list[str]:
+    tree = ast.parse(SETUP_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+
+    compile_args = next(
+        node.value
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "compile_args"
+            for target in node.targets
+        )
+    )
+    if not isinstance(compile_args, ast.Dict):
+        raise AssertionError("compile_args must be a literal dictionary")
+
+    for key, value in zip(compile_args.keys, compile_args.values, strict=True):
+        if isinstance(key, ast.Constant) and key.value == "nvcc":
+            flags = ast.literal_eval(value)
+            if not isinstance(flags, list) or not all(isinstance(flag, str) for flag in flags):
+                raise AssertionError("compile_args['nvcc'] must be a literal list of strings")
+            return flags
+
+    raise AssertionError("compile_args does not define nvcc flags")
+
+
+class TestSetupCompileFlags(unittest.TestCase):
+    def test_hybrid_ep_inherits_torch_cxx_standard(self):
+        nvcc_flags = get_literal_nvcc_flags("get_extension_hybrid_ep_cpp")
+
+        self.assertIn("-O3", nvcc_flags)
+        self.assertFalse(
+            any(re.fullmatch(r"-std=c\+\+\d+", flag) for flag in nvcc_flags),
+            "hybrid_ep_cpp must inherit the C++ standard selected by PyTorch",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_compile_flags.py
+++ b/tests/test_setup_compile_flags.py
@@ -8,43 +8,27 @@ from pathlib import Path
 SETUP_PATH = Path(__file__).resolve().parents[1] / "setup.py"
 
 
-def get_literal_nvcc_flags(function_name: str) -> list[str]:
+def get_hardcoded_cxx_standard_flags(function_name: str):
     tree = ast.parse(SETUP_PATH.read_text(encoding="utf-8"))
     function = next(
         node
         for node in tree.body
         if isinstance(node, ast.FunctionDef) and node.name == function_name
     )
-
-    compile_args = next(
+    return [
         node.value
         for node in ast.walk(function)
-        if isinstance(node, ast.Assign)
-        and any(
-            isinstance(target, ast.Name) and target.id == "compile_args"
-            for target in node.targets
-        )
-    )
-    if not isinstance(compile_args, ast.Dict):
-        raise AssertionError("compile_args must be a literal dictionary")
-
-    for key, value in zip(compile_args.keys, compile_args.values, strict=True):
-        if isinstance(key, ast.Constant) and key.value == "nvcc":
-            flags = ast.literal_eval(value)
-            if not isinstance(flags, list) or not all(isinstance(flag, str) for flag in flags):
-                raise AssertionError("compile_args['nvcc'] must be a literal list of strings")
-            return flags
-
-    raise AssertionError("compile_args does not define nvcc flags")
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and re.fullmatch(r"-std=c\+\+\d+", node.value)
+    ]
 
 
 class TestSetupCompileFlags(unittest.TestCase):
     def test_hybrid_ep_inherits_torch_cxx_standard(self):
-        nvcc_flags = get_literal_nvcc_flags("get_extension_hybrid_ep_cpp")
-
-        self.assertIn("-O3", nvcc_flags)
-        self.assertFalse(
-            any(re.fullmatch(r"-std=c\+\+\d+", flag) for flag in nvcc_flags),
+        self.assertEqual(
+            get_hardcoded_cxx_standard_flags("get_extension_hybrid_ep_cpp"),
+            [],
             "hybrid_ep_cpp must inherit the C++ standard selected by PyTorch",
         )
 


### PR DESCRIPTION
## Summary

- remove the hardcoded `-std=c++17` flag from `hybrid_ep_cpp`
- let PyTorch's `CUDAExtension` / `BuildExtension` select the compatible C++ standard, matching `deep_ep_cpp`
- add a standard-library regression test that rejects any exact hardcoded `-std=c++NN` string anywhere in this extension builder, including future appended or `cxx` flags

Fixes #698.

## Why

Recent PyTorch headers require C++20, while older supported PyTorch releases may still select C++17. Inheriting PyTorch's selected standard avoids forcing either generation and keeps the two DeepEP extensions consistent.

The runtime JIT compiler's separate C++17 flag is intentionally unchanged because this patch only covers the PyTorch-header extension build.

## Validation

- The regression scanner finds `-std=c++17` on the exact base, `hybrid-ep@94a9f8f6b146c07d97ec58f67cd6d303296d6098`.
- After the source change, `python -m unittest tests/test_setup_compile_flags.py -v` passes.
- The exact test also passes under an actual official Python 3.8.10 Windows embeddable runtime, covering the repository's documented minimum; it also passes under Python 3.12.10.
- `python -m py_compile setup.py tests/test_setup_compile_flags.py`
- `git diff --check`

## Validation boundary

I did not run an NVCC/CUDA build, GPU workload, or training run in this environment. This PR's local evidence is limited to the red/green structural regression, Python 3.8/3.12 test execution, Python compilation, and diff validation.

The implementation, test, review-response update, and PR text were prepared with material AI assistance and checked against the current source and issue before submission.