### PR TITLE
zero-initialize overflow_flag to prevent stale garbage value

### DIFF
--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -115,7 +115,8 @@ HandleImpl Executor::metadata_preprocess_core(
   int32_t *dense_to_expert_map_ptr = nullptr;
   int32_t *tokens_per_expert_ptr = nullptr;
   handle.overflow_flag =
-      torch::zeros({1}, torch::dtype(torch::kInt32).device(torch::kCUDA));
+      torch::empty({1}, torch::dtype(torch::kInt32).device(torch::kCUDA));
+  cudaMemsetAsync(handle.overflow_flag.data_ptr<int>(), 0, sizeof(int32_t), stream);
   if(enable_permute) {
     int num_of_chunks_per_rank = (num_of_tokens_per_rank - 1) / config.num_of_tokens_per_chunk_preprocessing_api + 1;
     handle.dense_chunk_layout = 

--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -115,7 +115,7 @@ HandleImpl Executor::metadata_preprocess_core(
   int32_t *dense_to_expert_map_ptr = nullptr;
   int32_t *tokens_per_expert_ptr = nullptr;
   handle.overflow_flag =
-      torch::empty({1}, torch::dtype(torch::kInt32).device(torch::kCUDA));
+      torch::zeros({1}, torch::dtype(torch::kInt32).device(torch::kCUDA));
   if(enable_permute) {
     int num_of_chunks_per_rank = (num_of_tokens_per_rank - 1) / config.num_of_tokens_per_chunk_preprocessing_api + 1;
     handle.dense_chunk_layout = 


### PR DESCRIPTION
After #625 removed the standalone permute_preprocessing that unconditionally wrote *overflow_flag = 0, the non-fused path leaves overflow_flag
  uninitialized (torch::empty garbage), causing callers to see a false-positive token drop on every dispatch.