### PR TITLE
[HybridEP] Support configurable RoCE settings in DOCA backend

### DIFF
--- a/csrc/hybrid_ep/backend/ibvcore.h
+++ b/csrc/hybrid_ep/backend/ibvcore.h
@@ -248,8 +248,8 @@
      }
      union ibv_gid gid;
      CALL_CHECK(ibv_query_gid(context, portNum, *gidIndex, &gid));
-     if (!validGid(&gid)) {
-       fprintf(stderr, "[Error] NCCL_IB_GID_INDEX=%d is not a valid routable GID\n",
+     if (!configuredGid(&gid)) {
+       fprintf(stderr, "[Error] NCCL_IB_GID_INDEX=%d does not reference a configured GID\n",
                *gidIndex);
        return ncclInvalidArgument;
      }

--- a/csrc/hybrid_ep/backend/ibvcore.h
+++ b/csrc/hybrid_ep/backend/ibvcore.h
@@ -8,6 +8,10 @@
 
  #ifdef HYBRID_EP_BUILD_MULTINODE_ENABLE
  #include <arpa/inet.h>
+ #include <cerrno>
+ #include <climits>
+ #include <cstdlib>
+ #include <cstring>
  #include <fcntl.h>
  #include <infiniband/verbs.h>
  #include <sys/socket.h>
@@ -20,6 +24,39 @@
    static const int IB_ROCE_VERSION_NUM = 2;
    static const sa_family_t DEFAULT_FAMILY = AF_INET;
    static const char NCCL_IB_ADDR_RANGE[] = { 0 };
+
+   static ncclResult_t envIbGidIndex(int* gidIndex) {
+     const char* env = std::getenv("NCCL_IB_GID_INDEX");
+     if (env == nullptr || env[0] == '\0') {
+       *gidIndex = IB_GID_INDEX;
+       return ncclSuccess;
+     }
+
+     char* end = nullptr;
+     errno = 0;
+     const long value = std::strtol(env, &end, 10);
+     if (errno != 0 || end == env || *end != '\0' || value < -1 || value > INT_MAX) {
+       fprintf(stderr, "[Error] NCCL_IB_GID_INDEX must be an integer greater than or equal to -1, got '%s'\n", env);
+       return ncclInvalidArgument;
+     }
+
+     *gidIndex = static_cast<int>(value);
+     return ncclSuccess;
+   }
+
+   static sa_family_t envIbAddrFamily() {
+     const char* env = std::getenv("NCCL_IB_ADDR_FAMILY");
+     if (env == nullptr || env[0] == '\0') {
+       return DEFAULT_FAMILY;
+     }
+     if (std::strcmp(env, "AF_INET") == 0) {
+       return AF_INET;
+     }
+     if (std::strcmp(env, "AF_INET6") == 0) {
+       return AF_INET6;
+     }
+     return DEFAULT_FAMILY;
+   }
  
    int ncclIbExtractFlid(union ibv_gid *gid) {
      return ntohs(*((uint16_t*)((uintptr_t)(gid->raw) + 4)));
@@ -184,7 +221,8 @@
  
    }
  
- static ncclResult_t ncclIbGetGidIndex(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex) {
+ static ncclResult_t ncclIbGetGidIndex(struct ibv_context *context, uint8_t portNum,
+                                      struct ibv_port_attr* portAttr, int *gidIndex) {
    int gidTblLen = portAttr->gid_tbl_len;
    //for IB, choose GID Index that will have routable FLID if present
    if (portAttr->link_layer == IBV_LINK_LAYER_INFINIBAND) {
@@ -201,11 +239,23 @@
      return ncclSuccess;
    }
    //for ROCE
-   *gidIndex = IB_GID_INDEX;
+   NCCL_CHECK(envIbGidIndex(gidIndex));
    if (*gidIndex >= 0) {
+     if (*gidIndex >= gidTblLen) {
+       fprintf(stderr, "[Error] NCCL_IB_GID_INDEX=%d exceeds GID table length %d\n",
+               *gidIndex, gidTblLen);
+       return ncclInvalidArgument;
+     }
+     union ibv_gid gid;
+     CALL_CHECK(ibv_query_gid(context, portNum, *gidIndex, &gid));
+     if (!validGid(&gid)) {
+       fprintf(stderr, "[Error] NCCL_IB_GID_INDEX=%d is not a valid routable GID\n",
+               *gidIndex);
+       return ncclInvalidArgument;
+     }
      return ncclSuccess;
    }
-   sa_family_t userAddrFamily = DEFAULT_FAMILY;
+   sa_family_t userAddrFamily = envIbAddrFamily();
    int userRoceVersion = IB_ROCE_VERSION_NUM;
    int prefixlen;
    void *prefix = envIbAddrRange(userAddrFamily, &prefixlen);

--- a/csrc/hybrid_ep/buffer/internode_doca.cu
+++ b/csrc/hybrid_ep/buffer/internode_doca.cu
@@ -18,9 +18,9 @@ static int get_env_int_in_range(const char* name, int default_value, int min_val
   const long parsed_value = std::strtol(raw_value, &end, 10);
   if (errno != 0 || end == raw_value || *end != '\0' ||
       parsed_value < min_value || parsed_value > max_value) {
-    fprintf(stderr, "[Error] %s must be an integer in [%d, %d], got '%s'\n",
-            name, min_value, max_value, raw_value);
-    std::abort();
+    fprintf(stderr, "[Warning] %s must be an integer in [%d, %d], got '%s'; using default %d\n",
+            name, min_value, max_value, raw_value, default_value);
+    return default_value;
   }
   return static_cast<int>(parsed_value);
 }
@@ -211,8 +211,10 @@ int setup_qp_attr_for_modify(struct ibv_port_attr *port_attr, struct doca_verbs_
   struct remote_info *l_info, struct remote_info *r_info,
   struct ibv_context *ib_context) {
   int status = 0;
+  static const int configured_traffic_class =
+      get_env_int_in_range("NCCL_IB_TC", DEF_IB_TC, -1, 255);
   const auto traffic_class = static_cast<uint8_t>(
-      get_env_int_in_range("NCCL_IB_TC", DEF_IB_TC, 0, 255));
+      configured_traffic_class == -1 ? DEF_IB_TC : configured_traffic_class);
   status = doca_verbs_qp_attr_set_dest_qp_num(qp_attr, r_info->qpn);
   assert(status == 0);
   struct doca_verbs_ah_attr *ah = nullptr;

--- a/csrc/hybrid_ep/buffer/internode_doca.cu
+++ b/csrc/hybrid_ep/buffer/internode_doca.cu
@@ -2,9 +2,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 // All rights reserved
 #include "buffer/internode_doca.cuh"
+#include <cerrno>
 #include <sstream>
 #include <cstdlib>
 #include <unordered_map>
+
+static int get_env_int_in_range(const char* name, int default_value, int min_value, int max_value) {
+  const char* raw_value = std::getenv(name);
+  if (raw_value == nullptr || raw_value[0] == '\0') {
+    return default_value;
+  }
+
+  char* end = nullptr;
+  errno = 0;
+  const long parsed_value = std::strtol(raw_value, &end, 10);
+  if (errno != 0 || end == raw_value || *end != '\0' ||
+      parsed_value < min_value || parsed_value > max_value) {
+    fprintf(stderr, "[Error] %s must be an integer in [%d, %d], got '%s'\n",
+            name, min_value, max_value, raw_value);
+    std::abort();
+  }
+  return static_cast<int>(parsed_value);
+}
 
 // Functions realted to get RDMA context.
 ibv_device *ctx_find_dev(const char *ib_devname) {
@@ -192,6 +211,8 @@ int setup_qp_attr_for_modify(struct ibv_port_attr *port_attr, struct doca_verbs_
   struct remote_info *l_info, struct remote_info *r_info,
   struct ibv_context *ib_context) {
   int status = 0;
+  const auto traffic_class = static_cast<uint8_t>(
+      get_env_int_in_range("NCCL_IB_TC", DEF_IB_TC, 0, 255));
   status = doca_verbs_qp_attr_set_dest_qp_num(qp_attr, r_info->qpn);
   assert(status == 0);
   struct doca_verbs_ah_attr *ah = nullptr;
@@ -200,7 +221,11 @@ int setup_qp_attr_for_modify(struct ibv_port_attr *port_attr, struct doca_verbs_
   if (port_attr->link_layer == IBV_LINK_LAYER_INFINIBAND) {
     status = doca_verbs_ah_attr_set_addr_type(ah, DOCA_VERBS_ADDR_TYPE_IB_NO_GRH);
   } else {
-    status = doca_verbs_ah_attr_set_addr_type(ah, DOCA_VERBS_ADDR_TYPE_IPv4);
+    const auto gid_family = hybrid_ep::getGidAddrFamily(&r_info->gid);
+    const auto addr_type = gid_family == AF_INET6
+                               ? DOCA_VERBS_ADDR_TYPE_IPv6
+                               : DOCA_VERBS_ADDR_TYPE_IPv4;
+    status = doca_verbs_ah_attr_set_addr_type(ah, addr_type);
   }
   assert(status == 0);
   status = doca_verbs_ah_attr_set_dlid(ah, r_info->lid);
@@ -213,7 +238,7 @@ int setup_qp_attr_for_modify(struct ibv_port_attr *port_attr, struct doca_verbs_
   assert(status == 0);
   status = doca_verbs_ah_attr_set_hop_limit(ah, DEF_HOP_LIMIT);
   assert(status == 0);
-  status = doca_verbs_ah_attr_set_traffic_class(ah, DEF_IB_TC);
+  status = doca_verbs_ah_attr_set_traffic_class(ah, traffic_class);
   assert(status == 0);
   status = doca_verbs_qp_attr_set_ah_attr(qp_attr, ah);
   assert(status == 0);
@@ -368,7 +393,12 @@ void RDMACoordinator::init(
   ibv_query_port(ib_context, IB_PORT, &port_attr);
   uint8_t link_layer = port_attr.link_layer;
   assert(link_layer == IBV_LINK_LAYER_INFINIBAND || link_layer == IBV_LINK_LAYER_ETHERNET);
-  hybrid_ep::ncclIbGetGidIndex(ib_context, IB_PORT, &port_attr, &gid_index);
+  const auto gid_status = hybrid_ep::ncclIbGetGidIndex(
+      ib_context, IB_PORT, &port_attr, &gid_index);
+  if (gid_status != ncclSuccess) {
+    fprintf(stderr, "[Error] Failed to select a valid HybridEP GID index\n");
+    std::abort();
+  }
 
   // Alloc protect domain.
   ib_pd = ibv_alloc_pd(ib_context);

--- a/docs/Hybrid-EP_Implementation.md
+++ b/docs/Hybrid-EP_Implementation.md
@@ -273,9 +273,9 @@ The DOCA backend also honors the standard NCCL InfiniBand/RoCE settings when cre
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `NCCL_IB_GID_INDEX` | GID table index used for RoCE. The default `-1` selects a GID automatically |
+| `NCCL_IB_GID_INDEX` | GID table index used for RoCE. The default `-1` selects a GID automatically; an explicit index must reference a configured GID |
 | `NCCL_IB_ADDR_FAMILY` | Address family (`AF_INET` or `AF_INET6`) used during automatic GID selection. The default is `AF_INET` |
-| `NCCL_IB_TC` | RoCE traffic class in the range 0–255. The default is `0` |
+| `NCCL_IB_TC` | RoCE traffic class in the range 0–255. Unset or `-1` uses the default `0` |
 
 ### 4.2 Buffer Allocation
 

--- a/docs/Hybrid-EP_Implementation.md
+++ b/docs/Hybrid-EP_Implementation.md
@@ -260,7 +260,7 @@ Hybrid-EP uses two categories of GPU memory:
 - **Registered Buffer**: GPU memory registered for cross-rank access. For inter-node, memory is registered with RDMA; for intra-node, a CUDA IPC handle is exported.
 - **Normal Buffer**: Standard `cudaMalloc` memory for local computation, not accessible by other ranks.
 
-**GPU-NIC Mapping for RDMA**
+**RDMA Network Configuration**
 
 For RDMA scenarios, buffer registration requires establishing a GPU-NIC mapping to specify which network interface each GPU uses for communication. The backend supports automatic topology discovery by default. If manual configuration is needed, the following environment variables can be used:
 
@@ -268,6 +268,14 @@ For RDMA scenarios, buffer registration requires establishing a GPU-NIC mapping 
 |---------------------|-------------|
 | `HYBRID_EP_ENABLE_MANUAL_NIC_MAPPING` | Set to `1` to enable manual NIC mapping; otherwise, automatic topology discovery is used |
 | `HYBRID_EP_NIC_MAPPING` | GPU-to-NIC mapping string in the format `<gpu_id>:<nic_name>,...` |
+
+The DOCA backend also honors the standard NCCL InfiniBand/RoCE settings when creating its queue pairs:
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `NCCL_IB_GID_INDEX` | GID table index used for RoCE. The default `-1` selects a GID automatically |
+| `NCCL_IB_ADDR_FAMILY` | Address family (`AF_INET` or `AF_INET6`) used during automatic GID selection. The default is `AF_INET` |
+| `NCCL_IB_TC` | RoCE traffic class in the range 0–255. The default is `0` |
 
 ### 4.2 Buffer Allocation
 


### PR DESCRIPTION
## Summary
Add support for standard NCCL RoCE settings in the HybridEP DOCA backend.
Configure GID selection, address family, and traffic class through `NCCL_IB_GID_INDEX`, `NCCL_IB_ADDR_FAMILY`, and `NCCL_IB_TC`.
Preserve the existing native InfiniBand FLID selection behavior.
Document the supported network settings.
## Why
HybridEP previously used default RoCE settings, including automatic GID selection, IPv4 addressing, and traffic class 0. This can create invalid DOCA queue pairs on fabrics requiring a specific GID, IPv6, or non-default traffic class, resulting in requester CQ errors and device-side assertions, ```Assertion `status >= 0` failed.```

Using standard NCCL environment variables makes HybridEP compatible with these RoCE configurations without introducing backend-specific settings.