### PR TITLE
Reject NCCL runtimes older than the build

### DIFF
--- a/deep_ep/__init__.py
+++ b/deep_ep/__init__.py
@@ -64,6 +64,7 @@ def check_nccl_so():
         for so in [line.strip().split(' ')[-1] for line in f if 'libnccl' in line]:
             loaded_nccl_so = so if loaded_nccl_so is None else loaded_nccl_so
             assert so == loaded_nccl_so, f'Duplicate NCCL runtime found in the current system: {so} and {loaded_nccl_so}'
+    assert loaded_nccl_so is not None, 'No NCCL runtime is loaded in the current process'
     linked_nccl_so_candidates = sorted(glob.glob(f'{find_nccl_root()}/lib/libnccl.so*'))
     assert linked_nccl_so_candidates, f'No libnccl.so found in {find_nccl_root()}/lib/'
     linked_nccl_so = linked_nccl_so_candidates[0]

--- a/deep_ep/__init__.py
+++ b/deep_ep/__init__.py
@@ -6,14 +6,21 @@ import torch
 import os
 
 from .utils.find_pkgs import find_nccl_root
+from .utils.nccl import format_nccl_version, get_nccl_runtime_version
 
 # Set some default environment provided at setup
+built_nccl_version = None
 try:
     # noinspection PyUnresolvedReferences
     from .envs import persistent_envs
-    for key, value in persistent_envs.items():
-        if key not in os.environ:
-            os.environ[key] = value
+except ImportError:
+    persistent_envs = {}
+for key, value in persistent_envs.items():
+    if key not in os.environ:
+        os.environ[key] = value
+try:
+    # noinspection PyUnresolvedReferences
+    from .envs import built_nccl_version
 except ImportError:
     pass
 
@@ -60,6 +67,13 @@ def check_nccl_so():
     linked_nccl_so_candidates = sorted(glob.glob(f'{find_nccl_root()}/lib/libnccl.so*'))
     assert linked_nccl_so_candidates, f'No libnccl.so found in {find_nccl_root()}/lib/'
     linked_nccl_so = linked_nccl_so_candidates[0]
+
+    if built_nccl_version is not None:
+        runtime_nccl_version = get_nccl_runtime_version(loaded_nccl_so)
+        assert runtime_nccl_version >= built_nccl_version, \
+            (f'NCCL runtime {format_nccl_version(runtime_nccl_version)} is older than the '
+             f'{format_nccl_version(built_nccl_version)} version used to build DeepEP; '
+             f'upgrade NCCL before importing deep_ep')
 
     # So checking binary-level equalness is necessary
     # noinspection PyTypeChecker

--- a/deep_ep/utils/__init__.py
+++ b/deep_ep/utils/__init__.py
@@ -1,3 +1,11 @@
-# For forward compatibility
-# noinspection PyUnresolvedReferences
-from .event import EventHandle
+__all__ = ['EventHandle']
+
+
+def __getattr__(name):
+    if name == 'EventHandle':
+        # Keep the forward-compatible export without loading deep_ep._C while
+        # the package-level NCCL compatibility checks are still running.
+        from .event import EventHandle
+        globals()[name] = EventHandle
+        return EventHandle
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/deep_ep/utils/nccl.py
+++ b/deep_ep/utils/nccl.py
@@ -20,7 +20,10 @@ def read_nccl_header_version(header_path) -> int:
 
 def get_nccl_runtime_version(library_path: str) -> int:
     library = ctypes.CDLL(library_path)
-    get_version = library.ncclGetVersion
+    try:
+        get_version = library.ncclGetVersion
+    except AttributeError as exc:
+        raise RuntimeError(f"{library_path} does not export ncclGetVersion") from exc
     get_version.argtypes = [ctypes.POINTER(ctypes.c_int)]
     get_version.restype = ctypes.c_int
     version = ctypes.c_int()

