### PR TITLE
perf: reuse HybridEP routing allgather buffer

### DIFF
--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -46,7 +46,11 @@ torch::Tensor Executor::allgather_routing_map(
     torch::Tensor global_routing_map;
     // At inter-node case, we will use NCCL allgather
     if(config.num_of_nodes > 1 || !enable_custom_allgather || !custom_allgather_aligned) {
-        global_routing_map = torch::empty(
+        // Reuse the allgather coordinator's preallocated output buffer. Metadata
+        // preprocessing runs on the same stream immediately after this collective,
+        // so the buffer is no longer live when the next dispatch reuses it.
+        global_routing_map = torch::from_blob(
+            allgather_obj.get_output_buffer(),
             {num_of_tokens_per_rank * group_size, num_cols},
             torch::TensorOptions().dtype(dtype).device(torch::kCUDA)
         );

--- a/tests/test_allgather_grad_validation.py
+++ b/tests/test_allgather_grad_validation.py
@@ -25,6 +25,7 @@ TOPK = int(os.environ.get("TOPK", 8))
 HIDDEN_DIM = int(os.environ.get("HIDDEN_DIM", 1024))
 REPEATS = int(os.environ.get("REPEATS", 3))
 SEED = int(os.environ.get("SEED", 1025))
+EXPECTED_NUM_NODES = int(os.environ.get("EXPECTED_NUM_NODES", 0))
 
 
 def assert_equal(label, lhs, rhs):
@@ -208,6 +209,15 @@ def worker(local_rank, num_local_ranks, _args):
         num_local_experts=NUM_LOCAL_EXPERTS,
         enable_custom_allgather=False,
     )
+    if EXPECTED_NUM_NODES:
+        assert buffer_custom.num_of_nodes == EXPECTED_NUM_NODES
+        assert buffer_nccl.num_of_nodes == EXPECTED_NUM_NODES
+    if rank == 0:
+        print(
+            f"TOPOLOGY ranks={world_size}, nodes={buffer_nccl.num_of_nodes}, "
+            f"ranks_per_node={buffer_nccl.num_of_hybrid_ep_ranks_per_nvlink_domain}",
+            flush=True,
+        )
 
     for repeat in range(REPEATS):
         for mode in ("indices", "sparse"):

--- a/tests/test_allgather_grad_validation.py
+++ b/tests/test_allgather_grad_validation.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Regression coverage for HybridEP custom-allgather and NCCL fallback paths.
+
+This extends the dedicated allgather output comparison through combine and the
+documented manual backward communication sequence:
+
+    forward:  dispatch -> expert -> combine
+    backward: dispatch(combined grads) -> expert backward -> combine
+"""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+from utils import init_dist
+
+
+NUM_TOKENS = int(os.environ.get("NUM_TOKENS_PER_RANK", 1024))
+NUM_LOCAL_EXPERTS = int(os.environ.get("NUM_LOCAL_EXPERTS", 8))
+TOPK = int(os.environ.get("TOPK", 8))
+HIDDEN_DIM = int(os.environ.get("HIDDEN_DIM", 1024))
+REPEATS = int(os.environ.get("REPEATS", 3))
+SEED = int(os.environ.get("SEED", 1025))
+
+
+def assert_equal(label, lhs, rhs):
+    assert (lhs is None) == (rhs is None), f"{label}: None mismatch"
+    if lhs is None:
+        return
+    assert lhs.shape == rhs.shape, f"{label}: shape {lhs.shape} != {rhs.shape}"
+    assert lhs.dtype == rhs.dtype, f"{label}: dtype {lhs.dtype} != {rhs.dtype}"
+    if not torch.equal(
+        lhs.contiguous().view(torch.uint8), rhs.contiguous().view(torch.uint8)
+    ):
+        mismatches = (lhs != rhs).sum().item()
+        if lhs.is_floating_point():
+            max_diff = (lhs.float() - rhs.float()).abs().max().item()
+            raise AssertionError(
+                f"{label}: {mismatches} values differ, max_abs_diff={max_diff}"
+            )
+        raise AssertionError(f"{label}: {mismatches} values differ")
+
+
+def assert_dispatch_equal(label, custom, nccl):
+    for name, custom_tensor, nccl_tensor in zip(
+        ("hidden", "probs", "scaling_factor"), custom[:3], nccl[:3]
+    ):
+        assert_equal(f"{label}.dispatch.{name}", custom_tensor, nccl_tensor)
+
+    custom_handle, nccl_handle = custom[3], nccl[3]
+    assert len(custom_handle) == len(nccl_handle)
+    assert_equal(
+        f"{label}.handle.num_dispatched_tokens",
+        custom_handle[3],
+        nccl_handle[3],
+    )
+    custom_count = int(custom_handle[3].item())
+    nccl_count = int(nccl_handle[3].item())
+    assert custom_count == nccl_count
+    assert_equal(
+        f"{label}.handle.local_expert_routing_map",
+        custom_handle[4][:custom_count],
+        nccl_handle[4][:nccl_count],
+    )
+    assert custom_handle[5] == nccl_handle[5]
+
+
+def make_inputs(rank, num_experts):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(SEED + rank)
+    hidden = torch.randn(
+        NUM_TOKENS,
+        HIDDEN_DIM,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    scores = torch.randn(
+        NUM_TOKENS, num_experts, device="cuda", dtype=torch.float32, generator=generator
+    )
+    topk_idx = scores.topk(TOPK, dim=-1, sorted=False).indices
+    topk_weights = torch.rand(
+        NUM_TOKENS, TOPK, device="cuda", dtype=torch.float32, generator=generator
+    )
+    routing_map = torch.zeros(
+        NUM_TOKENS, num_experts, device="cuda", dtype=torch.bool
+    ).scatter_(1, topk_idx, True)
+    probs = torch.zeros(
+        NUM_TOKENS, num_experts, device="cuda", dtype=torch.float32
+    ).scatter_(1, topk_idx, topk_weights)
+    scaling_factor = torch.randn(
+        NUM_TOKENS,
+        HIDDEN_DIM // 128,
+        device="cuda",
+        dtype=torch.float32,
+        generator=generator,
+    )
+    return generator, hidden, topk_idx, topk_weights, routing_map, probs, scaling_factor
+
+
+def run_case(
+    label,
+    buffer_custom,
+    buffer_nccl,
+    generator,
+    hidden,
+    dispatch_kwargs,
+):
+    custom = buffer_custom.dispatch(hidden=hidden, **dispatch_kwargs)
+    nccl = buffer_nccl.dispatch(hidden=hidden, **dispatch_kwargs)
+    assert_dispatch_equal(label, custom, nccl)
+
+    # Forward expert output and combine outputs.
+    expert_custom = custom[0] * torch.tensor(1.25, device="cuda", dtype=torch.bfloat16)
+    expert_nccl = nccl[0] * torch.tensor(1.25, device="cuda", dtype=torch.bfloat16)
+    combined_custom = buffer_custom.combine(expert_custom, custom[1], custom[3])
+    combined_nccl = buffer_nccl.combine(expert_nccl, nccl[1], nccl[3])
+    assert_equal(f"{label}.combine.hidden", combined_custom[0], combined_nccl[0])
+    assert_equal(f"{label}.combine.probs", combined_custom[1], combined_nccl[1])
+
+    # Backward of combine: dispatch gradients from tokens back to expert outputs.
+    grad_combined_hidden = torch.randn(
+        hidden.shape, device="cuda", dtype=torch.bfloat16, generator=generator
+    )
+    num_experts = dispatch_kwargs.get("num_of_experts")
+    if num_experts is None:
+        num_experts = dispatch_kwargs["routing_map"].shape[1]
+    grad_combined_probs = None
+    if custom[1] is not None:
+        grad_combined_probs = torch.randn(
+            hidden.shape[0],
+            num_experts,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+    grad_expert_custom = buffer_custom.dispatch(
+        hidden=grad_combined_hidden,
+        probs=grad_combined_probs,
+        num_of_experts=num_experts,
+        handle=custom[3],
+    )
+    grad_expert_nccl = buffer_nccl.dispatch(
+        hidden=grad_combined_hidden,
+        probs=grad_combined_probs,
+        num_of_experts=num_experts,
+        handle=nccl[3],
+    )
+    assert_dispatch_equal(
+        f"{label}.backward_combine", grad_expert_custom, grad_expert_nccl
+    )
+
+    # Backward of dispatch: combine expert-input gradients back to token inputs.
+    grad_dispatched_hidden = torch.randn(
+        custom[0].shape, device="cuda", dtype=torch.bfloat16, generator=generator
+    )
+    grad_dispatched_probs = None
+    if custom[1] is not None:
+        grad_dispatched_probs = torch.randn(
+            custom[1].shape, device="cuda", dtype=torch.float32, generator=generator
+        )
+    grad_input_custom = buffer_custom.combine(
+        grad_dispatched_hidden, grad_dispatched_probs, custom[3]
+    )
+    grad_input_nccl = buffer_nccl.combine(
+        grad_dispatched_hidden, grad_dispatched_probs, nccl[3]
+    )
+    assert_equal(
+        f"{label}.backward_dispatch.hidden_grad",
+        grad_input_custom[0],
+        grad_input_nccl[0],
+    )
+    assert_equal(
+        f"{label}.backward_dispatch.probs_grad",
+        grad_input_custom[1],
+        grad_input_nccl[1],
+    )
+
+
+def worker(local_rank, num_local_ranks, _args):
+    import deep_ep
+
+    _, _, group = init_dist(local_rank, num_local_ranks)
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    num_experts = NUM_LOCAL_EXPERTS * world_size
+    assert TOPK <= num_experts
+    assert HIDDEN_DIM % 128 == 0
+
+    generator, hidden, topk_idx, topk_weights, routing_map, probs, scaling_factor = (
+        make_inputs(rank, num_experts)
+    )
+    buffer_custom = deep_ep.HybridEPBuffer(
+        group=group,
+        hidden_dim=HIDDEN_DIM,
+        max_num_of_tokens_per_rank=NUM_TOKENS,
+        num_local_experts=NUM_LOCAL_EXPERTS,
+        enable_custom_allgather=True,
+    )
+    buffer_nccl = deep_ep.HybridEPBuffer(
+        group=group,
+        hidden_dim=HIDDEN_DIM,
+        max_num_of_tokens_per_rank=NUM_TOKENS,
+        num_local_experts=NUM_LOCAL_EXPERTS,
+        enable_custom_allgather=False,
+    )
+
+    for repeat in range(REPEATS):
+        for mode in ("indices", "sparse"):
+            for with_probs in (False, True):
+                if mode == "indices":
+                    kwargs = {
+                        "topk_idx": topk_idx,
+                        "topk_weights": topk_weights if with_probs else None,
+                        "num_of_experts": num_experts,
+                        "scaling_factor": scaling_factor,
+                    }
+                else:
+                    kwargs = {
+                        "routing_map": routing_map,
+                        "probs": probs if with_probs else None,
+                        "scaling_factor": scaling_factor,
+                    }
+                label = f"repeat={repeat},mode={mode},with_probs={with_probs}"
+                run_case(
+                    label,
+                    buffer_custom,
+                    buffer_nccl,
+                    generator,
+                    hidden,
+                    kwargs,
+                )
+                dist.barrier()
+                if rank == 0:
+                    print(f"PASS {label}", flush=True)
+
+    if rank == 0:
+        print(
+            f"ALL OUTPUT/GRAD CHECKS PASSED: ranks={world_size}, repeats={REPEATS}, "
+            f"tokens={NUM_TOKENS}, hidden={HIDDEN_DIM}, experts={num_experts}, topk={TOPK}",
+            flush=True,
+        )
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-processes", type=int, default=8)
+    args = parser.parse_args()
+    torch.multiprocessing.spawn(
+        worker, args=(args.num_processes, args), nprocs=args.num_processes
+    )


### PR DESCRIPTION
## Summary

Reuse HybridEP's preallocated allgather output buffer for the NCCL/inter-node routing-map allgather instead of allocating a temporary CUDA tensor during every dispatch.

The routing map is consumed by metadata preprocessing on the same stream before the next dispatch can reuse the buffer, so its lifetime does not overlap the following collective.

## Memory impact

The removed temporary allocation contains the globally gathered routing payload on every rank.

For sparse Boolean routing, the saved allocation per rank is:

```text
tokens_per_rank x world_size x num_experts bytes
```

For dense `int16` routing, it is:

```text
tokens_per_rank x world_size x topk x 2 bytes
```

For the stress configuration used during validation (`8192` tokens/rank, `8` ranks, `256` experts, and top-k `36`), this avoids:

- Sparse routing: 16 MiB per rank, or 128 MiB across the process group.
- Dense routing: 4.5 MiB per rank, or 36 MiB across the process group.

## Implementation

- Wrap `CustomAllgather::get_output_buffer()` as the NCCL allgather output tensor.
- Preserve the existing NCCL behavior for inter-node execution, disabled custom allgather, and unaligned payloads.
- Preserve the upstream dense-routing behavior, including the dynamic `bool`/`int16` dtype, routing shape, and byte views used for NCCL.
- Add a distributed output and gradient regression test.
- Assert the requested node topology so multi-node validation cannot silently execute as a single-node test.

## Testing

Validation was performed on H100 GPUs using a multi-node DOCA/RDMA build in both of these topologies:

- One node with eight local ranks.
- Two nodes with four local ranks per node, for eight global ranks.

### Output and gradient regression

Added `tests/test_allgather_grad_validation.py`, which compares the reused-buffer path with the existing allgather behavior.

The test covers the Cartesian product of:

- Dense expert indices and sparse Boolean routing maps.
- Routing with and without probabilities.
- Three independently executed dispatch/combine cycles.

This produces 12 cases per topology. Each case validates:

- Dispatched hidden states and routing probabilities.
- Per-expert token counts and dispatch-handle metadata.
- Forward combine hidden-state and probability outputs.
- Hidden-state and probability gradients for the backward-of-combine communication.
- Hidden-state and probability gradients for the backward-of-dispatch communication.
- Tensor shapes, dtypes, and optional `None` behavior.

All 12 cases passed on both the single-node and two-node topologies.

### Full HybridEP reference validation

Ran `tests/test_hybrid_ep.py` with 512 tokens/rank, eight local experts, top-k 8, hidden dimension 1024, and padding multiple 32.

The following passed for both BF16 and FP8 on both topologies:

- Standard dispatch and combine.
- Sparse and dense routing.
- Routing with and without probabilities.
- Dispatch with permutation and combine with unpermutation.
- Non-fused and fused permute/dispatch execution.
- Torch reference comparisons.
- Intra-node NVLink and inter-node RDMA execution.

The API-level and kernel-level benchmark loops also completed successfully.

### CUDA graph and nonblocking validation

Ran `tests/test_graphed_hybrid_ep.py` across:

- BF16 and FP8.
- With and without routing probabilities.
- Fused and non-fused execution.
- CUDA graph capture/replay and nonblocking dispatch/combine behavior.

All combinations passed on every rank in both topologies.

### Harry Zhou's standalone allgather stress test

Thanks to Harry Zhou for providing [`test_allgather.py`](https://github.com/harryzhou2000/DeepEP/blob/hhanyu/hybrid-ep-sparse-opt-2/tests/test_allgather.py), which was used as an additional correctness and stress test.

It was run in both single-node and two-node configurations with its original stress dimensions:

```text
tokens per rank  = 8192
hidden dimension = 7168
global experts   = 256
local experts    = 32
top-k            = 36
global ranks     = 8
```

For both dense-index and sparse-Boolean routing:

- Dispatched hidden tokens matched bitwise.
- Dispatched probabilities matched bitwise.
- The custom, NCCL, and legacy benchmark loops completed successfully.
- Repeated execution completed without exposing buffer-lifetime or reuse issues.

Thanks again to Harry for the focused test coverage and stress configuration.

### Static checks

The new regression test also passed Ruff linting, Ruff formatting, Python bytecode compilation, and repository pre-commit checks.