--- a/deep_ep/utils/nccl.py
+++ b/deep_ep/utils/nccl.py
@@ -1,0 +1,37 @@
+import ctypes
+import re
+from pathlib import Path
+
+
+_VERSION_MACROS = ("NCCL_MAJOR", "NCCL_MINOR", "NCCL_PATCH")
+
+
+def read_nccl_header_version(header_path) -> int:
+    header_path = Path(header_path)
+    contents = header_path.read_text(encoding="utf-8")
+    values = {}
+    for name in _VERSION_MACROS:
+        match = re.search(rf"^\s*#\s*define\s+{name}\s+(\d+)\s*$", contents, re.MULTILINE)
+        if match is None:
+            raise ValueError(f"Missing {name} in NCCL header: {header_path}")
+        values[name] = int(match.group(1))
+    return values["NCCL_MAJOR"] * 10000 + values["NCCL_MINOR"] * 100 + values["NCCL_PATCH"]
+
+
+def get_nccl_runtime_version(library_path: str) -> int:
+    library = ctypes.CDLL(library_path)
+    get_version = library.ncclGetVersion
+    get_version.argtypes = [ctypes.POINTER(ctypes.c_int)]
+    get_version.restype = ctypes.c_int
+    version = ctypes.c_int()
+    return_code = get_version(ctypes.byref(version))
+    if return_code != 0:
+        raise RuntimeError(f"ncclGetVersion failed for {library_path} with return code {return_code}")
+    return version.value
+
+
+def format_nccl_version(version: int) -> str:
+    major = version // 10000
+    minor = (version // 100) % 100
+    patch = version % 100
+    return f"{major}.{minor}.{patch}"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ find_pkgs_spec = importlib.util.spec_from_file_location('find_pkgs', os.path.joi
 find_pkgs = importlib.util.module_from_spec(find_pkgs_spec)
 find_pkgs_spec.loader.exec_module(find_pkgs)
 
+nccl_utils_spec = importlib.util.spec_from_file_location('nccl_utils', os.path.join(current_dir, 'deep_ep', 'utils', 'nccl.py'))
+nccl_utils = importlib.util.module_from_spec(nccl_utils_spec)
+nccl_utils_spec.loader.exec_module(nccl_utils)
+
 
 # Wheel specific: NVIDIA pip wheels (nvidia-nvshmem-cu12, nvidia-nccl-cu12)
 # only ship the SO name of the host library, e.g. `libnvshmem_host.so.3`,
@@ -81,6 +85,9 @@ class CustomBuildPy(build_py):
         # noinspection PyShadowingNames
         for name in persistent_env_names:
             code += f"persistent_envs['{name}'] = '{os.environ[name]}'\n" if name in os.environ else ''
+        nccl_header = os.path.join(find_pkgs.find_nccl_root(), 'include', 'nccl.h')
+        built_nccl_version = nccl_utils.read_nccl_header_version(nccl_header)
+        code += f'built_nccl_version = {built_nccl_version}\n'
 
         # Create temporary build directory
         build_include_dir = os.path.join(self.build_lib, 'deep_ep')

--- a/tests/test_nccl_import_guard.py
+++ b/tests/test_nccl_import_guard.py
@@ -1,0 +1,166 @@
+import builtins
+import io
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+INIT_PATH = Path(__file__).parents[1] / "deep_ep" / "__init__.py"
+
+
+def module(name, **attributes):
+    value = types.ModuleType(name)
+    for key, item in attributes.items():
+        setattr(value, key, item)
+    return value
+
+
+def load_deep_ep(monkeypatch, *, runtime_version=22809, built_version=23004, suppress=False):
+    package_name = "deep_ep_guard_test"
+    calls = {"runtime_queries": [], "init_jit": 0}
+
+    package = module(package_name)
+    package.__path__ = [str(INIT_PATH.parent)]
+    utils_package = module(f"{package_name}.utils")
+    utils_package.__path__ = [str(INIT_PATH.parent / "utils")]
+    buffers_package = module(f"{package_name}.buffers")
+    buffers_package.__path__ = [str(INIT_PATH.parent / "buffers")]
+    monkeypatch.setitem(sys.modules, package_name, package)
+    monkeypatch.setitem(sys.modules, f"{package_name}.utils", utils_package)
+    monkeypatch.setitem(sys.modules, f"{package_name}.buffers", buffers_package)
+
+    monkeypatch.setitem(sys.modules, "torch", module("torch"))
+    monkeypatch.setitem(
+        sys.modules,
+        f"{package_name}.utils.find_pkgs",
+        module(f"{package_name}.utils.find_pkgs", find_nccl_root=lambda: "/expected"),
+    )
+
+    def get_runtime_version(path):
+        calls["runtime_queries"].append(path)
+        return runtime_version
+
+    monkeypatch.setitem(
+        sys.modules,
+        f"{package_name}.utils.nccl",
+        module(
+            f"{package_name}.utils.nccl",
+            get_nccl_runtime_version=get_runtime_version,
+            format_nccl_version=lambda version: f"{version // 10000}.{(version // 100) % 100}.{version % 100}",
+        ),
+    )
+
+    generated_envs = module(
+        f"{package_name}.envs",
+        persistent_envs={"EP_TEST_PERSISTENT": "from-wheel"},
+    )
+    if built_version is not None:
+        generated_envs.built_nccl_version = built_version
+    monkeypatch.setitem(sys.modules, f"{package_name}.envs", generated_envs)
+
+    def init_jit(*args):
+        calls["init_jit"] += 1
+
+    extension = module(
+        f"{package_name}._C",
+        init_jit=init_jit,
+        Config=object,
+        topk_idx_t=object,
+    )
+    monkeypatch.setitem(sys.modules, f"{package_name}._C", extension)
+    canonical_package = module("deep_ep")
+    canonical_package.__path__ = [str(INIT_PATH.parent)]
+    monkeypatch.setitem(sys.modules, "deep_ep", canonical_package)
+    monkeypatch.setitem(sys.modules, "deep_ep._C", extension)
+    monkeypatch.setitem(
+        sys.modules,
+        f"{package_name}.buffers.legacy",
+        module(f"{package_name}.buffers.legacy", Buffer=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        f"{package_name}.buffers.elastic",
+        module(f"{package_name}.buffers.elastic", ElasticBuffer=object, EPHandle=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        f"{package_name}.utils.event",
+        module(f"{package_name}.utils.event", EventOverlap=object, EventHandle=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        f"{package_name}.utils.envs",
+        module(
+            f"{package_name}.utils.envs",
+            get_physical_domain_size=lambda: 1,
+            get_logical_domain_size=lambda: 1,
+        ),
+    )
+
+    real_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if str(path) == "/proc/self/maps":
+            return io.StringIO("7f000 r-xp 0000 00:00 0 /runtime/libnccl.so.2\n")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    monkeypatch.setattr("glob.glob", lambda pattern: ["/expected/lib/libnccl.so.2"])
+    monkeypatch.setattr("filecmp.cmp", lambda left, right, shallow=False: True)
+    if suppress:
+        monkeypatch.setenv("EP_SUPPRESS_NCCL_CHECK", "1")
+    else:
+        monkeypatch.delenv("EP_SUPPRESS_NCCL_CHECK", raising=False)
+    monkeypatch.setenv("CUDA_HOME", "/fake/cuda")
+
+    spec = importlib.util.spec_from_file_location(
+        package_name,
+        INIT_PATH,
+        submodule_search_locations=[str(INIT_PATH.parent)],
+    )
+    loaded = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, package_name, loaded)
+    spec.loader.exec_module(loaded)
+    calls["persistent_env"] = os.environ.get("EP_TEST_PERSISTENT")
+    return calls
+
+
+def test_rejects_runtime_older_than_build_before_extension_init(monkeypatch):
+    with pytest.raises(AssertionError, match=r"2\.28\.9.*2\.30\.4.*upgrade NCCL"):
+        load_deep_ep(monkeypatch, runtime_version=22809, built_version=23004)
+
+
+@pytest.mark.parametrize("runtime_version", [23004, 23100])
+def test_accepts_runtime_equal_to_or_newer_than_build(monkeypatch, runtime_version):
+    calls = load_deep_ep(
+        monkeypatch,
+        runtime_version=runtime_version,
+        built_version=23004,
+    )
+
+    assert calls["runtime_queries"] == ["/runtime/libnccl.so.2"]
+    assert calls["init_jit"] == 1
+
+
+def test_missing_build_metadata_keeps_existing_behavior(monkeypatch):
+    calls = load_deep_ep(monkeypatch, runtime_version=22809, built_version=None)
+
+    assert calls["runtime_queries"] == []
+    assert calls["init_jit"] == 1
+    assert calls["persistent_env"] == "from-wheel"
+
+
+def test_suppression_skips_runtime_version_check(monkeypatch):
+    calls = load_deep_ep(
+        monkeypatch,
+        runtime_version=22809,
+        built_version=23004,
+        suppress=True,
+    )
+
+    assert calls["runtime_queries"] == []
+    assert calls["init_jit"] == 1

--- a/tests/test_nccl_import_guard.py
+++ b/tests/test_nccl_import_guard.py
@@ -19,7 +19,14 @@ def module(name, **attributes):
     return value
 
 
-def load_deep_ep(monkeypatch, *, runtime_version=22809, built_version=23004, suppress=False):
+def load_deep_ep(
+    monkeypatch,
+    *,
+    runtime_version=22809,
+    built_version=23004,
+    suppress=False,
+    loaded_nccl_path="/runtime/libnccl.so.2",
+):
     package_name = "deep_ep_guard_test"
     calls = {"runtime_queries": [], "init_jit": 0}
 
@@ -105,7 +112,8 @@ def load_deep_ep(monkeypatch, *, runtime_version=22809, built_version=23004, sup
 
     def fake_open(path, *args, **kwargs):
         if str(path) == "/proc/self/maps":
-            return io.StringIO("7f000 r-xp 0000 00:00 0 /runtime/libnccl.so.2\n")
+            line = f"7f000 r-xp 0000 00:00 0 {loaded_nccl_path}\n" if loaded_nccl_path else ""
+            return io.StringIO(line)
         return real_open(path, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "open", fake_open)
@@ -164,3 +172,8 @@ def test_suppression_skips_runtime_version_check(monkeypatch):
 
     assert calls["runtime_queries"] == []
     assert calls["init_jit"] == 1
+
+
+def test_reports_when_no_nccl_runtime_is_loaded(monkeypatch):
+    with pytest.raises(AssertionError, match="No NCCL runtime is loaded"):
+        load_deep_ep(monkeypatch, loaded_nccl_path=None)

--- a/tests/utils/test_nccl.py
+++ b/tests/utils/test_nccl.py
@@ -99,6 +99,14 @@ def test_reports_nccl_api_failure(monkeypatch):
         module.get_nccl_runtime_version("/runtime/libnccl.so.2")
 
 
+def test_reports_missing_nccl_version_symbol(monkeypatch):
+    module = load_nccl_module()
+    monkeypatch.setattr(module.ctypes, "CDLL", lambda path: object())
+
+    with pytest.raises(RuntimeError, match=r"libnccl\.so\.2.*does not export ncclGetVersion"):
+        module.get_nccl_runtime_version("/runtime/libnccl.so.2")
+
+
 def test_build_metadata_records_nccl_header_version(tmp_path, monkeypatch):
     module = load_setup_module(monkeypatch)
     nccl_root = tmp_path / "nccl"

--- a/tests/utils/test_nccl.py
+++ b/tests/utils/test_nccl.py
@@ -1,0 +1,118 @@
+import ctypes
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).parents[2] / "deep_ep" / "utils" / "nccl.py"
+
+
+def load_nccl_module():
+    spec = importlib.util.spec_from_file_location("nccl_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_setup_module(monkeypatch):
+    cpp_extension = types.ModuleType("torch.utils.cpp_extension")
+    cpp_extension.BuildExtension = object
+    cpp_extension.CUDAExtension = lambda *args, **kwargs: None
+    torch_utils = types.ModuleType("torch.utils")
+    torch_utils.cpp_extension = cpp_extension
+    torch = types.ModuleType("torch")
+    torch.utils = torch_utils
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.utils", torch_utils)
+    monkeypatch.setitem(sys.modules, "torch.utils.cpp_extension", cpp_extension)
+
+    setup_path = Path(__file__).parents[2] / "setup.py"
+    spec = importlib.util.spec_from_file_location("setup_under_test", setup_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_reads_version_from_nccl_header(tmp_path):
+    module = load_nccl_module()
+    header = tmp_path / "nccl.h"
+    header.write_text(
+        "#define NCCL_MAJOR 2\n#define NCCL_MINOR 30\n#define NCCL_PATCH 4\n",
+        encoding="utf-8",
+    )
+
+    assert module.read_nccl_header_version(header) == 23004
+
+
+def test_rejects_header_with_missing_version_macro(tmp_path):
+    module = load_nccl_module()
+    header = tmp_path / "nccl.h"
+    header.write_text(
+        "#define NCCL_MAJOR 2\n#define NCCL_MINOR 30\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="NCCL_PATCH"):
+        module.read_nccl_header_version(header)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [(23004, "2.30.4"), (22809, "2.28.9"), (30000, "3.0.0")],
+)
+def test_formats_nccl_version(version, expected):
+    module = load_nccl_module()
+
+    assert module.format_nccl_version(version) == expected
+
+
+class FakeNcclGetVersion:
+    def __init__(self, version, return_code=0):
+        self.version = version
+        self.return_code = return_code
+
+    def __call__(self, version_ptr):
+        ctypes.cast(version_ptr, ctypes.POINTER(ctypes.c_int)).contents.value = self.version
+        return self.return_code
+
+
+class FakeLibrary:
+    def __init__(self, version, return_code=0):
+        self.ncclGetVersion = FakeNcclGetVersion(version, return_code)
+
+
+def test_reads_runtime_version_with_nccl_api(monkeypatch):
+    module = load_nccl_module()
+    monkeypatch.setattr(module.ctypes, "CDLL", lambda path: FakeLibrary(22809))
+
+    assert module.get_nccl_runtime_version("/runtime/libnccl.so.2") == 22809
+
+
+def test_reports_nccl_api_failure(monkeypatch):
+    module = load_nccl_module()
+    monkeypatch.setattr(module.ctypes, "CDLL", lambda path: FakeLibrary(0, 7))
+
+    with pytest.raises(RuntimeError, match=r"libnccl\.so\.2.*return code 7"):
+        module.get_nccl_runtime_version("/runtime/libnccl.so.2")
+
+
+def test_build_metadata_records_nccl_header_version(tmp_path, monkeypatch):
+    module = load_setup_module(monkeypatch)
+    nccl_root = tmp_path / "nccl"
+    include_dir = nccl_root / "include"
+    include_dir.mkdir(parents=True)
+    (include_dir / "nccl.h").write_text(
+        "#define NCCL_MAJOR 2\n#define NCCL_MINOR 30\n#define NCCL_PATCH 4\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module.find_pkgs, "find_nccl_root", lambda: str(nccl_root))
+    build_lib = tmp_path / "build"
+    builder = types.SimpleNamespace(build_lib=str(build_lib))
+
+    module.CustomBuildPy.generate_default_envs(builder)
+
+    generated = (build_lib / "deep_ep" / "envs.py").read_text(encoding="utf-8")
+    assert "built_nccl_version = 23004" in generated

--- a/tests/utils/test_utils_init.py
+++ b/tests/utils/test_utils_init.py
@@ -1,0 +1,33 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+UTILS_DIR = Path(__file__).parents[2] / "deep_ep" / "utils"
+
+
+def load_utils_package(monkeypatch):
+    package_name = "deep_ep_utils_lazy_test"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(UTILS_DIR.parent)]
+    monkeypatch.setitem(sys.modules, package_name, package)
+
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.utils",
+        UTILS_DIR / "__init__.py",
+        submodule_search_locations=[str(UTILS_DIR)],
+    )
+    utils = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, utils)
+    spec.loader.exec_module(utils)
+    return utils
+
+
+def test_importing_utils_does_not_import_compiled_extension(monkeypatch):
+    monkeypatch.delitem(sys.modules, "deep_ep._C", raising=False)
+
+    utils = load_utils_package(monkeypatch)
+
+    assert "deep_ep._C" not in sys.modules
+    assert utils.__all__ == ["EventHandle"]


### PR DESCRIPTION
## Summary

- record the NCCL header version used to build each wheel
- query the already-loaded NCCL runtime before importing `deep_ep._C`
- reject runtimes older than the build with an actionable versioned error
- defer the compatibility `EventHandle` export so `_C` is not loaded before the NCCL guard

## Why

When another package downgrades NCCL, the existing loaded-vs-installed binary comparison moves both sides to the downgraded library. The check therefore cannot detect that `_C` was built against a newer NCCL Device API, and users see an opaque undefined-symbol error.

Generated wheel metadata now carries `built_nccl_version`. At import, DeepEP calls `ncclGetVersion` on the mapped runtime and allows equal or newer versions. Source checkouts without generated metadata keep the existing behavior, and `EP_SUPPRESS_NCCL_CHECK=1` still bypasses the checks.

## Testing

- `PYTHONPYCACHEPREFIX=/tmp/deepep-pycache python3 -m pytest tests/utils/test_nccl.py tests/utils/test_utils_init.py tests/test_nccl_import_guard.py -q`
- `PYTHONPYCACHEPREFIX=/tmp/deepep-pycache python3 -m compileall -q deep_ep tests`

Result: 14 tests passed. These are GPU-free unit tests; no CUDA/NCCL integration run was performed.

Fixes #710