### PR TITLE
Add unordered hybrid kernels for transports without ordered delivery (opt-in via EP_HYBRID_KERNEL)  

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ The library provides some environment variables, which may be useful:
     - `EP_NIC_NAME`: string, the default NIC name used to query NIC properties, `mlx5_0` by default
     - `EP_OVERRIDE_RDMA_SL`: integer, override the RDMA service level index for traffic isolation
     - `EP_DISABLE_GIN`: `0` or `1`, disable the NCCL Gin backend (fall back to non-Gin path), `0` by default
+    - `EP_HYBRID_KERNEL`: `ordered` or `unordered`, select the hybrid (scale-out) dispatch/combine kernel pair. See [Hybrid kernel variants](#hybrid-kernel-variants-ordered-and-unordered)
 - JIT
     - `EP_JIT_DEBUG`: `0` or `1`, print JIT debugging information, `0` by default
     - `EP_JIT_CACHE_DIR`: string, cache directory for compiled kernels, `$HOME/.deep_ep` by default
@@ -398,6 +399,28 @@ If the hardware supports it, we recommend using the following command to set the
 ```bash
 sudo mlxconfig -y -d mlx5_$i set PCI_ATOMIC_MODE=4
 ```
+
+## Hybrid kernel variants (ordered and unordered)
+
+We have two implementations of the hybrid (scale-out) dispatch and combine kernels. The `EP_HYBRID_KERNEL` environment variable selects between them at JIT compile time. The value is read once per process, and the JIT cache distinguishes the two variants automatically. Direct mode is not affected by this setting.
+
+- `EP_HYBRID_KERNEL=unordered`. The sender batches tokens into parts with in-band headers, and the receiver counts signal arrivals to learn how much data has landed. The kernels make no assumption about network delivery order, so they only need weak (counting) signals from the GIN backend.
+- `EP_HYBRID_KERNEL=ordered`. The upstream kernels. The sender publishes a tail pointer through a trailing signal, and the receiver assumes all data preceding the tail has already landed. This requires a GIN backend that supports [strong signals and VA signals](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/device_gin.html#signals-and-counters)
+
+## Running on AWS EFA
+
+On EFA the traffic is carried by an NCCL GIN backend provided by the [aws-ofi-nccl](https://github.com/aws/aws-ofi-nccl) plugin. Two backends are available:
+
+- **EFA-GDA** (GPU-initiated). The NIC work queues are mapped into GPU memory and the kernels post RDMA operations themselves.
+- **CPU proxy**. The GPU hands work descriptors to a CPU proxy thread that posts the RDMA operations.
+
+Enabling NCCL GIN backends on AWS has different requirements, see details in this [document](https://github.com/aws/aws-ofi-nccl/blob/master/doc/gin-getting-started.md).
+
+### Benchmarking on EFA
+
+A ready-to-run setup (install script, reference Dockerfile, and Slurm launchers for intra-node and inter-node `test_ep.py` runs) is maintained in the awsome-distributed-ai repository:
+
+- [DeepEP V2 Benchmark (NCCL GIN / EFA-GDA)](https://github.com/awslabs/awsome-distributed-ai/blob/main/micro-benchmarks/expert-parallelism/deepep-v2-benchmark/README.md)
 
 ## Experimental branches
 

--- a/csrc/elastic/buffer.hpp
+++ b/csrc/elastic/buffer.hpp
@@ -1,11 +1,23 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <cuda_runtime.h>
 #include <memory>
 #include <numeric>
 #include <vector>
 #include <pybind11/functional.h>
 
+#include <deep_ep/common/gin_resource_alloc.cuh>
 #include <deep_ep/common/layout.cuh>
 #include <deep_ep/common/compiled.cuh>
 
@@ -171,6 +183,10 @@ public:
 
     std::tuple<int, int> get_physical_domain_size() const {
         return {nccl_context->num_rdma_ranks, nccl_context->num_nvl_ranks};
+    }
+
+    int get_num_allocated_qps() const {
+        return nccl_context->num_allocated_qps;
     }
 
     std::tuple<int, int> get_logical_domain_size() const {
@@ -1349,6 +1365,7 @@ static void register_apis(pybind11::module_& m) {
         .def("destroy", &ElasticBuffer::destroy)
         .def("get_comm_stream", &ElasticBuffer::get_comm_stream)
         .def("get_physical_domain_size", &ElasticBuffer::get_physical_domain_size)
+        .def("get_num_allocated_qps", &ElasticBuffer::get_num_allocated_qps)
         .def("get_logical_domain_size", &ElasticBuffer::get_logical_domain_size)
         .def("barrier", &ElasticBuffer::barrier)
         .def("engram_write", &ElasticBuffer::engram_write)

--- a/csrc/elastic/buffer.hpp
+++ b/csrc/elastic/buffer.hpp
@@ -619,13 +619,25 @@ public:
             return send_buffer_layout.get_num_bytes() + recv_buffer_layout.get_num_bytes();
         } else {
             // Hybrid dispatch
+            const auto scaleup_recv_buffer = layout::BufferLayout<false>(
+                token_layout, num_scaleup_ranks, num_scaleout_ranks * num_max_tokens_per_rank);
+            if (elastic::use_ordered_hybrid_kernel()) {
+                // The ordered kernel keeps upstream's send/recv shapes: a single token-indexed
+                // send buffer and header-less recv slots.
+                const auto scaleout_send_buffer = layout::BufferLayout<false>(
+                    token_layout, 1, num_max_tokens_per_rank);
+                const auto scaleout_recv_buffer = layout::BufferLayout<false>(
+                    token_layout, num_scaleout_ranks,
+                    /* kNumChannels * kNumMaxTokensPerChannel */ num_max_tokens_per_rank + kNumMaxChannels);
+                return scaleup_recv_buffer.get_num_bytes() +
+                       scaleout_send_buffer.get_num_bytes() +
+                       scaleout_recv_buffer.get_num_bytes();
+            }
             const auto scaleout_token_layout = layout::TokenLayout(
                 hidden * elem_size, num_sf_packs * sizeof(sf_pack_t), num_topk, true,
                 nullptr, /*with_scaleout_hdr=*/true);
             const int scaleout_slots =
                 num_max_tokens_per_rank + kNumMaxChannels * elastic::gin_alloc::kScaleoutSlotRoundingReserve;
-            const auto scaleup_recv_buffer = layout::BufferLayout<false>(
-                token_layout, num_scaleup_ranks, num_scaleout_ranks * num_max_tokens_per_rank);
             const auto scaleout_send_buffer = layout::BufferLayout<false>(
                 scaleout_token_layout, num_scaleout_ranks, scaleout_slots);
             const auto scaleout_recv_buffer = layout::BufferLayout<false>(
@@ -659,6 +671,19 @@ public:
             const int num_tokens_in_scaleup_layout = allow_multiple_reduction ? std::min(num_scaleup_ranks, num_topk) : num_topk;
             const auto scaleup_recv_buffer = layout::BufferLayout<false>(
                 token_layout, num_tokens_in_scaleup_layout, num_scaleout_ranks * num_max_tokens_per_rank);
+            if (elastic::use_ordered_hybrid_kernel()) {
+                // The ordered kernel keeps upstream's token-indexed return layout.
+                const int num_tokens_in_scaleout_layout = allow_multiple_reduction ? std::min(num_scaleout_ranks, num_topk) : num_topk;
+                const auto scaleout_recv_buffer = layout::BufferLayout<false>(
+                    token_layout, num_tokens_in_scaleout_layout, num_max_tokens_per_rank);
+                const auto scaleout_send_buffer = layout::BufferLayout<false>(
+                    token_layout, allow_multiple_reduction ? 1 : num_topk,
+                    /* kNumChannels * num_scaleout_ranks * kNumMaxTokensPerChannel */
+                    num_scaleout_ranks * (num_max_tokens_per_rank + kNumMaxChannels));
+                return scaleup_recv_buffer.get_num_bytes() +
+                       scaleout_send_buffer.get_num_bytes() +
+                       scaleout_recv_buffer.get_num_bytes();
+            }
             const auto scaleout_recv_buffer = layout::BufferLayout<false>(
                 token_layout, num_scaleout_ranks,
                 (num_max_tokens_per_rank + kNumMaxChannels) * (allow_multiple_reduction ? 1 : num_topk));
@@ -882,6 +907,14 @@ public:
             num_channels_per_sm = std::min<int>(
                 num_smem_bytes / combine_token_layout.get_num_bytes<true>(),
                 num_channels_per_sm);
+            if (elastic::use_ordered_hybrid_kernel()) {
+                // The ordered kernel carves one send + one forward TMA buffer per channel and has
+                // no per-channel signal budget, so keep the upstream channel decision.
+                num_channels_per_sm = std::min<int>(
+                    /* 2 kinds of warps */ num_channels_per_sm / 2, kNumMaxChannelsPerSM);
+                if (not prefer_overlap_with_compute)
+                    num_channels_per_sm = std::min<int>(num_channels_per_sm, 4);
+            } else {
             const int dispatch_buffers_per_channel = prefer_overlap_with_compute
                 ? kNumDispatchSendBuffers + 1
                 : kNumDispatchBuffersPerChannel;
@@ -917,6 +950,7 @@ public:
                 -- num_channels_per_sm;
             EP_HOST_ASSERT(num_channels_per_sm >= 1 and
                            "shared memory cannot host a single dispatch channel at this token size");
+            }
             num_channels = num_sms * num_channels_per_sm;
             if (get_env<int>("EP_BUFFER_DEBUG"))
                 printf("Elastic buffer uses %d channels per SM\n", num_channels_per_sm);

--- a/csrc/elastic/buffer.hpp
+++ b/csrc/elastic/buffer.hpp
@@ -18,6 +18,7 @@
 #include <pybind11/functional.h>
 
 #include <deep_ep/common/gin_resource_alloc.cuh>
+#include <deep_ep/impls/proxy_ring.cuh>
 #include <deep_ep/common/layout.cuh>
 #include <deep_ep/common/compiled.cuh>
 
@@ -656,15 +657,14 @@ public:
         } else {
             // Hybrid combine
             const int num_tokens_in_scaleup_layout = allow_multiple_reduction ? std::min(num_scaleup_ranks, num_topk) : num_topk;
-            const int num_tokens_in_scaleout_layout = allow_multiple_reduction ? std::min(num_scaleout_ranks, num_topk) : num_topk;
             const auto scaleup_recv_buffer = layout::BufferLayout<false>(
                 token_layout, num_tokens_in_scaleup_layout, num_scaleout_ranks * num_max_tokens_per_rank);
             const auto scaleout_recv_buffer = layout::BufferLayout<false>(
-                token_layout, num_tokens_in_scaleout_layout, num_max_tokens_per_rank);
+                token_layout, num_scaleout_ranks,
+                (num_max_tokens_per_rank + kNumMaxChannels) * (allow_multiple_reduction ? 1 : num_topk));
             const auto scaleout_send_buffer = layout::BufferLayout<false>(
-                token_layout, allow_multiple_reduction ? 1 : num_topk,
-                /* kNumChannels * num_scaleout_ranks * kNumMaxTokensPerChannel */
-                num_scaleout_ranks * (num_max_tokens_per_rank + kNumMaxChannels));
+                token_layout, num_scaleout_ranks,
+                (num_max_tokens_per_rank + kNumMaxChannels) * (allow_multiple_reduction ? 1 : num_topk));
             return scaleup_recv_buffer.get_num_bytes() +
                    scaleout_send_buffer.get_num_bytes() +
                    scaleout_recv_buffer.get_num_bytes();
@@ -905,6 +905,16 @@ public:
                     nccl_context->gin_config.gin_indexed_signals_cnt,
                     num_sms, num_qps, /*with_notify=*/true, num_channels_per_sm);
             }
+            // The unordered combine also carves the proxy hand-off rings out of the
+            // same dynamic shared memory as its TMA buffers; shrink the channel count
+            // until both fit (see the matching assert in `launch_combine`).
+            while (num_channels_per_sm > 1 and
+                   static_cast<int64_t>(2 * num_channels_per_sm) *
+                           combine_token_layout.get_num_bytes<true, int64_t>() +
+                       elastic::ProxyRingLayout::get_num_bytes(num_channels_per_sm,
+                                                               elastic::kProxyRingDepthDefault) >
+                   num_smem_bytes)
+                -- num_channels_per_sm;
             EP_HOST_ASSERT(num_channels_per_sm >= 1 and
                            "shared memory cannot host a single dispatch channel at this token size");
             num_channels = num_sms * num_channels_per_sm;
@@ -1259,6 +1269,7 @@ public:
             const torch::Tensor& psum_num_recv_tokens_per_scaleup_rank,
             const std::optional<torch::Tensor>& token_metadata_at_forward,
             const std::optional<torch::Tensor>& channel_linked_list,
+            const std::optional<torch::Tensor>& token_map_at_dispatch,
             const int& num_experts,
             const int& num_max_tokens_per_rank,
             const int& num_sms, const int& num_qps,
@@ -1332,6 +1343,7 @@ public:
         int num_channels = 1;
         int* token_metadata_at_forward_ptr = nullptr;
         int* channel_linked_list_ptr = nullptr;
+        int* token_map_at_dispatch_ptr = nullptr;
         if (nccl_context->num_scaleout_ranks > 1) {
             // The token metadata during forward
             const auto [num_channels_, d1, d2] = get_shape<3>(token_metadata_at_forward.value());
@@ -1351,6 +1363,14 @@ public:
             EP_HOST_ASSERT(d2_ == nccl_context->num_scaleup_ranks);
             EP_HOST_ASSERT(channel_linked_list->is_cuda() and channel_linked_list->is_contiguous());
             EP_HOST_ASSERT(channel_linked_list->scalar_type() == torch::kInt);
+
+            // Per-(token, k) recv address map — consumed by the epilogue.
+            EP_HOST_ASSERT(token_map_at_dispatch.has_value());
+            const auto [num_max_tokens_per_rank_, num_topk_] = get_shape<2>(token_map_at_dispatch.value());
+            EP_HOST_ASSERT(num_max_tokens_per_rank == num_max_tokens_per_rank_ and num_topk == num_topk_);
+            EP_HOST_ASSERT(token_map_at_dispatch->is_cuda() and token_map_at_dispatch->is_contiguous());
+            EP_HOST_ASSERT(token_map_at_dispatch->scalar_type() == torch::kInt);
+            token_map_at_dispatch_ptr = token_map_at_dispatch->data_ptr<int>();
         }
 
         // Push data into remote buffers
@@ -1362,9 +1382,11 @@ public:
             psum_num_recv_tokens_per_scaleup_rank.data_ptr<int>(),
             token_metadata_at_forward_ptr,
             channel_linked_list_ptr,
+            token_map_at_dispatch_ptr,
             nccl_context->dev_comm, nccl_context->window,
             buffer, workspace,
-            num_reduced_tokens, num_max_tokens_per_rank,
+            num_reduced_tokens, num_combined_tokens,
+            num_max_tokens_per_rank,
             hidden, num_experts, num_topk,
             num_qps, num_gpu_timeout_cycles,
             nccl_context->num_scaleout_ranks, nccl_context->num_scaleup_ranks,
@@ -1392,8 +1414,10 @@ public:
                                        num_combined_tokens, num_max_tokens_per_rank,
                                        hidden,
                                        num_experts, num_topk,
+                                       num_channels,
                                        reduce_buffer,
                                        bias_ptrs[0], bias_ptrs[1],
+                                       token_map_at_dispatch_ptr,
                                        nccl_context->num_scaleout_ranks, nccl_context->num_scaleup_ranks,
                                        nccl_context->scaleout_rank_idx, nccl_context->scaleup_rank_idx,
                                        jit::device_runtime->get_num_sms(),
@@ -1409,7 +1433,8 @@ public:
              combined_x, combined_topk_weights,
              psum_num_recv_tokens_per_scaleup_rank,
              token_metadata_at_forward,
-             channel_linked_list},
+             channel_linked_list,
+             token_map_at_dispatch},
             compute_stream,
             allocate_on_comm_stream, async_with_compute_stream);
         return {combined_x, combined_topk_weights, event};

--- a/csrc/elastic/buffer.hpp
+++ b/csrc/elastic/buffer.hpp
@@ -55,6 +55,8 @@ class ElasticBuffer {
     // Whether to allow multiple reductions
     bool allow_multiple_reduction;
 
+    mutable int dispatch_iteration = 0;
+
     // Whether to prefer overlapping communication with compute (use more SMs and channels if false)
     bool prefer_overlap_with_compute;
 
@@ -616,13 +618,17 @@ public:
             return send_buffer_layout.get_num_bytes() + recv_buffer_layout.get_num_bytes();
         } else {
             // Hybrid dispatch
+            const auto scaleout_token_layout = layout::TokenLayout(
+                hidden * elem_size, num_sf_packs * sizeof(sf_pack_t), num_topk, true,
+                nullptr, /*with_scaleout_hdr=*/true);
+            const int scaleout_slots =
+                num_max_tokens_per_rank + kNumMaxChannels * elastic::gin_alloc::kScaleoutSlotRoundingReserve;
             const auto scaleup_recv_buffer = layout::BufferLayout<false>(
                 token_layout, num_scaleup_ranks, num_scaleout_ranks * num_max_tokens_per_rank);
             const auto scaleout_send_buffer = layout::BufferLayout<false>(
-                token_layout, 1, num_max_tokens_per_rank);
+                scaleout_token_layout, num_scaleout_ranks, scaleout_slots);
             const auto scaleout_recv_buffer = layout::BufferLayout<false>(
-                token_layout, num_scaleout_ranks,
-                /* kNumChannels * kNumMaxTokensPerChannel */ num_max_tokens_per_rank + kNumMaxChannels);
+                scaleout_token_layout, num_scaleout_ranks, scaleout_slots);
             return scaleup_recv_buffer.get_num_bytes() +
                    scaleout_send_buffer.get_num_bytes() +
                    scaleout_recv_buffer.get_num_bytes();
@@ -714,6 +720,7 @@ public:
                torch::Tensor, torch::Tensor, torch::Tensor,
                torch::Tensor, torch::Tensor,
                std::optional<torch::Tensor>, std::optional<torch::Tensor>,
+               std::optional<torch::Tensor>,
                std::optional<EventHandle>>
     dispatch(const torch::Tensor& x,
              const std::optional<torch::Tensor>& sf,
@@ -730,6 +737,7 @@ public:
              const std::optional<torch::Tensor>& cached_token_metadata_at_forward,
              const std::optional<torch::Tensor>& cached_recv_src_metadata,
              const std::optional<torch::Tensor>& cached_channel_linked_list,
+             const std::optional<torch::Tensor>& cached_token_map_at_dispatch,
              const int& num_max_tokens_per_rank,
              const int& num_experts, const int& expert_alignment,
              const int& num_sms, const int& num_qps,
@@ -760,6 +768,7 @@ public:
             if (nccl_context->num_scaleout_ranks > 1) {
                 EP_HOST_ASSERT(cached_token_metadata_at_forward.has_value());
                 EP_HOST_ASSERT(cached_channel_linked_list.has_value());
+                EP_HOST_ASSERT(cached_token_map_at_dispatch.has_value());
             }
         }
 
@@ -873,10 +882,31 @@ public:
             num_channels_per_sm = std::min<int>(
                 num_smem_bytes / combine_token_layout.get_num_bytes<true>(),
                 num_channels_per_sm);
+            const int dispatch_buffers_per_channel = prefer_overlap_with_compute
+                ? kNumDispatchSendBuffers + 1
+                : kNumDispatchBuffersPerChannel;
             num_channels_per_sm = std::min<int>(
-                /* 2 kinds of warps */ num_channels_per_sm / 2, kNumMaxChannelsPerSM);
+                num_channels_per_sm / dispatch_buffers_per_channel, kNumMaxChannelsPerSM);
+            // The dispatch kernel carves (send + forward) TMA buffers per channel out of dynamic
+            // shared memory; the budget above must cover the real pool or the launch fails at
+            // higher channel counts.
+            EP_HOST_ASSERT(static_cast<int64_t>(dispatch_buffers_per_channel) * num_channels_per_sm *
+                                   dispatch_token_layout.get_num_bytes<true>() +
+                               get_num_notify_smem_bytes(nccl_context->num_ranks, num_experts) <=
+                           num_smem_bytes and
+                           "dispatch TMA pool exceeds the shared-memory budget");
             if (not prefer_overlap_with_compute)
                 num_channels_per_sm = std::min<int>(num_channels_per_sm, 4);
+            // Reduce the channel count to fit this launch's GIN indexed-signal budget.
+            // `with_notify` is pinned (not `not cached_mode`) so a cached dispatch derives the
+            // same count the handle was shaped with.
+            if (num_sms > 0 and nccl_context->gin_config.gin_indexed_signals_cnt > 0) {
+                num_channels_per_sm = elastic::gin_alloc::constexpr_channels_per_sm(
+                    nccl_context->gin_config.gin_indexed_signals_cnt,
+                    num_sms, num_qps, /*with_notify=*/true, num_channels_per_sm);
+            }
+            EP_HOST_ASSERT(num_channels_per_sm >= 1 and
+                           "shared memory cannot host a single dispatch channel at this token size");
             num_channels = num_sms * num_channels_per_sm;
             if (get_env<int>("EP_BUFFER_DEBUG"))
                 printf("Elastic buffer uses %d channels per SM\n", num_channels_per_sm);
@@ -898,8 +928,9 @@ public:
         }
 
         // Hybrid mode handles
-        std::optional<torch::Tensor> token_metadata_at_forward, channel_linked_list;
+        std::optional<torch::Tensor> token_metadata_at_forward, channel_linked_list, token_map_at_dispatch;
         int *token_metadata_at_forward_ptr = nullptr, *channel_linked_list_ptr = nullptr;
+        int *token_map_at_dispatch_ptr = nullptr;
         if (nccl_context->num_scaleout_ranks > 1) {
             // The token destination slot idx during forward
             // `[i, j, k, l]` means: from channel i from scale-out peer k, the j-th token's index in the l-th rank buffer
@@ -965,6 +996,23 @@ public:
                 );
             }
             channel_linked_list_ptr = channel_linked_list->data_ptr<int>();
+
+            // Per-(token, k) recv address map. `[T, k]` records the per-(channel, dst_rank) slot
+            // number that dispatch chose for expert k of my token T. The epilogue derives the full
+            // recv offset as `channel = T % kNumChannels`, `addr = channel * kNumSlotsPerChannel + slot`.
+            if (cached_mode) {
+                token_map_at_dispatch = cached_token_map_at_dispatch;
+                const auto [num_max_tokens_per_rank_, num_topk_] = get_shape<2>(token_map_at_dispatch.value());
+                EP_HOST_ASSERT(num_max_tokens_per_rank == num_max_tokens_per_rank_ and num_topk == num_topk_);
+                EP_HOST_ASSERT(token_map_at_dispatch->is_cuda() and token_map_at_dispatch->is_contiguous());
+                EP_HOST_ASSERT(token_map_at_dispatch->scalar_type() == torch::kInt);
+            } else {
+                token_map_at_dispatch = torch::empty(
+                    {num_max_tokens_per_rank, num_topk},
+                    torch::TensorOptions().device(torch::kCUDA).dtype(torch::kInt)
+                );
+            }
+            token_map_at_dispatch_ptr = token_map_at_dispatch->data_ptr<int>();
         }
 
         // Clone `topk_idx` for saving in the handle (to prevent users' modification)
@@ -991,6 +1039,8 @@ public:
         std::fill_n(host_workspace_layout.get_scaleup_expert_count_ptr<false>(), num_local_experts, 0);
         std::atomic_thread_fence(std::memory_order_seq_cst);
 
+        ++ dispatch_iteration;
+
         // Do dispatch into the buffers (with SM limitation)
         EP_HOST_ASSERT(num_sms <= jit::device_runtime->get_num_sms());
         launch_dispatch(x.data_ptr(), sf_ptr,
@@ -1002,6 +1052,7 @@ public:
                         num_unaligned_recv_tokens_per_expert_ptr,
                         dst_buffer_slot_idx.data_ptr<int>(),
                         token_metadata_at_forward_ptr,
+                        token_map_at_dispatch_ptr,
                         num_tokens, num_max_tokens_per_rank,
                         hidden, x.element_size(),
                         num_sf_packs, sf_token_stride, sf_hidden_stride,
@@ -1013,9 +1064,13 @@ public:
                         nccl_context->num_scaleout_ranks, nccl_context->num_scaleup_ranks,
                         nccl_context->is_scaleup_nvlink,
                         num_sms, num_channels_per_sm,
+                        nccl_context->gin_config.gin_indexed_signals_cnt,
                         num_smem_bytes,
                         num_qps, num_gpu_timeout_cycles,
                         cached_mode, do_cpu_sync,
+                        not prefer_overlap_with_compute,
+                        allow_multiple_reduction, do_expand,
+                        dispatch_iteration,
                         comm_stream);
 
         // Received token counters
@@ -1173,7 +1228,8 @@ public:
              recv_src_metadata,
              dst_buffer_slot_idx,
              token_metadata_at_forward,
-             channel_linked_list},
+             channel_linked_list,
+             token_map_at_dispatch},
             compute_stream,
             allocate_on_comm_stream, async_with_compute_stream);
 
@@ -1189,6 +1245,7 @@ public:
                 dst_buffer_slot_idx,
                 token_metadata_at_forward,
                 channel_linked_list,
+                token_map_at_dispatch,
                 event};
     }
 

--- a/csrc/kernels/backend/api.cuh
+++ b/csrc/kernels/backend/api.cuh
@@ -1,8 +1,21 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <memory>
 #include <vector>
 #include <optional>
+
+#include <deep_ep/common/gin_resource_alloc.cuh>
 
 #include <nccl.h>
 #include <nccl_device.h>
@@ -73,6 +86,7 @@ public:
 
     // Configs
     int num_allocated_qps;
+    elastic::gin_alloc::GinResourceConfig gin_config;
 
     // Buffer size
     int64_t num_gpu_bytes;

--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -126,7 +126,7 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
         if (scaleout_active) {
             gin_config = elastic::gin_alloc::make_gin_resources(resolve_gin_context_cnt());
         } else {
-            gin_config.gin_context_cnt = this->num_allocated_qps;
+            gin_config.gin_context_cnt = resolve_gin_context_cnt();
             gin_config.gin_indexed_signals_cnt = 0;
         }
 
@@ -134,8 +134,7 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
                        "GIN indexed-signal budget cannot give each peer rail team a dedicated "
                        "signal; reduce num_allocated_qps to raise the per-context signal count");
 
-        if (scaleout_active)
-            this->num_allocated_qps = gin_config.gin_context_cnt;
+        this->num_allocated_qps = gin_config.gin_context_cnt;
 
         if (get_env<int>("EP_BUFFER_DEBUG"))
             printf("GIN layout: gin_context_cnt=%d, gin_indexed_signals_cnt=%d, num_qp=%d\n",

--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -113,13 +113,20 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
         // upstream requirements untouched.
         if (allow_hybrid_mode and not elastic::use_ordered_hybrid_kernel()) {
         auto resolve_gin_context_cnt = [&]() -> int {
-            const int ctx = (this->num_allocated_qps == 0)
+            const int requested = (this->num_allocated_qps == 0)
                 ? elastic::gin_alloc::kDefaultGinContextCnt
                 : this->num_allocated_qps;
-            EP_HOST_ASSERT(ctx >= elastic::gin_alloc::kMinGinContextCnt and
-                           ctx <= elastic::gin_alloc::kMaxGinContextCnt and
-                           "num_allocated_qps must be 0 (auto -> kDefaultGinContextCnt) or within "
-                           "[kMinGinContextCnt, kMaxGinContextCnt]: one GIN context supplies one QP");
+            int ctx = requested;
+            if (ctx < elastic::gin_alloc::kMinGinContextCnt)
+                ctx = elastic::gin_alloc::kMinGinContextCnt;
+            if (ctx > elastic::gin_alloc::kMaxGinContextCnt)
+                ctx = elastic::gin_alloc::kMaxGinContextCnt;
+            if (ctx != requested)
+                printf("[WARN] DeepEP clamped num_allocated_qps from %d to %d: the unordered "
+                       "GIN layout supports [%d, %d] contexts (one GIN context supplies one QP)\n",
+                       requested, ctx,
+                       elastic::gin_alloc::kMinGinContextCnt,
+                       elastic::gin_alloc::kMaxGinContextCnt);
             return ctx;
         };
 

--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -1,3 +1,14 @@
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <cstring>
 #include <vector>
 #include <string>
@@ -79,22 +90,83 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
     if (get_env<int>("EP_BUFFER_DEBUG"))
         printf("EP NCCL device communicator has %d allocated QPs\n", num_allocated_qps);
 
+    const bool gin_disabled = get_env("EP_DISABLE_GIN", 0) != 0;
+
     // Initialize NCCL device communicator
     ncclCommProperties props = NCCL_COMM_PROPERTIES_INITIALIZER;
     NCCL_CHECK(ncclCommQueryProperties(comm, &props));
     ncclDevCommRequirements_t reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
-    if (num_ranks > 1 and get_env("EP_DISABLE_GIN", 0) == 0) {
+    if (num_ranks > 1 and not gin_disabled) {
         EP_HOST_ASSERT(
             (allow_hybrid_mode ? props.railedGinType : props.ginType) != NCCL_GIN_TYPE_NONE and
             "NCCL GIN is unavailable. This is usually due to a network configuration issue, "
             "such as `allow_hybrid_mode=0` (disable direct RDMA kernels) in multi-plane network.");
 
-        reqs.ginContextCount = num_allocated_qps;
-        reqs.ginExclusiveContexts = true;
+        const int num_rdma_ranks = ncclTeamRail(comm).nRanks;
+        EP_HOST_ASSERT(num_ranks == ncclTeamLsa(comm).nRanks * num_rdma_ranks);
+
+        const bool scaleout_active = num_rdma_ranks > 1;
+
+        // Only hybrid mode uses the shared-context weak-signal GIN configuration;
+        // direct mode keeps the upstream requirements untouched.
+        if (allow_hybrid_mode) {
+        auto resolve_gin_context_cnt = [&]() -> int {
+            const int ctx = (this->num_allocated_qps == 0)
+                ? elastic::gin_alloc::kDefaultGinContextCnt
+                : this->num_allocated_qps;
+            EP_HOST_ASSERT(ctx >= elastic::gin_alloc::kMinGinContextCnt and
+                           ctx <= elastic::gin_alloc::kMaxGinContextCnt and
+                           "num_allocated_qps must be 0 (auto -> kDefaultGinContextCnt) or within "
+                           "[kMinGinContextCnt, kMaxGinContextCnt]: one GIN context supplies one QP");
+            return ctx;
+        };
+
+        if (scaleout_active) {
+            gin_config = elastic::gin_alloc::make_gin_resources(resolve_gin_context_cnt());
+        } else {
+            gin_config.gin_context_cnt = this->num_allocated_qps;
+            gin_config.gin_indexed_signals_cnt = 0;
+        }
+
+        EP_HOST_ASSERT(gin_config.gin_indexed_signals_cnt >= (num_rdma_ranks - 1) and
+                       "GIN indexed-signal budget cannot give each peer rail team a dedicated "
+                       "signal; reduce num_allocated_qps to raise the per-context signal count");
+
+        if (scaleout_active)
+            this->num_allocated_qps = gin_config.gin_context_cnt;
+
+        if (get_env<int>("EP_BUFFER_DEBUG"))
+            printf("GIN layout: gin_context_cnt=%d, gin_indexed_signals_cnt=%d, num_qp=%d\n",
+                   gin_config.gin_context_cnt,
+                   gin_config.gin_indexed_signals_cnt,
+                   this->num_allocated_qps);
+
+        reqs.ginExclusiveContexts = false;
         reqs.ginQueueDepth = kGinQPDepth;
         reqs.ginTrafficClass = sl_idx;
-        // Customized RDMA barrier needs extra signals
-        reqs.ginSignalCount = num_ranks + 2 * 2;
+        if (scaleout_active) {
+            reqs.ginContextCount = gin_config.gin_context_cnt;
+            reqs.ginSignalCount = gin_config.gin_indexed_signals_cnt;
+        } else if (gin_config.gin_context_cnt > 0) {
+            reqs.ginContextCount = gin_config.gin_context_cnt;
+        }
+
+        // The unordered kernels synchronize through counting signals only; VA and
+        // strong signals are not required.
+        reqs.ginVaSignalsRequired = false;
+        reqs.ginStrongSignalsRequired = false;
+        } else {
+            // Direct-mode / ordered-kernel path: the upstream GIN requirements,
+            // unchanged. The automatic QP count is resolved on the Python side
+            // (65/129 for hybrid mode by fast-RDMA-atomic support, 17 otherwise).
+            reqs.ginContextCount = this->num_allocated_qps;
+            reqs.ginExclusiveContexts = true;
+            reqs.ginQueueDepth = kGinQPDepth;
+            reqs.ginTrafficClass = sl_idx;
+            // Customized RDMA barrier needs extra signals
+            reqs.ginSignalCount = num_ranks + 2 * 2;
+        }
+
         reqs.ginConnectionType = allow_hybrid_mode ? NCCL_GIN_CONNECTION_RAIL: NCCL_GIN_CONNECTION_FULL;
     }
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2, 31, 0)

--- a/csrc/kernels/backend/nccl.cu
+++ b/csrc/kernels/backend/nccl.cu
@@ -21,6 +21,7 @@
 
 #include <deep_ep/common/compiled.cuh>
 #include <deep_ep/common/exception.cuh>
+#include "../elastic/kernel_select.hpp"
 
 #include "api.cuh"
 #include "../../utils/system.hpp"
@@ -107,9 +108,10 @@ NCCLSymmetricMemoryContext::NCCLSymmetricMemoryContext(const int64_t& nccl_comm,
 
         const bool scaleout_active = num_rdma_ranks > 1;
 
-        // Only hybrid mode uses the shared-context weak-signal GIN configuration;
-        // direct mode keeps the upstream requirements untouched.
-        if (allow_hybrid_mode) {
+        // Only the unordered hybrid kernels use the shared-context weak-signal GIN
+        // configuration; direct mode and the ordered hybrid kernels keep the
+        // upstream requirements untouched.
+        if (allow_hybrid_mode and not elastic::use_ordered_hybrid_kernel()) {
         auto resolve_gin_context_cnt = [&]() -> int {
             const int ctx = (this->num_allocated_qps == 0)
                 ? elastic::gin_alloc::kDefaultGinContextCnt

--- a/csrc/kernels/elastic/combine.hpp
+++ b/csrc/kernels/elastic/combine.hpp
@@ -19,6 +19,7 @@
 
 #include "../../jit/compiler.hpp"
 #include "../../jit/launch_runtime.hpp"
+#include "kernel_select.hpp"
 
 namespace deep_ep::elastic {
 
@@ -28,6 +29,9 @@ public:
         // Templated arguments
         bool is_scaleup_nvlink;
         bool use_expanded_layout, allow_multiple_reduction;
+        // Use the ordered (upstream) hybrid kernel instead of the unordered one.
+        // Resolved once from `EP_HYBRID_KERNEL`; only affects the hybrid path.
+        bool use_ordered_kernel;
         int num_scaleup_warps, num_forward_warps;
         int num_scaleout_ranks, num_scaleup_ranks;
         int hidden;
@@ -72,8 +76,9 @@ public:
                                     args.num_topk,
                                     args.num_qps, args.num_timeout_cycles);
         } else {
-            header_name = "hybrid_combine_unordered";
-            func_name = fmt::format("hybrid_unordered_combine_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+            header_name = args.use_ordered_kernel ? "hybrid_combine" : "hybrid_combine_unordered";
+            func_name = fmt::format("{}<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+                                    args.use_ordered_kernel ? "hybrid_combine_impl" : "hybrid_unordered_combine_impl",
                                     args.use_expanded_layout, args.allow_multiple_reduction,
                                     args.launch_args.grid_dim.first,
                                     args.num_scaleup_warps, args.num_forward_warps,
@@ -104,6 +109,17 @@ static void __instantiate_kernel() {{
                                                      args.nccl_dev_comm, args.nccl_window,
                                                      args.buffer, args.workspace,
                                                      args.scaleup_rank_idx,
+                                                     args.num_reduced_tokens));
+        } else if (args.use_ordered_kernel) {
+            EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(kernel, config,
+                                                     args.x, args.topk_weights,
+                                                     args.src_metadata,
+                                                     args.psum_num_recv_tokens_per_scaleup_rank,
+                                                     args.token_metadata_at_forward,
+                                                     args.channel_linked_list,
+                                                     args.nccl_dev_comm, args.nccl_window,
+                                                     args.buffer, args.workspace,
+                                                     args.scaleout_rank_idx, args.scaleup_rank_idx,
                                                      args.num_reduced_tokens));
         } else {
             EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(kernel, config,
@@ -153,6 +169,7 @@ static void* launch_combine(void* x,
     auto num_warps = std::min(num_smem_bytes / token_layout.get_num_bytes<true>(), 32);
 
     // Decide warps
+    const bool use_ordered_kernel = use_ordered_hybrid_kernel();
     int num_scaleup_warps = 0, num_forward_warps = 0;
     if (num_scaleout_ranks > 1) {
         EP_HOST_ASSERT(num_channels % num_sms == 0 and
@@ -161,21 +178,28 @@ static void* launch_combine(void* x,
 
         num_scaleup_warps = num_forward_warps = num_channels / num_sms;
 
-        const auto num_data_warps = num_scaleup_warps + num_forward_warps;
-        num_warps = num_data_warps + 1;
-        EP_HOST_ASSERT(num_warps * 32 <= 1024 and
-                       "combine warp count (scale-up + forward + proxy) exceeds the "
-                       "1024-thread block limit; use at least num_channels / 15 SMs");
+        if (use_ordered_kernel) {
+            // The ordered kernel has no proxy warp and only carves TMA buffers out of shmem.
+            num_warps = num_scaleup_warps + num_forward_warps;
+            EP_HOST_ASSERT(num_warps * token_layout.get_num_bytes<true>() <= num_smem_bytes and
+                           "Invalid combine SM count, please try to match your dispatch config");
+        } else {
+            const auto num_data_warps = num_scaleup_warps + num_forward_warps;
+            num_warps = num_data_warps + 1;
+            EP_HOST_ASSERT(num_warps * 32 <= 1024 and
+                           "combine warp count (scale-up + forward + proxy) exceeds the "
+                           "1024-thread block limit; use at least num_channels / 15 SMs");
 
-        // TMA buffers and the proxy hand-off rings both live in the dynamic shmem arena; the
-        // rings are placed after the TMA region (see hybrid_combine_unordered.cuh) so no alignment pad is
-        // needed. Bound by the same total the channel auto-tuner sized against.
-        const int64_t tma_smem_bytes = static_cast<int64_t>(num_data_warps) * token_layout.get_num_bytes<true>();
-        const int64_t proxy_ring_bytes = deep_ep::elastic::ProxyRingLayout::get_num_bytes(
-            num_forward_warps, deep_ep::elastic::kProxyRingDepthDefault);
-        // The channel auto-tuner should prevent this assert from firing; leaving it as a sanity check.
-        EP_HOST_ASSERT(tma_smem_bytes + proxy_ring_bytes <= num_smem_bytes and
-                       "Combine TMA buffers + proxy rings exceed per-block shared memory");
+            // TMA buffers and the proxy hand-off rings both live in the dynamic shmem arena; the
+            // rings are placed after the TMA region (see hybrid_combine_unordered.cuh) so no alignment pad is
+            // needed. Bound by the same total the channel auto-tuner sized against.
+            const int64_t tma_smem_bytes = static_cast<int64_t>(num_data_warps) * token_layout.get_num_bytes<true>();
+            const int64_t proxy_ring_bytes = deep_ep::elastic::ProxyRingLayout::get_num_bytes(
+                num_forward_warps, deep_ep::elastic::kProxyRingDepthDefault);
+            // The channel auto-tuner should prevent this assert from firing; leaving it as a sanity check.
+            EP_HOST_ASSERT(tma_smem_bytes + proxy_ring_bytes <= num_smem_bytes and
+                           "Combine TMA buffers + proxy rings exceed per-block shared memory");
+        }
     }
 
     // Generate, build and launch
@@ -184,6 +208,7 @@ static void* launch_combine(void* x,
         .is_scaleup_nvlink = is_scaleup_nvlink,
         .use_expanded_layout = use_expanded_layout,
         .allow_multiple_reduction = allow_multiple_reduction,
+        .use_ordered_kernel = use_ordered_kernel,
         .num_scaleup_warps = num_scaleup_warps, .num_forward_warps = num_forward_warps,
         .num_scaleout_ranks = num_scaleout_ranks, .num_scaleup_ranks = num_scaleup_ranks,
         .hidden = hidden,
@@ -230,6 +255,9 @@ public:
     struct Args {
         // Templated arguments
         bool use_expanded_layout, allow_multiple_reduction;
+        // Use the ordered (upstream) epilogue lookup instead of the unordered recv-map one.
+        // Only meaningful for the hybrid path (`num_scaleout_ranks > 1`).
+        bool use_ordered_kernel;
         int num_scaleout_ranks, num_scaleup_ranks;
         int hidden;
         int num_max_tokens_per_rank;
@@ -257,7 +285,7 @@ public:
 using namespace deep_ep::elastic;
 
 static void __instantiate_kernel() {{
-    auto ptr = reinterpret_cast<void*>(&combine_reduce_epilogue_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>);
+    auto ptr = reinterpret_cast<void*>(&combine_reduce_epilogue_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>);
 }}
 )",                        args.use_expanded_layout, args.allow_multiple_reduction,
                            args.launch_args.grid_dim.first,
@@ -266,7 +294,8 @@ static void __instantiate_kernel() {{
                            args.hidden,
                            args.num_max_tokens_per_rank,
                            args.num_experts, args.num_topk,
-                           args.num_channels);
+                           args.num_channels,
+                           args.use_ordered_kernel);
     }
 
     static void launch_impl(const jit::KernelHandle& kernel, const jit::LaunchConfigHandle& config, Args args) {
@@ -307,6 +336,7 @@ static void launch_combine_reduce_epilogue(void* combined_x,
     const CombineReduceEpilogueRuntime::Args args = {
         .use_expanded_layout = use_expanded_layout,
         .allow_multiple_reduction = allow_multiple_reduction,
+        .use_ordered_kernel = use_ordered_hybrid_kernel(),
         .num_scaleout_ranks = num_scaleout_ranks, .num_scaleup_ranks = num_scaleup_ranks,
         .hidden = hidden,
         .num_max_tokens_per_rank = num_max_tokens_per_rank,

--- a/csrc/kernels/elastic/combine.hpp
+++ b/csrc/kernels/elastic/combine.hpp
@@ -58,8 +58,8 @@ public:
                                     args.num_topk,
                                     args.num_qps, args.num_timeout_cycles);
         } else {
-            header_name = "hybrid_combine";
-            func_name = fmt::format("hybrid_combine_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+            header_name = "hybrid_combine_unordered";
+            func_name = fmt::format("hybrid_unordered_combine_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
                                     args.use_expanded_layout, args.allow_multiple_reduction,
                                     args.launch_args.grid_dim.first,
                                     args.num_scaleup_warps, args.num_forward_warps,

--- a/csrc/kernels/elastic/combine.hpp
+++ b/csrc/kernels/elastic/combine.hpp
@@ -1,9 +1,21 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <nccl.h>
 
 #include <deep_ep/common/compiled.cuh>
 #include <deep_ep/common/exception.cuh>
+#include <deep_ep/impls/proxy_ring.cuh>
 
 #include "../../jit/compiler.hpp"
 #include "../../jit/launch_runtime.hpp"
@@ -32,12 +44,14 @@ public:
         int* psum_num_recv_tokens_per_scaleup_rank;
         int* token_metadata_at_forward;
         int* channel_linked_list;
+        int* token_map_at_dispatch;
         jit::NoRefPtr nccl_dev_comm;
         ncclWindow_t nccl_window;
         void* buffer;
         void* workspace;
         int scaleout_rank_idx, scaleup_rank_idx;
         int num_reduced_tokens;
+        int num_combined_tokens;
 
         jit::LaunchArgs launch_args;
     };
@@ -98,10 +112,12 @@ static void __instantiate_kernel() {{
                                                      args.psum_num_recv_tokens_per_scaleup_rank,
                                                      args.token_metadata_at_forward,
                                                      args.channel_linked_list,
+                                                     args.token_map_at_dispatch,
                                                      args.nccl_dev_comm, args.nccl_window,
                                                      args.buffer, args.workspace,
                                                      args.scaleout_rank_idx, args.scaleup_rank_idx,
-                                                     args.num_reduced_tokens));
+                                                     args.num_reduced_tokens,
+                                                     args.num_combined_tokens));
         }
     }
 };
@@ -117,9 +133,11 @@ static void* launch_combine(void* x,
                             int* psum_num_recv_tokens_per_scaleup_rank,
                             int* token_metadata_at_forward,
                             int* channel_linked_list,
+                            int* token_map_at_dispatch,
                             const jit::NoRefPtr& nccl_dev_comm, const ncclWindow_t& nccl_window,
                             void* buffer, void* workspace,
-                            const int& num_reduced_tokens, const int& num_max_tokens_per_rank,
+                            const int& num_reduced_tokens, const int& num_combined_tokens,
+                            const int& num_max_tokens_per_rank,
                             const int& hidden,
                             const int& num_experts, const int& num_topk,
                             const int& num_qps, const int64_t& num_timeout_cycles,
@@ -142,9 +160,22 @@ static void* launch_combine(void* x,
         EP_HOST_ASSERT(num_channels / num_sms <= 16);
 
         num_scaleup_warps = num_forward_warps = num_channels / num_sms;
-        num_warps = num_scaleup_warps + num_forward_warps;
-        EP_HOST_ASSERT(num_warps * token_layout.get_num_bytes<true>() <= num_smem_bytes and
-                       "Invalid combine SM count, please try to match your dispatch config");
+
+        const auto num_data_warps = num_scaleup_warps + num_forward_warps;
+        num_warps = num_data_warps + 1;
+        EP_HOST_ASSERT(num_warps * 32 <= 1024 and
+                       "combine warp count (scale-up + forward + proxy) exceeds the "
+                       "1024-thread block limit; use at least num_channels / 15 SMs");
+
+        // TMA buffers and the proxy hand-off rings both live in the dynamic shmem arena; the
+        // rings are placed after the TMA region (see hybrid_combine_unordered.cuh) so no alignment pad is
+        // needed. Bound by the same total the channel auto-tuner sized against.
+        const int64_t tma_smem_bytes = static_cast<int64_t>(num_data_warps) * token_layout.get_num_bytes<true>();
+        const int64_t proxy_ring_bytes = deep_ep::elastic::ProxyRingLayout::get_num_bytes(
+            num_forward_warps, deep_ep::elastic::kProxyRingDepthDefault);
+        // The channel auto-tuner should prevent this assert from firing; leaving it as a sanity check.
+        EP_HOST_ASSERT(tma_smem_bytes + proxy_ring_bytes <= num_smem_bytes and
+                       "Combine TMA buffers + proxy rings exceed per-block shared memory");
     }
 
     // Generate, build and launch
@@ -166,10 +197,12 @@ static void* launch_combine(void* x,
         .psum_num_recv_tokens_per_scaleup_rank = psum_num_recv_tokens_per_scaleup_rank,
         .token_metadata_at_forward = token_metadata_at_forward,
         .channel_linked_list = channel_linked_list,
+        .token_map_at_dispatch = token_map_at_dispatch,
         .nccl_dev_comm = nccl_dev_comm, .nccl_window = nccl_window,
         .buffer = buffer, .workspace = workspace,
         .scaleout_rank_idx = scaleout_rank_idx, .scaleup_rank_idx = scaleup_rank_idx,
         .num_reduced_tokens = num_reduced_tokens,
+        .num_combined_tokens = num_combined_tokens,
         // NOTES: make cluster dim 2 to overlap with clustered computation kernels
         .launch_args = jit::LaunchArgs(num_sms, num_threads, num_smem_bytes, 2 - (num_sms % 2), true)
     };
@@ -201,6 +234,7 @@ public:
         int hidden;
         int num_max_tokens_per_rank;
         int num_experts, num_topk;
+        int num_channels;
 
         // Parameters
         nv_bfloat16* combined_x;
@@ -209,6 +243,7 @@ public:
         void* reduce_buffer;
         void* bias_0;
         void* bias_1;
+        int* token_map_at_dispatch;
         int num_combined_tokens;
         int scaleout_rank_idx, scaleup_rank_idx;
 
@@ -222,7 +257,7 @@ public:
 using namespace deep_ep::elastic;
 
 static void __instantiate_kernel() {{
-    auto ptr = reinterpret_cast<void*>(&combine_reduce_epilogue_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}>);
+    auto ptr = reinterpret_cast<void*>(&combine_reduce_epilogue_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>);
 }}
 )",                        args.use_expanded_layout, args.allow_multiple_reduction,
                            args.launch_args.grid_dim.first,
@@ -230,7 +265,8 @@ static void __instantiate_kernel() {{
                            args.num_scaleout_ranks, args.num_scaleup_ranks,
                            args.hidden,
                            args.num_max_tokens_per_rank,
-                           args.num_experts, args.num_topk);
+                           args.num_experts, args.num_topk,
+                           args.num_channels);
     }
 
     static void launch_impl(const jit::KernelHandle& kernel, const jit::LaunchConfigHandle& config, Args args) {
@@ -240,6 +276,7 @@ static void __instantiate_kernel() {{
                                                  args.combined_topk_idx,
                                                  args.reduce_buffer,
                                                  args.bias_0, args.bias_1,
+                                                 args.token_map_at_dispatch,
                                                  args.num_combined_tokens,
                                                  args.scaleout_rank_idx, args.scaleup_rank_idx));
     }
@@ -251,8 +288,10 @@ static void launch_combine_reduce_epilogue(void* combined_x,
                                            const int& num_combined_tokens, const int& num_max_tokens_per_rank,
                                            const int& hidden,
                                            const int& num_experts, const int& num_topk,
+                                           const int& num_channels,
                                            void* reduce_buffer,
                                            void* bias_0, void* bias_1,
+                                           int* token_map_at_dispatch,
                                            const int& num_scaleout_ranks, const int& num_scaleup_ranks,
                                            const int& scaleout_rank_idx, const int& scaleup_rank_idx,
                                            const int& num_sms, const int& num_smem_bytes,
@@ -272,11 +311,13 @@ static void launch_combine_reduce_epilogue(void* combined_x,
         .hidden = hidden,
         .num_max_tokens_per_rank = num_max_tokens_per_rank,
         .num_experts = num_experts, .num_topk = num_topk,
+        .num_channels = num_channels,
         .combined_x = static_cast<nv_bfloat16*>(combined_x),
         .combined_topk_weights = combined_topk_weights,
         .combined_topk_idx = combined_topk_idx,
         .reduce_buffer = reduce_buffer,
         .bias_0 = bias_0, .bias_1 = bias_1,
+        .token_map_at_dispatch = token_map_at_dispatch,
         .num_combined_tokens = num_combined_tokens,
         .scaleout_rank_idx = scaleout_rank_idx, .scaleup_rank_idx = scaleup_rank_idx,
         .launch_args = jit::LaunchArgs(num_sms, num_threads, num_smem_bytes, 1, false, true)

--- a/csrc/kernels/elastic/dispatch.hpp
+++ b/csrc/kernels/elastic/dispatch.hpp
@@ -1,10 +1,22 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <nccl.h>
 #include <nccl_device.h>
 
 #include <deep_ep/common/compiled.cuh>
 #include <deep_ep/common/exception.cuh>
+#include <deep_ep/common/gin_resource_alloc.cuh>
 
 #include "../../jit/compiler.hpp"
 #include "../../jit/launch_runtime.hpp"
@@ -18,9 +30,19 @@ public:
         bool is_scaleup_nvlink;
         bool do_cpu_sync;
         bool reuse_slot_indices;
+        // Combine-time reduction mode. Only used by the hybrid kernel to decide how to encode
+        // per-(token, k) slot offsets in `token_map_at_dispatch`. Ignored by the direct kernel.
+        bool allow_multiple_reduction;
+        // Expanded dispatch. Selects the `token_map_at_dispatch` slot numbering that matches the
+        // combine this handle feeds: per valid k when expanded, per destination rank otherwise.
+        bool do_expand;
+        // Double-buffer the forward warp's TMA token loads (ping-pong). Enabled only when compute
+        // overlap is off, so overlap runs keep DeepEP's original single-buffer forward path.
+        bool double_buffer_forward;
         int num_notify_warps;
         int num_dispatch_warps; // For hybrid dispatch
         int num_scaleout_warps, num_forward_warps; // For direct dispatch
+        int gin_indexed_signals_cnt;  // provisioned per-context signal budget, hybrid dispatch only
         int num_scaleout_ranks, num_scaleup_ranks;
         int num_hidden_bytes, num_sf_packs;
         int num_max_tokens_per_rank;
@@ -37,6 +59,7 @@ public:
         int* num_unaligned_recv_tokens_per_expert;
         int* dst_buffer_slot_idx;
         int* token_metadata_at_forward;
+        int* token_map_at_dispatch;
         int num_tokens;
         int sf_token_stride, sf_hidden_stride;
         jit::NoRefPtr nccl_dev_comm;
@@ -44,6 +67,7 @@ public:
         void* buffer;
         void* workspace; void* mapped_host_workspace;
         int scaleout_rank_idx, scaleup_rank_idx;
+        int dispatch_iteration;
 
         jit::LaunchArgs launch_args;
     };
@@ -65,16 +89,20 @@ public:
                 args.num_qps, args.num_timeout_cycles);
         } else {
             header_name = "hybrid_dispatch_unordered";
-            func_name = fmt::format("hybrid_unordered_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+            func_name = fmt::format("hybrid_unordered_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
                 args.do_cpu_sync,
                 args.reuse_slot_indices,
+                args.allow_multiple_reduction,
+                args.do_expand,
+                args.double_buffer_forward,
                 args.launch_args.grid_dim.first,
                 args.num_notify_warps, args.num_scaleout_warps, args.num_forward_warps,
                 args.num_scaleout_ranks, args.num_scaleup_ranks,
                 args.num_hidden_bytes, args.num_sf_packs,
                 args.num_max_tokens_per_rank,
                 args.num_experts, args.num_topk, args.expert_alignment,
-                args.num_qps, args.num_timeout_cycles);
+                args.num_qps, args.num_timeout_cycles,
+                args.gin_indexed_signals_cnt);
         }
 
         return fmt::format(R"(
@@ -116,12 +144,14 @@ static void __instantiate_kernel() {{
                 args.num_unaligned_recv_tokens_per_expert,
                 args.dst_buffer_slot_idx,
                 args.token_metadata_at_forward,
+                args.token_map_at_dispatch,
                 args.num_tokens,
                 args.sf_token_stride, args.sf_hidden_stride,
                 args.nccl_dev_comm, args.nccl_window,
                 args.buffer,
                 args.workspace, args.mapped_host_workspace,
-                args.scaleout_rank_idx, args.scaleup_rank_idx
+                args.scaleout_rank_idx, args.scaleup_rank_idx,
+                args.dispatch_iteration
             ));
         }
     }
@@ -147,6 +177,7 @@ static void launch_dispatch(void* x, void* sf,
                             int* num_unaligned_recv_tokens_per_expert,
                             int* dst_buffer_slot_idx,
                             int* token_metadata_at_forward,
+                            int* token_map_at_dispatch,
                             const int& num_tokens, const int& num_max_tokens_per_rank,
                             const int& hidden, const int& elem_size,
                             const int& num_sf_packs, const int& sf_token_stride, const int& sf_hidden_stride,
@@ -158,10 +189,21 @@ static void launch_dispatch(void* x, void* sf,
                             const int& num_scaleout_ranks, const int& num_scaleup_ranks,
                             const bool& is_scaleup_nvlink,
                             const int& num_sms, const int& num_channels_per_sm,
+                            const int& gin_indexed_signals_cnt,
                             const int& num_smem_bytes,
                             const int& num_qps, const int64_t& num_timeout_cycles,
                             const bool& cached_mode,
                             const bool& do_cpu_sync,
+                            // Double-buffer the forward warp's TMA loads. Only enabled when compute
+                            // overlap is off; overlap runs keep the original single-buffer path.
+                            const bool& double_buffer_forward,
+                            // Combine-time reduction mode. Only affects the hybrid kernel's
+                            // `token_map_at_dispatch` slot encoding; direct dispatch ignores it.
+                            const bool& allow_multiple_reduction,
+                            // Expanded dispatch. Selects the matching slot encoding for the combine
+                            // this handle feeds; direct dispatch ignores it.
+                            const bool& do_expand,
+                            const int& dispatch_iteration,
                             const at::cuda::CUDAStream& stream) {
     // Cached mode does not support expert token counting
     if (cached_mode)
@@ -200,9 +242,13 @@ static void launch_dispatch(void* x, void* sf,
         .is_scaleup_nvlink = is_scaleup_nvlink,
         .do_cpu_sync = do_cpu_sync,
         .reuse_slot_indices = reuse_slot_indices,
+        .allow_multiple_reduction = allow_multiple_reduction,
+        .do_expand = do_expand,
+        .double_buffer_forward = double_buffer_forward,
         .num_notify_warps = num_notify_warps,
         .num_dispatch_warps = num_dispatch_warps,
         .num_scaleout_warps = num_scaleout_warps, .num_forward_warps = num_forward_warps,
+        .gin_indexed_signals_cnt = gin_indexed_signals_cnt,
         .num_scaleout_ranks = num_scaleout_ranks, .num_scaleup_ranks = num_scaleup_ranks,
         .num_hidden_bytes = hidden * elem_size, .num_sf_packs = num_sf_packs,
         .num_max_tokens_per_rank = num_max_tokens_per_rank,
@@ -216,12 +262,14 @@ static void launch_dispatch(void* x, void* sf,
         .num_unaligned_recv_tokens_per_expert = num_unaligned_recv_tokens_per_expert,
         .dst_buffer_slot_idx = dst_buffer_slot_idx,
         .token_metadata_at_forward = token_metadata_at_forward,
+        .token_map_at_dispatch = token_map_at_dispatch,
         .num_tokens = num_tokens,
         .sf_token_stride = sf_token_stride, .sf_hidden_stride = sf_hidden_stride,
         .nccl_dev_comm = nccl_dev_comm, .nccl_window = nccl_window,
         .buffer = buffer,
         .workspace = workspace, .mapped_host_workspace = mapped_host_workspace,
         .scaleout_rank_idx = scaleout_rank_idx, .scaleup_rank_idx = scaleup_rank_idx,
+        .dispatch_iteration = dispatch_iteration,
         // NOTES: make cluster dim 2 to overlap with clustered computation kernels
         .launch_args = jit::LaunchArgs(num_sms, num_threads, num_smem_bytes, 2 - (num_sms % 2), true)};
     const auto code = DispatchRuntime::generate(args);

--- a/csrc/kernels/elastic/dispatch.hpp
+++ b/csrc/kernels/elastic/dispatch.hpp
@@ -20,6 +20,7 @@
 
 #include "../../jit/compiler.hpp"
 #include "../../jit/launch_runtime.hpp"
+#include "kernel_select.hpp"
 
 namespace deep_ep::elastic {
 
@@ -30,6 +31,9 @@ public:
         bool is_scaleup_nvlink;
         bool do_cpu_sync;
         bool reuse_slot_indices;
+        // Use the ordered (upstream) hybrid kernel instead of the unordered one.
+        // Resolved once from `EP_HYBRID_KERNEL`; only affects the hybrid path.
+        bool use_ordered_kernel;
         // Combine-time reduction mode. Only used by the hybrid kernel to decide how to encode
         // per-(token, k) slot offsets in `token_map_at_dispatch`. Ignored by the direct kernel.
         bool allow_multiple_reduction;
@@ -87,6 +91,18 @@ public:
                 args.num_max_tokens_per_rank,
                 args.num_experts, args.num_topk, args.expert_alignment,
                 args.num_qps, args.num_timeout_cycles);
+        } else if (args.use_ordered_kernel) {
+            header_name = "hybrid_dispatch";
+            func_name = fmt::format("hybrid_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+                args.do_cpu_sync,
+                args.reuse_slot_indices,
+                args.launch_args.grid_dim.first,
+                args.num_notify_warps, args.num_scaleout_warps, args.num_forward_warps,
+                args.num_scaleout_ranks, args.num_scaleup_ranks,
+                args.num_hidden_bytes, args.num_sf_packs,
+                args.num_max_tokens_per_rank,
+                args.num_experts, args.num_topk, args.expert_alignment,
+                args.num_qps, args.num_timeout_cycles);
         } else {
             header_name = "hybrid_dispatch_unordered";
             func_name = fmt::format("hybrid_unordered_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
@@ -133,6 +149,24 @@ static void __instantiate_kernel() {{
                 args.buffer,
                 args.workspace, args.mapped_host_workspace,
                 args.scaleup_rank_idx));
+        } else if (args.use_ordered_kernel) {
+            EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(
+                kernel, config,
+                args.x, args.sf, args.topk_idx, args.topk_weights,
+                args.copied_topk_idx,
+                args.cumulative_local_expert_recv_stats,
+                args.psum_num_recv_tokens_per_scaleup_rank,
+                args.psum_num_recv_tokens_per_expert,
+                args.num_unaligned_recv_tokens_per_expert,
+                args.dst_buffer_slot_idx,
+                args.token_metadata_at_forward,
+                args.num_tokens,
+                args.sf_token_stride, args.sf_hidden_stride,
+                args.nccl_dev_comm, args.nccl_window,
+                args.buffer,
+                args.workspace, args.mapped_host_workspace,
+                args.scaleout_rank_idx, args.scaleup_rank_idx
+            ));
         } else {
             EP_CUDA_UNIFIED_CHECK(jit::launch_kernel(
                 kernel, config,
@@ -242,6 +276,7 @@ static void launch_dispatch(void* x, void* sf,
         .is_scaleup_nvlink = is_scaleup_nvlink,
         .do_cpu_sync = do_cpu_sync,
         .reuse_slot_indices = reuse_slot_indices,
+        .use_ordered_kernel = use_ordered_hybrid_kernel(),
         .allow_multiple_reduction = allow_multiple_reduction,
         .do_expand = do_expand,
         .double_buffer_forward = double_buffer_forward,

--- a/csrc/kernels/elastic/dispatch.hpp
+++ b/csrc/kernels/elastic/dispatch.hpp
@@ -64,8 +64,8 @@ public:
                 args.num_experts, args.num_topk, args.expert_alignment,
                 args.num_qps, args.num_timeout_cycles);
         } else {
-            header_name = "hybrid_dispatch";
-            func_name = fmt::format("hybrid_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
+            header_name = "hybrid_dispatch_unordered";
+            func_name = fmt::format("hybrid_unordered_dispatch_impl<{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}>",
                 args.do_cpu_sync,
                 args.reuse_slot_indices,
                 args.launch_args.grid_dim.first,

--- a/csrc/kernels/elastic/kernel_select.hpp
+++ b/csrc/kernels/elastic/kernel_select.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+// MIT License
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <cstdio>
+#include <string>
+
+#include <deep_ep/common/exception.cuh>
+
+#include "../../utils/system.hpp"
+
+namespace deep_ep::elastic {
+
+// `EP_HYBRID_KERNEL` selects the hybrid (scale-out) dispatch/combine kernel pair at
+// JIT-generation time:
+//
+//   "ordered" (default)   — the upstream kernels: the sender publishes a tail via a
+//                           trailing signal and the receiver assumes all data
+//                           preceding the tail has landed. Requires the backend to
+//                           support strong signals and VA signals.
+//
+//   "unordered"           — per-part batched puts with in-band token headers and
+//                           counting signals. Makes no assumption about network
+//                           delivery order, so strong signal is not required, and
+//                           weak signal is enough. Use on transports without ordered
+//                           delivery or VA/strong signal support (e.g. EFA SRD).
+//
+// The value is read once per process. It changes the JIT-generated source (header and
+// kernel names differ), so the JIT cache distinguishes the two variants automatically.
+static bool use_ordered_hybrid_kernel() {
+    static const bool ordered = [] {
+        const auto value = get_env<std::string>("EP_HYBRID_KERNEL");
+        bool result = true;
+        if (value.empty() or value == "ordered") {
+            result = true;
+        } else if (value == "unordered") {
+            result = false;
+        } else {
+            EP_HOST_ASSERT(false and "EP_HYBRID_KERNEL must be `ordered` or `unordered`");
+        }
+        printf("DeepEP hybrid kernel selection: %s\n", result ? "ordered" : "unordered");
+        return result;
+    }();
+    return ordered;
+}
+
+} // namespace deep_ep::elastic

--- a/csrc/python_api.cpp
+++ b/csrc/python_api.cpp
@@ -2,6 +2,7 @@
 #include <torch/python.h>
 
 #include <deep_ep/common/compiled.cuh>
+#include <deep_ep/common/gin_resource_alloc.cuh>
 
 #include "jit/api.hpp"
 #include "elastic/buffer.hpp"
@@ -27,6 +28,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
     // The integer type of top-k indices
     m.attr("topk_idx_t") = py::cast(c10::CppTypeToScalarType<deep_ep::topk_idx_t>::value);
+
+    m.attr("min_unordered_gin_qps") = py::int_(deep_ep::elastic::gin_alloc::kMinGinContextCnt);
+    m.attr("max_unordered_gin_qps") = py::int_(deep_ep::elastic::gin_alloc::kMaxGinContextCnt);
+    m.attr("default_unordered_gin_qps") = py::int_(deep_ep::elastic::gin_alloc::kDefaultGinContextCnt);
 
     // JIT API
     deep_ep::jit::register_apis(m);

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -377,6 +377,11 @@ class ElasticBuffer:
                                         self.explicitly_destroy)
 
         self.num_allocated_qps = self.runtime.get_num_allocated_qps()
+        # The unordered hybrid path intentionally passes 0 down and relies on C++ to
+        # resolve it (see the automatic QP count above). A 0 read back here means that
+        # delegation did not happen; it would surface far downstream as `kNumQPs == 0`.
+        assert self.num_allocated_qps >= 1, \
+            f'runtime returned num_allocated_qps={self.num_allocated_qps}: the QP count was never resolved'
 
         # Logical rank indices
         self.num_scaleout_ranks, self.num_scaleup_ranks = self.get_logical_domain_size()

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -1,3 +1,14 @@
+# MIT License
+#
+# Copyright (c) 2025 DeepSeek
+# Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import functools
 import os
 import math
@@ -261,7 +272,15 @@ class ElasticBuffer:
             allow_multiple_reduction: whether to allow multiple reductions in combine.
             prefer_overlap_with_compute: whether to prefer overlapping communication with compute.
             sl_idx: the RDMA service level index, can be overridden by `EP_OVERRIDE_RDMA_SL` env var.
-            num_allocated_qps: the number of QPs to allocate for RDMA (0 for automatic).
+            num_allocated_qps: the number of QPs to allocate for RDMA. One GIN context supplies
+                one QP, so this is also the GIN context count. Pass 0 for automatic, which
+                resolves per hybrid kernel mode (see `EP_HYBRID_KERNEL`):
+                  - unordered: 11 QPs and 21 signals per QP, for the balance
+                    between token batch size and the number of QPs. An explicit value
+                    must be within [2, 17]; anything else is rejected. Requesting fewer
+                    QPs gives each context more signals.
+                  - ordered (default): 129 QPs. This mode signals through VA/strong signals rather than
+                    the indexed-signal budget.
             num_cpu_timeout_secs: CPU-side timeout in seconds for CPU sync.
             num_gpu_timeout_secs: GPU-side timeout in seconds for GPU operations.
             explicitly_destroy: If this flag is set to True, you need to explicitly call `destroy()` to release resources;
@@ -323,16 +342,10 @@ class ElasticBuffer:
         if 'EP_OVERRIDE_RDMA_SL' in os.environ:
             sl_idx = int(os.environ['EP_OVERRIDE_RDMA_SL'])
 
-        # Automatic maximum QP count allowed
-        # TODO(tianr22): revise the QP count in consideration of Engram
-        if num_allocated_qps == 0:
-            # Hybrid mode will consume more QPs
-            # The extra QP is for notify warps
-            if self.allow_hybrid_mode:
-                num_allocated_qps = 65 if check_fast_rdma_atomic_support() else 129
-            else:
-                num_allocated_qps = 17
-        self.num_allocated_qps = num_allocated_qps
+        # Automatic QP count
+        if num_allocated_qps == 0 and not self.allow_hybrid_mode:
+            # Hybrid mode resolves the QP count in C++ from the GIN signal budget.
+            num_allocated_qps = 17
 
         # Create CPU communicator (exchange POSIX FD handles for CPU segments)
         cpu_comm = []
@@ -352,6 +365,8 @@ class ElasticBuffer:
                                         sl_idx, num_allocated_qps,
                                         num_cpu_timeout_secs, num_gpu_timeout_secs,
                                         self.explicitly_destroy)
+
+        self.num_allocated_qps = self.runtime.get_num_allocated_qps()
 
         # Logical rank indices
         self.num_scaleout_ranks, self.num_scaleup_ranks = self.get_logical_domain_size()

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -1121,6 +1121,7 @@ class ElasticBuffer:
                                  handle.psum_num_recv_tokens_per_scaleup_rank,
                                  handle.token_metadata_at_forward,
                                  handle.channel_linked_list,
+                                 handle.token_map_at_dispatch,
                                  handle.num_experts,
                                  handle.num_max_tokens_per_rank,
                                  num_sms, num_qps,

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -348,9 +348,14 @@ class ElasticBuffer:
             sl_idx = int(os.environ['EP_OVERRIDE_RDMA_SL'])
 
         # Automatic QP count
-        if num_allocated_qps == 0 and not self.allow_hybrid_mode:
-            # Hybrid mode resolves the QP count in C++ from the GIN signal budget.
-            num_allocated_qps = 17
+        if num_allocated_qps == 0 and (not self.allow_hybrid_mode or os.environ.get('EP_HYBRID_KERNEL', 'ordered') == 'ordered'):
+            # Hybrid mode will consume more QPs; the extra QP is for notify warps.
+            # The unordered hybrid kernels (`EP_HYBRID_KERNEL=unordered`) instead
+            # resolve the QP count in C++ from the GIN signal budget.
+            if self.allow_hybrid_mode:
+                num_allocated_qps = 65 if check_fast_rdma_atomic_support() else 129
+            else:
+                num_allocated_qps = 17
 
         # Create CPU communicator (exchange POSIX FD handles for CPU segments)
         cpu_comm = []

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -64,6 +64,9 @@ class EPHandle:
         dst_buffer_slot_idx: destination buffer slot indices from dispatch.
         token_metadata_at_forward: per-channel forwarded token metadata (hybrid mode only).
         channel_linked_list: per-channel per-scaleup-peer linked list (hybrid mode only).
+        token_map_at_dispatch: per-(token, k) recv slot for combine's return trip, `[num_max_tokens_per_rank, num_topk]`
+            (hybrid mode only). Populated by dispatch; consumed by the combine epilogue to look up
+            each partial's location under the queue-based recv layout.
         num_recv_tokens: the total number of received tokens.
     """
 
@@ -82,7 +85,8 @@ class EPHandle:
                  recv_src_metadata: torch.Tensor,
                  dst_buffer_slot_idx: torch.Tensor,
                  token_metadata_at_forward: Optional[torch.Tensor],
-                 channel_linked_list: Optional[torch.Tensor]):
+                 channel_linked_list: Optional[torch.Tensor],
+                 token_map_at_dispatch: Optional[torch.Tensor]):
         # NOTES: remember to copy the original users' input to prevent uncasual modifications on them
         assert topk_idx is not None
 
@@ -100,6 +104,7 @@ class EPHandle:
         self.dst_buffer_slot_idx = dst_buffer_slot_idx
         self.token_metadata_at_forward = token_metadata_at_forward
         self.channel_linked_list = channel_linked_list
+        self.token_map_at_dispatch = token_map_at_dispatch
 
         # May not be accurate without CPU sync
         self.num_recv_tokens = num_recv_tokens
@@ -527,9 +532,9 @@ class ElasticBuffer:
         -> Tuple[Optional[int], Optional[int], Optional[list],
                  Optional[torch.Tensor], Optional[torch.Tensor],
                  Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor],
-                 Optional[torch.Tensor], Optional[torch.Tensor]]:
+                 Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
         if handle is None:
-            return None, None, None, None, None, None, None, None, None, None
+            return None, None, None, None, None, None, None, None, None, None, None
         return (handle.num_recv_tokens,
                 handle.num_expanded_tokens,
                 handle.num_recv_tokens_per_expert_list,
@@ -539,7 +544,8 @@ class ElasticBuffer:
                 handle.dst_buffer_slot_idx,
                 handle.token_metadata_at_forward,
                 handle.recv_src_metadata,
-                handle.channel_linked_list)
+                handle.channel_linked_list,
+                handle.token_map_at_dispatch)
 
     @staticmethod
     def capture() -> EventHandle:
@@ -968,7 +974,8 @@ class ElasticBuffer:
          cached_dst_buffer_slot_idx,
          cached_token_metadata_at_forward,
          cached_recv_src_metadata,
-         cached_channel_linked_list) = self._unpack_handle(handle)
+         cached_channel_linked_list,
+         cached_token_map_at_dispatch) = self._unpack_handle(handle)
 
         # Some default values
         num_max_tokens_per_rank = value_or(num_max_tokens_per_rank, self.num_max_tokens_per_rank)
@@ -988,6 +995,7 @@ class ElasticBuffer:
          dst_buffer_slot_idx,
          token_metadata_at_forward,
          channel_linked_list,
+         token_map_at_dispatch,
          event) = self.runtime.dispatch(x, sf, topk_idx, topk_weights,
                                         cumulative_local_expert_recv_stats,
                                         cached_num_recv_tokens,
@@ -1000,6 +1008,7 @@ class ElasticBuffer:
                                         cached_token_metadata_at_forward,
                                         cached_recv_src_metadata,
                                         cached_channel_linked_list,
+                                        cached_token_map_at_dispatch,
                                         num_max_tokens_per_rank,
                                         num_experts, expert_alignment,
                                         num_sms, num_qps,
@@ -1026,7 +1035,8 @@ class ElasticBuffer:
                               recv_src_metadata,
                               dst_buffer_slot_idx,
                               token_metadata_at_forward,
-                              channel_linked_list)
+                              channel_linked_list,
+                              token_map_at_dispatch)
 
         # Create event
         event_overlap = EventOverlap(event)

--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -282,10 +282,11 @@ class ElasticBuffer:
                 resolves per hybrid kernel mode (see `EP_HYBRID_KERNEL`):
                   - unordered: 11 QPs and 21 signals per QP, for the balance
                     between token batch size and the number of QPs. An explicit value
-                    must be within [2, 17]; anything else is rejected. Requesting fewer
+                    is clamped into [2, 17] with a warning. Requesting fewer
                     QPs gives each context more signals.
                   - ordered (default): 129 QPs. This mode signals through VA/strong signals rather than
-                    the indexed-signal budget.
+                    the indexed-signal budget, so any explicit value passes through
+                    without restriction.
             num_cpu_timeout_secs: CPU-side timeout in seconds for CPU sync.
             num_gpu_timeout_secs: GPU-side timeout in seconds for GPU operations.
             explicitly_destroy: If this flag is set to True, you need to explicitly call `destroy()` to release resources;
@@ -356,6 +357,13 @@ class ElasticBuffer:
                 num_allocated_qps = 65 if check_fast_rdma_atomic_support() else 129
             else:
                 num_allocated_qps = 17
+        elif num_allocated_qps > 0 and self.allow_hybrid_mode and os.environ.get('EP_HYBRID_KERNEL', 'ordered') != 'ordered':
+            clamped_qps = max(_C.min_unordered_gin_qps, min(num_allocated_qps, _C.max_unordered_gin_qps))
+            if clamped_qps != num_allocated_qps:
+                print(f'[WARN] DeepEP clamped num_allocated_qps from {num_allocated_qps} to {clamped_qps}: '
+                      f'the unordered GIN layout supports [{_C.min_unordered_gin_qps}, {_C.max_unordered_gin_qps}] '
+                      f'contexts (one GIN context supplies one QP)', flush=True)
+                num_allocated_qps = clamped_qps
 
         # Create CPU communicator (exchange POSIX FD handles for CPU segments)
         cpu_comm = []

--- a/deep_ep/include/deep_ep/common/comm.cuh
+++ b/deep_ep/include/deep_ep/common/comm.cuh
@@ -77,6 +77,12 @@ __device__ __forceinline__ void timeout_while(const func_t& func, const int64_t&
 template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, bool kWithNotifyWarps = false>
 __device__ __forceinline__ std::pair<int, ncclGinResourceSharingMode> get_qp_mode(
     const int& sm_idx, const int& channel_in_sm_idx, const bool& is_notify_warp = false) {
+    static_assert(kNumQPs >= 1,
+                  "kNumQPs must be >= 1. With 0 the kNumQPs == 1 fast path is skipped, "
+                  "kNumSMs <= kNumAvailableQPs is false, and balanced_partition() is called "
+                  "with q == 0, i.e. n / 0. Compiled for the host this specialization exits on "
+                  "SIGFPE; in a GPU run it produced corrupted output and no reported fault.");
+
     constexpr auto kSharingCTA = NCCL_GIN_RESOURCE_SHARING_CTA;
     constexpr auto kSharingGrid = kNumSMs == 1 ? NCCL_GIN_RESOURCE_SHARING_CTA : NCCL_GIN_RESOURCE_SHARING_GPU;
 

--- a/deep_ep/include/deep_ep/common/comm.cuh
+++ b/deep_ep/include/deep_ep/common/comm.cuh
@@ -1,5 +1,16 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <cooperative_groups.h>
 #include <nccl.h>
 #include <nccl_device.h>
@@ -7,6 +18,7 @@
 #include <deep_ep/common/handle.cuh>
 #include <deep_ep/common/ptx.cuh>
 #include <deep_ep/common/layout.cuh>
+#include <deep_ep/common/qp_mapping.cuh>
 
 namespace deep_ep::elastic::comm {
 
@@ -53,6 +65,15 @@ __device__ __forceinline__ void timeout_while(const func_t& func, const int64_t&
     timeout_while<kNumTimeoutCycles, func_t>(true, func, start_clock);
 }
 
+// Channels map onto QPs with a BALANCED CONTIGUOUS (block) partition: fill a QP with
+// consecutive channels before spilling to the next (so an SM's channels stay grouped
+// on the same GIN context), and when the channels do not divide the QPs evenly,
+// spread the remainder one-per-QP across the leading QPs instead of leaving a
+// trailing QP idle. Used by all callers (dispatch, hybrid_dispatch, combine,
+// hybrid_combine). The integer partition lives in `qp_mapping.cuh` (host-testable);
+// this wrapper only adds the NCCL resource-sharing mode.
+//   e.g. 48 channels / 4 QPs  -> {12,12,12,12}  (even; identical to before)
+//        4  channels / 3 QPs  -> QP0<-2, QP1<-1, QP2<-1  (was {2,2,0}, QP2 idle)
 template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, bool kWithNotifyWarps = false>
 __device__ __forceinline__ std::pair<int, ncclGinResourceSharingMode> get_qp_mode(
     const int& sm_idx, const int& channel_in_sm_idx, const bool& is_notify_warp = false) {
@@ -67,22 +88,42 @@ __device__ __forceinline__ std::pair<int, ncclGinResourceSharingMode> get_qp_mod
     if (is_notify_warp)
         return {0, kSharingCTA};
 
-    // Data channels
-    constexpr int kQPStartIdx = static_cast<int>(kWithNotifyWarps);
-    constexpr int kNumAvailableQPs = kNumQPs - kQPStartIdx;
-    if constexpr (kNumSMs <= kNumAvailableQPs) {
-        // A single SM uses an entire QP
-        // e.g., 3 SMs and 10 QPs
-        // SM 0: 0 3 6 9
-        // SM 1: 1 4 7
-        // SM 2: 2 5 8
-        const int num_qps_in_sm = (kNumAvailableQPs / kNumSMs) + (sm_idx < (kNumAvailableQPs % kNumSMs));
-        return {kQPStartIdx + sm_idx + (channel_in_sm_idx % num_qps_in_sm) * kNumSMs, kSharingCTA};
-    } else {
-        // All SMs share all QPs
-        const auto global_channel_idx = sm_idx * kNumChannelsPerSM + channel_in_sm_idx;
-        return {kQPStartIdx + (global_channel_idx % kNumAvailableQPs), kSharingGrid};
-    }
+    // Data channels: QP index from the shared balanced partition, sharing mode from
+    // the branch (CTA when SMs each own their QPs, GPU-wide when SMs share QPs).
+    constexpr int kNumAvailableQPs = kNumQPs - static_cast<int>(kWithNotifyWarps);
+    const int qp_idx = channel_to_qp<kNumSMs, kNumQPs, kNumChannelsPerSM, kWithNotifyWarps>(
+        sm_idx, channel_in_sm_idx, is_notify_warp);
+    if constexpr (kNumSMs <= kNumAvailableQPs)
+        return {qp_idx, kSharingCTA};
+    else
+        return {qp_idx, kSharingGrid};
+}
+
+// Companion to `get_qp_mode`: within a QP, gives a unique per-channel signal id
+// (position of this channel among all channels sharing the same QP). Uses the same
+// BALANCED CONTIGUOUS partition as `get_qp_mode` (see `qp_mapping.cuh`), so the id is
+// the channel's offset within its QP's block:
+//   kNumQPs == 1                : every channel on the single QP -> id = global_channel_idx
+//   kNumSMs <= kNumAvailableQPs : offset within the SM's balanced local-QP block
+//   kNumSMs  > kNumAvailableQPs : offset within the global balanced QP block
+// In all cases id < ceil(channels / qps), so `(qp, id)` is unique per channel and the
+// tuner's per-QP signal budget (sized for ceil(channels / qps)) is never exceeded.
+template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, bool kWithNotifyWarps = false>
+__device__ __forceinline__ int get_qp_signal_id(
+    const int& sm_idx, const int& channel_in_sm_idx) {
+    return channel_to_signal_id<kNumSMs, kNumQPs, kNumChannelsPerSM, kWithNotifyWarps>(
+        sm_idx, channel_in_sm_idx);
+}
+
+// Per-part indexed-signal id: kNumParts contiguous ids under the channel's base id, one
+// per token part and shared by all sources. The tuner + channel cap guarantee
+// ceil(num_channels / qps) * kNumParts <= gin_indexed_signals_cnt.
+template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, int kNumParts,
+          bool kWithNotifyWarps = false>
+__device__ __forceinline__ int get_per_part_signal_id(
+    const int& sm_idx, const int& channel_in_sm_idx, const int& part_idx) {
+    return get_qp_signal_id<kNumSMs, kNumQPs, kNumChannelsPerSM, kWithNotifyWarps>(
+               sm_idx, channel_in_sm_idx) * kNumParts + part_idx;
 }
 
 template <int kNumRanks, int kNumSMs, int kNumThreads, int64_t kNumTimeoutCycles, int kTag = kDeviceBarrierTag>
@@ -160,19 +201,28 @@ __forceinline__ __device__ void gin_barrier_wo_local_sync(
         const auto team = (std::is_same_v<team_t, ncclTeamTagWorld>) ?
             ncclTeamWorld(nccl_dev_comm) : ncclTeamRail(nccl_dev_comm);
         const ncclGin gin(nccl_dev_comm, 0, NCCL_GIN_RESOURCE_SHARING_CTA);
-        for (int i = thread_idx; i < kNumRanks; i += kNumThreads)
-            gin.signal(team, i, ncclGin_SignalInc{static_cast<ncclGinSignal_t>(rank_idx)});
 
-        // TODO(NCCL): Using the official NCCL wait signal API, after they added timeout check.
+        // Compact signal indexing: (kNumRanks - 1) signal slots per rank. Sender rank_idx
+        // writes to every peer i at the slot that identifies *itself* in the peer's
+        // enumeration:
+        //   sig = (rank_idx < i) ? rank_idx : (rank_idx - 1)
+        // So on receiver R, each of the (kNumRanks - 1) slots gets exactly +1 from a
+        // distinct sender, and the wait side just iterates all slots looking for one
+        // increment per slot.
         for (int i = thread_idx; i < kNumRanks; i += kNumThreads) {
+            if (i == rank_idx) continue;
+            const auto sig = static_cast<ncclGinSignal_t>((rank_idx < i) ? rank_idx : (rank_idx - 1));
+            gin.signal(team, i, ncclGin_SignalInc{sig});
+        }
+
+        for (int i = thread_idx; i < kNumRanks - 1; i += kNumThreads) {
             const auto signal_idx = static_cast<ncclGinSignal_t>(i);
             const auto shadow_ptr = gin.getSignalShadowPtr(signal_idx);
             const auto target = ++(*shadow_ptr);
 
-            const auto gdaki = static_cast<struct ncclGinGdakiGPUContext*>(gin._ginHandle) + gin.contextId;
-            const auto signal_ptr = reinterpret_cast<uint64_t*>(__ldg(reinterpret_cast<uint64_t*>(&gdaki->signals_table.buffer))) + signal_idx;
+            // TODO(NCCL): Using the official NCCL wait signal API, after they added timeout check.
             timeout_while<kNumTimeoutCycles>([=](const bool& is_last_check) {
-                const auto signal = ptx::ld_acquire_sys<uint64_t>(signal_ptr);
+                const auto signal = gin.readSignal(signal_idx, 64, cuda::memory_order_acquire);
                 if (signal >= target)
                     return true;
 

--- a/deep_ep/include/deep_ep/common/compiled.cuh
+++ b/deep_ep/include/deep_ep/common/compiled.cuh
@@ -1,5 +1,16 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 // Make CLion CUDA indexing work
 #ifdef __CLION_IDE__
 #define __CUDA_ARCH__ 900
@@ -83,5 +94,12 @@ constexpr int kNumAlignedSFPacks = 16 / sizeof(sf_pack_t);
 constexpr int kNumMaxChannels = 1024;
 constexpr int kGinQPDepth = 1024;
 constexpr int kGinQPFlushDepth = 768;
+
+// Per-channel shared-memory TMA buffer count for the hybrid dispatch kernel:
+// 1 for the scale-out send warp + 2 for the forward warp (double-buffered
+// loads). The host channel budget and the kernel pool must both use this.
+constexpr int kNumDispatchSendBuffers = 1;
+constexpr int kNumDispatchFwdBuffers = 2;
+constexpr int kNumDispatchBuffersPerChannel = kNumDispatchSendBuffers + kNumDispatchFwdBuffers;
 
 } // namespace deep_ep

--- a/deep_ep/include/deep_ep/common/gin_resource_alloc.cuh
+++ b/deep_ep/include/deep_ep/common/gin_resource_alloc.cuh
@@ -1,0 +1,170 @@
+#pragma once
+
+// MIT License
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <algorithm>
+
+#include <deep_ep/common/exception.cuh>
+#include <deep_ep/common/math.cuh>
+
+namespace deep_ep::elastic::gin_alloc {
+
+// NCCL GIN: provider resource budget.
+static constexpr int kTotalQPBudget              = 256;
+static constexpr int kMaxGinContextBudget        = 17;
+
+// Design constant: ScaleOut warps per SM used by the auto-tuner's budget math.
+// Matches the buffer's `!prefer_overlap_with_compute` cap on `num_channels_per_sm`
+// (one ScaleOut warp per channel). Under-provisions vs. the runtime peak (which
+// can go up to `kNumMaxChannelsPerSM = 8`); worst case just means heavier
+// warps-per-context sharing, not a correctness issue.
+static constexpr int kMaxWarpsPerSM              = 4;
+
+// Upper bound on ScaleOut warps used by any single kernel: 55 SMs × 4 warps = 220.
+//
+// Each ScaleOut warp (== channel) needs its own dedicated signal: e.g. when
+// warp0 (channel0) signals its peer channel0 warp on a remote node, it uses a
+// signal reserved for that channel. That same signal is reused for the channel
+// across all nodes in the rail group, so it is shared rail-wide — the signal
+// count scales with the number of channels (warps), not with the number of
+// nodes.
+static constexpr int kMaxSM           = (kTotalQPBudget - 2*kMaxGinContextBudget)/kMaxWarpsPerSM;
+static constexpr int kMaxScaleoutWarps           = kMaxSM * kMaxWarpsPerSM;
+
+struct GinResourceConfig {
+    int gin_indexed_signals_cnt;      // NGinIndexedSignalsPerGinContext (per NCCL context)
+    int gin_context_cnt;              // ScaleOut contexts + one Notify context
+};
+
+static constexpr int kMinGinContextCnt           = 2;
+static constexpr int kMaxGinContextCnt           = kMaxGinContextBudget;
+
+// Default context count (== default QP count). 11 contexts -> 21 signals/context.
+// Contexts and signals-per-context are inversely coupled through
+// `gin_indexed_signals_for`, so more QPs means a smaller per-context signal budget. The
+// equivalent alternatives are {5, 6, 7, 8, 9, 14}; everything else loses a part somewhere.
+// Notably 12, 15, 16 and 17 all drop to 3 parts at 12 SMs -- 17 (the provider maximum) leaves
+// only 13 signals/context, and its per-SM QP split puts 4 channels on the busiest QP.
+static constexpr int kDefaultGinContextCnt       = 11;
+
+// Per-context indexed-signal budget, workaround for current limitations in provider.
+__forceinline__ __device__ __host__ constexpr int gin_indexed_signals_for(int gin_context_cnt) {
+    return (kTotalQPBudget - 2 * gin_context_cnt) / gin_context_cnt;
+}
+
+__forceinline__ __device__ __host__ constexpr GinResourceConfig make_gin_resources(int gin_context_cnt) {
+    return GinResourceConfig{gin_indexed_signals_for(gin_context_cnt), gin_context_cnt};
+}
+
+// Each ScaleOut warp (== channel) needs its own dedicated indexed signal id, so the total
+// signal budget (ctx * signals/ctx) must cover the worst-case warp count for EVERY legal
+// context count, not just the default. The tightest points are ctx = 13 and ctx = 17, both at
+// 221 against the 220-warp ceiling -- one signal of slack. Do not raise `kMaxSM` /
+// `kMaxWarpsPerSM`, widen the context range, or lower `kTotalQPBudget` without re-checking.
+__forceinline__ __host__ constexpr bool all_gin_context_counts_cover_warps() {
+    for (int ctx = kMinGinContextCnt; ctx <= kMaxGinContextCnt; ++ ctx)
+        if (ctx * gin_indexed_signals_for(ctx) < kMaxScaleoutWarps)
+            return false;
+    return true;
+}
+static_assert(all_gin_context_counts_cover_warps(),
+              "GIN layout cannot give each ScaleOut warp a dedicated signal id "
+              "for every legal context count");
+
+// Preferred (and workspace-sizing) maximum for per-part signalling.
+static constexpr int kMaxParts = 4;
+
+static constexpr int kScaleoutSlotRoundingReserve = kMaxParts;
+
+struct GinPartAllocation {
+    int num_parts;           // per-channel part count (>= 1)
+    int num_channels_per_sm;
+};
+
+// Worst-case number of channels that land on a single GIN context (QP). MUST match the
+// signal-id assignment in `channel_to_signal_id` (`qp_mapping.cuh`) exactly, because the
+// per-channel signal id is its offset within its QP's block and the provisioned budget has
+// to cover the largest such offset.
+//
+// QP assignment is two-level, so there are two regimes:
+//   * num_sms <= num_available_qps: each SM owns its own block of QPs
+//     (`num_qps_in_sm = avail / num_sms`, plus one for the first `avail % num_sms` SMs) and
+//     balances only its OWN channels across them. The worst SM is one WITHOUT the remainder
+//     bonus, so it hosts `ceil(channels_per_sm / (avail / num_sms))` channels per QP.
+//   * num_sms >  num_available_qps: all SMs share all QPs, and the global balanced partition
+//     gives `ceil(num_channels / avail)` channels per QP.
+//
+// NOTE: the first regime is NOT `ceil(num_sms * channels_per_sm / avail)`. That form
+// under-counts, because spare QPs owned by OTHER SMs cannot absorb this SM's channels. Using
+// it there provisions too few signals, and the kernel then signals ids outside the
+// provisioned range -- which fails silently: no counts ever arrive and dispatch times out in
+// the CPU wait with all-zero received counts.
+__forceinline__ __device__ __host__ constexpr int channels_per_context(
+        int num_sms, int num_available_qps, int num_channels_per_sm) {
+    const int avail = num_available_qps > 1 ? num_available_qps : 1;
+    const int sms = num_sms > 1 ? num_sms : 1;
+    if (sms <= avail) {
+        const int num_qps_in_sm = avail / sms;
+        return math::constexpr_ceil_div(num_channels_per_sm,
+                                        num_qps_in_sm > 1 ? num_qps_in_sm : 1);
+    }
+    return math::constexpr_ceil_div(sms * num_channels_per_sm, avail);
+}
+
+// Per-part signal allocation: pick the largest num_parts (up to kMaxParts) that fits
+//   channels_per_context(...) * num_parts <= gin_indexed_signals_cnt
+// at the requested channels/SM, then reduce channels_per_sm until the budget holds.
+__forceinline__ __device__ __host__ constexpr GinPartAllocation compute_part_allocation(
+        const GinResourceConfig& cfg, int num_sms, int num_available_qps, int num_channels_per_sm) {
+    const int gin_signals = cfg.gin_indexed_signals_cnt;
+    const int channels_per_ctx = channels_per_context(num_sms, num_available_qps, num_channels_per_sm);
+    const int budget_parts = gin_signals / (channels_per_ctx > 1 ? channels_per_ctx : 1);
+    GinPartAllocation alloc{};
+    alloc.num_parts = budget_parts < kMaxParts ? budget_parts : kMaxParts;
+    alloc.num_parts = alloc.num_parts > 1 ? alloc.num_parts : 1;
+    alloc.num_channels_per_sm = num_channels_per_sm;
+    while (alloc.num_channels_per_sm > 1 and
+           static_cast<long long>(channels_per_context(num_sms, num_available_qps,
+                                                      alloc.num_channels_per_sm)) * alloc.num_parts > gin_signals)
+        --alloc.num_channels_per_sm;
+#ifndef __CUDA_ARCH__
+    if (alloc.num_channels_per_sm < num_channels_per_sm)
+        printf("[WARN] DeepEP GIN signal budget reduced the number of channels per SM "
+               "from %d to %d\n", num_channels_per_sm, alloc.num_channels_per_sm);
+#endif
+#ifndef __CUDA_ARCH__
+    EP_HOST_ASSERT(static_cast<long long>(channels_per_context(num_sms, num_available_qps,
+                                                               alloc.num_channels_per_sm)) * alloc.num_parts <= gin_signals and
+                   "GIN signal budget cannot host even 1 part-signal per channel "
+                   "at 1 channel/SM. Reduce --num-sms or num_allocated_qps.");
+#endif
+    return alloc;
+}
+
+// Kernel-side entry points: derive the per-channel part count (and verify the launched
+// channel count) as compile-time constants from the provisioned indexed-signal budget.
+__forceinline__ __device__ __host__ constexpr int constexpr_num_parts(
+        int gin_signals, int num_sms, int num_qps, bool with_notify, int channels_per_sm) {
+    GinResourceConfig cfg{};
+    cfg.gin_indexed_signals_cnt = gin_signals;
+    const int avail = (num_qps - (with_notify ? 1 : 0)) > 0 ? (num_qps - (with_notify ? 1 : 0)) : 1;
+    return compute_part_allocation(cfg, num_sms > 0 ? num_sms : 1, avail, channels_per_sm).num_parts;
+}
+
+__forceinline__ __device__ __host__ constexpr int constexpr_channels_per_sm(
+        int gin_signals, int num_sms, int num_qps, bool with_notify, int channels_per_sm) {
+    GinResourceConfig cfg{};
+    cfg.gin_indexed_signals_cnt = gin_signals;
+    const int avail = (num_qps - (with_notify ? 1 : 0)) > 0 ? (num_qps - (with_notify ? 1 : 0)) : 1;
+    return compute_part_allocation(cfg, num_sms > 0 ? num_sms : 1, avail, channels_per_sm).num_channels_per_sm;
+}
+
+}  // namespace deep_ep::elastic::gin_alloc

--- a/deep_ep/include/deep_ep/common/layout.cuh
+++ b/deep_ep/include/deep_ep/common/layout.cuh
@@ -1,5 +1,16 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <deep_ep/common/compiled.cuh>
 #include <deep_ep/common/exception.cuh>
 #include <deep_ep/common/math.cuh>
@@ -20,6 +31,7 @@ struct WorkspaceLayout {
     static constexpr int kNumMaxExperts = 2048;
     static constexpr int kNumMaxExpertsPerRank = 256;
     static constexpr int kNumMaxInflightAGRS = 32;
+    static constexpr int kNumMaxParts = 64;
 
     static constexpr int64_t kNumBarrierSignalBytes = 16;
 
@@ -180,22 +192,31 @@ struct TokenLayout {
     int num_hidden_bytes, num_sf_bytes;
     // NOTES: the top-k index is always 32-bit
     bool with_metadata;
+    // Per-token scale-out header present iff true. See kHdrBytes note below.
+    bool with_scaleout_hdr;
     int num_topk, num_metadata_bytes;
     void* base;
 
+    static constexpr int kHdrBytes = sizeof(int64_t);
+
     __forceinline__ __device__ __host__
     TokenLayout(const int& num_hidden_bytes, const int& num_sf_bytes,
-                const int& num_topk, const bool& with_metadata, void* base = nullptr) :
+                const int& num_topk, const bool& with_metadata,
+                void* base = nullptr, const bool& with_scaleout_hdr = false) :
         num_hidden_bytes(num_hidden_bytes),
         num_sf_bytes(num_sf_bytes),
-        // Metadata includes: top-k indices, weight and source rank/token index
         with_metadata(with_metadata),
+        with_scaleout_hdr(with_scaleout_hdr),
         num_topk(num_topk),
-        num_metadata_bytes(num_topk * (sizeof(int) + sizeof(float)) +
-                           (with_metadata ? (1 + num_topk) * sizeof(int) : 0)),
+        num_metadata_bytes((with_scaleout_hdr ? math::align<int>(hdrless_content_bytes(num_topk, with_metadata), sizeof(int64_t)) + kHdrBytes
+                                              : hdrless_content_bytes(num_topk, with_metadata))),
         base(base) {
         EP_STATIC_ASSERT(sizeof(int) == sizeof(float), "Invalid size assumption");
         EP_UNIFIED_ASSERT(num_hidden_bytes % ptx::kNumTMAAlignBytes == 0);
+    }
+
+    __forceinline__ __device__ __host__ static int hdrless_content_bytes(const int& num_topk, const bool& with_metadata) {
+        return num_topk * (sizeof(int) + sizeof(float)) + (with_metadata ? (1 + num_topk) * sizeof(int) : 0);
     }
 
     template <bool kWithMBarrier, typename dtype_t = int>
@@ -232,7 +253,7 @@ struct TokenLayout {
     }
 
     __forceinline__ __device__ __host__ float* get_topk_weights_ptr() const {
-        return math::advance_ptr<float>(get_metadata_ptr(), num_topk * sizeof(int));
+        return math::advance_ptr<float>(get_topk_idx_ptr(), num_topk * sizeof(int));
     }
 
     __forceinline__ __device__ __host__ int* get_src_token_global_idx_ptr() const {
@@ -241,6 +262,12 @@ struct TokenLayout {
 
     __forceinline__ __device__ __host__ int* get_linked_list_idx_ptr() const {
         return get_src_token_global_idx_ptr() + 1;
+    }
+
+    __forceinline__ __device__ __host__ int64_t* get_hdr_ptr() const {
+        const int hdr_offset = math::align<int>(hdrless_content_bytes(num_topk, with_metadata), sizeof(int64_t));
+        return static_cast<int64_t*>(static_cast<void*>(
+            math::advance_ptr<int8_t>(get_metadata_ptr(), hdr_offset)));
     }
 
     __forceinline__ __device__ ptx::mbarrier* get_mbarrier_ptr() const {
@@ -306,7 +333,8 @@ struct BufferLayout {
     TokenLayout get_token_buffer(const int& token_idx, const bool& global = false) const {
         EP_UNIFIED_ASSERT(num_ranks == 1 or global);
         return TokenLayout(token_layout.num_hidden_bytes, token_layout.num_sf_bytes, token_layout.num_topk, token_layout.with_metadata,
-                           static_cast<int8_t*>(base) + token_layout.get_num_bytes<kWithMBarrier, int64_t>() * token_idx);
+                           static_cast<int8_t*>(base) + token_layout.get_num_bytes<kWithMBarrier, int64_t>() * token_idx,
+                           token_layout.with_scaleout_hdr);
     }
 };
 

--- a/deep_ep/include/deep_ep/common/ptx.cuh
+++ b/deep_ep/include/deep_ep/common/ptx.cuh
@@ -1,5 +1,16 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <cuda_bf16.h>
 
 #include <deep_ep/common/compiled.cuh>
@@ -331,6 +342,34 @@ __forceinline__ __device__ void st_release_sys(void* ptr, dtype_t value) {
     } else if constexpr (sizeof(dtype_t) == 8) {
         uint64_t int_value = reinterpret_cast<const uint64_t&>(value);
         asm volatile("st.release.sys.global.u64 [%0], %1;" :: "l"(ptr), "l"(int_value));
+    } else {
+        EP_STATIC_ASSERT(sizeof(dtype_t) == 4 or sizeof(dtype_t) == 8, "Invalid data type length");
+    }
+}
+
+template <typename dtype_t>
+__forceinline__ __device__ dtype_t ld_acquire_cta(const dtype_t* ptr) {
+    if constexpr (sizeof(dtype_t) == 4) {
+        uint32_t value;
+        asm volatile("ld.acquire.cta.u32 %0, [%1];" : "=r"(value) : "l"(ptr));
+        return reinterpret_cast<const dtype_t&>(value);
+    } else if constexpr (sizeof(dtype_t) == 8) {
+        uint64_t value;
+        asm volatile("ld.acquire.cta.u64 %0, [%1];" : "=l"(value) : "l"(ptr));
+        return reinterpret_cast<const dtype_t&>(value);
+    } else {
+        EP_STATIC_ASSERT(sizeof(dtype_t) == 4 or sizeof(dtype_t) == 8, "Invalid data type length");
+    }
+}
+
+template <typename dtype_t>
+__forceinline__ __device__ void st_release_cta(void* ptr, dtype_t value) {
+    if constexpr (sizeof(dtype_t) == 4) {
+        uint32_t int_value = reinterpret_cast<const uint32_t&>(value);
+        asm volatile("st.release.cta.u32 [%0], %1;" :: "l"(ptr), "r"(int_value));
+    } else if constexpr (sizeof(dtype_t) == 8) {
+        uint64_t int_value = reinterpret_cast<const uint64_t&>(value);
+        asm volatile("st.release.cta.u64 [%0], %1;" :: "l"(ptr), "l"(int_value));
     } else {
         EP_STATIC_ASSERT(sizeof(dtype_t) == 4 or sizeof(dtype_t) == 8, "Invalid data type length");
     }

--- a/deep_ep/include/deep_ep/common/qp_mapping.cuh
+++ b/deep_ep/include/deep_ep/common/qp_mapping.cuh
@@ -62,6 +62,11 @@ QP_MAPPING_HD constexpr QPSlot balanced_partition(int idx, int n, int q) {
 template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, bool kWithNotifyWarps>
 QP_MAPPING_HD constexpr int channel_to_qp(int sm_idx, int channel_in_sm_idx,
                                           bool is_notify_warp = false) {
+    static_assert(kNumQPs >= 1,
+                  "kNumQPs must be >= 1. With 0 the kNumQPs == 1 fast path is skipped, "
+                  "kNumSMs <= kNumAvailableQPs is false, and balanced_partition() is called "
+                  "with q == 0, i.e. n / 0. Compiled for the host this specialization exits on "
+                  "SIGFPE; in a GPU run it produced corrupted output and no reported fault.");
     // Only one QP
     if constexpr (kNumQPs == 1)
         return 0;
@@ -95,6 +100,11 @@ QP_MAPPING_HD constexpr int channel_to_qp(int sm_idx, int channel_in_sm_idx,
 // `signal_id < ceil(channels / qps)` -- within the tuner's signal budget.
 template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, bool kWithNotifyWarps>
 QP_MAPPING_HD constexpr int channel_to_signal_id(int sm_idx, int channel_in_sm_idx) {
+    static_assert(kNumQPs >= 1,
+                  "kNumQPs must be >= 1. With 0 the kNumQPs == 1 fast path is skipped, "
+                  "kNumSMs <= kNumAvailableQPs is false, and balanced_partition() is called "
+                  "with q == 0, i.e. n / 0. Compiled for the host this specialization exits on "
+                  "SIGFPE; in a GPU run it produced corrupted output and no reported fault.");
     if constexpr (kNumQPs == 1)
         return sm_idx * kNumChannelsPerSM + channel_in_sm_idx;
 

--- a/deep_ep/include/deep_ep/common/qp_mapping.cuh
+++ b/deep_ep/include/deep_ep/common/qp_mapping.cuh
@@ -1,0 +1,113 @@
+#pragma once
+
+// MIT License
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Pure-integer channel<->QP mapping math shared by `get_qp_mode` and
+// `get_qp_signal_id` in `comm.cuh`. Kept free of CUDA/NCCL types so the exact
+// shipped logic also compiles as plain host C++ for the unit test in
+// `tests/cpp/test_qp_mapping.cpp`.
+
+#if defined(__CUDACC__)
+#define QP_MAPPING_HD __host__ __device__ __forceinline__
+#else
+#define QP_MAPPING_HD inline
+#endif
+
+namespace deep_ep::elastic::comm {
+
+// Result of a balanced contiguous partition: which bin an item lands in, its
+// 0-based index within that bin, and the total size of that bin.
+struct QPSlot {
+    int bin;
+    int local;
+    int bin_size;
+};
+
+// Balanced contiguous partition of `n` items across `q` bins.
+//
+// The first `n % q` bins own `ceil(n/q)` items; the remaining bins own
+// `floor(n/q)`. Items are assigned in monotonic, contiguous blocks (item 0 ->
+// bin 0, ...), so a producer's consecutive items stay grouped on one/adjacent
+// bin. Properties (all asserted in the unit test):
+//   * Balanced:   any two bins differ in size by <= 1.
+//   * No idle bin when q <= n: every bin index in [0, q) owns >= 1 item.
+//   * Contiguous & monotonic: bin index is non-decreasing in `idx`.
+//   * Backward-compatible: when `n % q == 0` the split is 0, every item takes
+//     the `else` path, and `bin == idx / (n/q)` -- byte-identical to the old
+//     ceil-block mapping for even divisions (all shipped power-of-2 configs).
+//
+// Callers guarantee `q >= 1`. `base == 0` (i.e. `q > n`) is safe: then
+// `rem == n`, `split == n`, and every valid `idx` in [0, n) takes the `if`
+// branch, so the `else` branch never divides by `base`.
+QP_MAPPING_HD constexpr QPSlot balanced_partition(int idx, int n, int q) {
+    const int base = n / q;
+    const int rem = n % q;                    // number of "big" (base+1) bins
+    const int split = rem * (base + 1);       // items owned by the leading big bins
+    if (idx < split)
+        return QPSlot{idx / (base + 1), idx % (base + 1), base + 1};
+    const int d = idx - split;
+    return QPSlot{rem + d / base, d % base, base};
+}
+
+// QP index for a data/notify channel. Mirrors `get_qp_mode` (minus the NCCL
+// resource-sharing mode, which stays in `comm.cuh`).
+template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, bool kWithNotifyWarps>
+QP_MAPPING_HD constexpr int channel_to_qp(int sm_idx, int channel_in_sm_idx,
+                                          bool is_notify_warp = false) {
+    // Only one QP
+    if constexpr (kNumQPs == 1)
+        return 0;
+
+    // The notify warp always uses 1 SM and 1 QP
+    if (is_notify_warp)
+        return 0;
+
+    constexpr int kQPStartIdx = static_cast<int>(kWithNotifyWarps);
+    constexpr int kNumAvailableQPs = kNumQPs - kQPStartIdx;
+    if constexpr (kNumSMs <= kNumAvailableQPs) {
+        // More QPs than SMs: an SM owns `num_qps_in_sm` QPs, strided across SMs at
+        // sm_idx + offset*kNumSMs. Within the SM, balance the SM's channels across
+        // its local QPs (contiguous blocks, remainder spread one-per-QP).
+        const int num_qps_in_sm = (kNumAvailableQPs / kNumSMs) + (sm_idx < (kNumAvailableQPs % kNumSMs));
+        const int local_qp_idx = balanced_partition(channel_in_sm_idx, kNumChannelsPerSM, num_qps_in_sm).bin;
+        return kQPStartIdx + sm_idx + local_qp_idx * kNumSMs;
+    } else {
+        // Fewer QPs than SMs: all SMs share all QPs. Balance the global channels
+        // across the QPs (contiguous blocks, remainder spread one-per-QP), so an
+        // SM's channels stay grouped and no QP is left idle.
+        constexpr int kNumChannels = kNumSMs * kNumChannelsPerSM;
+        const int global_channel_idx = sm_idx * kNumChannelsPerSM + channel_in_sm_idx;
+        return kQPStartIdx + balanced_partition(global_channel_idx, kNumChannels, kNumAvailableQPs).bin;
+    }
+}
+
+// Per-channel signal id within its QP (0-based index among the channels sharing
+// that QP). Mirrors `get_qp_signal_id`. Uses the same balanced partition as
+// `channel_to_qp`, so `(qp, signal_id)` is unique per channel and
+// `signal_id < ceil(channels / qps)` -- within the tuner's signal budget.
+template <int kNumSMs, int kNumQPs, int kNumChannelsPerSM, bool kWithNotifyWarps>
+QP_MAPPING_HD constexpr int channel_to_signal_id(int sm_idx, int channel_in_sm_idx) {
+    if constexpr (kNumQPs == 1)
+        return sm_idx * kNumChannelsPerSM + channel_in_sm_idx;
+
+    constexpr int kQPStartIdx = static_cast<int>(kWithNotifyWarps);
+    constexpr int kNumAvailableQPs = kNumQPs - kQPStartIdx;
+    if constexpr (kNumSMs <= kNumAvailableQPs) {
+        const int num_qps_in_sm = (kNumAvailableQPs / kNumSMs) + (sm_idx < (kNumAvailableQPs % kNumSMs));
+        return balanced_partition(channel_in_sm_idx, kNumChannelsPerSM, num_qps_in_sm).local;
+    } else {
+        constexpr int kNumChannels = kNumSMs * kNumChannelsPerSM;
+        const int global_channel_idx = sm_idx * kNumChannelsPerSM + channel_in_sm_idx;
+        return balanced_partition(global_channel_idx, kNumChannels, kNumAvailableQPs).local;
+    }
+}
+
+}  // namespace deep_ep::elastic::comm

--- a/deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh
+++ b/deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh
@@ -1,5 +1,16 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <deep_ep/common/compiled.cuh>
 #include <deep_ep/common/ptx.cuh>
 #include <deep_ep/common/layout.cuh>
@@ -16,17 +27,21 @@ template <bool kUseExpandedLayout, bool kAllowMultipleReduction,
           int kHidden,
           int kNumMaxTokensPerRank,
           int kNumExperts, int kNumTopk,
+          int kNumChannels,
           int kNumThreads = kNumWarps * 32,
           int kNumHiddenBytes = kHidden * sizeof(nv_bfloat16),
           int kNumRanks = kNumScaleoutRanks == 1 ? kNumScaleupRanks : kNumScaleoutRanks,
           bool kUseRankLayout = use_rank_layout<kAllowMultipleReduction, kNumRanks, kNumTopk>(),
-          int kNumTokensInLayout = get_num_tokens_in_layout<kAllowMultipleReduction, kNumRanks, kNumTopk>()>
+          int kNumTokensInLayout = get_num_tokens_in_layout<kAllowMultipleReduction, kNumRanks, kNumTopk>(),
+          int kNumMaxTokensPerChannel = math::constexpr_ceil_div(kNumMaxTokensPerRank, kNumChannels),
+          int kNumSlotsPerChannel = kNumMaxTokensPerChannel * (kAllowMultipleReduction ? 1 : kNumTopk)>
 __global__ void __launch_bounds__(kNumThreads, 1)
 combine_reduce_epilogue_impl(nv_bfloat16* combined_x,
                              float* combined_topk_weights,
                              topk_idx_t* combined_topk_idx,
                              void* recv_buffer,
                              void* bias_0, void* bias_1,
+                             const int* token_map_at_dispatch,
                              const int num_combined_tokens,
                              const int scaleout_rank_idx, const int scaleup_rank_idx) {
     constexpr int kNumExpertsPerScaleout = kNumExperts / kNumScaleoutRanks;
@@ -41,8 +56,12 @@ combine_reduce_epilogue_impl(nv_bfloat16* combined_x,
     // Load buffers from scale-out or scale-up ranks
     extern __shared__ __align__(ptx::kNumTMAAlignBytes) int8_t smem[];
     const auto comm_token_layout = layout::TokenLayout(kNumHiddenBytes, 0, kNumTopk, false);
+    constexpr int kHybridMode = (kNumScaleoutRanks > 1);
     const auto comm_buffer = layout::BufferLayout<false>(
-        comm_token_layout, kNumTokensInLayout, kNumMaxTokensPerRank, recv_buffer);
+        comm_token_layout,
+        kHybridMode ? kNumScaleoutRanks : kNumTokensInLayout,
+        kHybridMode ? (kNumChannels * kNumSlotsPerChannel) : kNumMaxTokensPerRank,
+        recv_buffer);
 
     // Store buffers
     const auto output_token_layout = layout::TokenLayout(kNumHiddenBytes, 0, 0, false);
@@ -53,6 +72,14 @@ combine_reduce_epilogue_impl(nv_bfloat16* combined_x,
     // Bias layout
     const auto bias_0_buffer = layout::BufferLayout<false>(output_token_layout, 1, num_combined_tokens, bias_0);
     const auto bias_1_buffer = layout::BufferLayout<false>(output_token_layout, 1, num_combined_tokens, bias_1);
+
+    // Guard against packed-layout overflow. See `combine_utils.cuh` for bit widths.
+    EP_STATIC_ASSERT(not kHybridMode or kNumChannels <= (1 << kCombineRecvMapChannelBits),
+                     "kNumChannels exceeds packed channel field capacity");
+    EP_STATIC_ASSERT(not kHybridMode or kNumScaleoutRanks <= (1 << kCombineRecvMapRankBits),
+                     "kNumScaleoutRanks exceeds packed rank field capacity");
+    EP_STATIC_ASSERT(not kHybridMode or kNumSlotsPerChannel <= (1 << kCombineRecvMapSlotBits),
+                     "kNumSlotsPerChannel exceeds packed slot field capacity");
 
     // Will block until the main combine kernel has finished and all data are visible
     // NOTES: PDL is used, please do not use `__ldg`
@@ -87,12 +114,21 @@ combine_reduce_epilogue_impl(nv_bfloat16* combined_x,
             ptx::gather(ptx::deduplicate(deduplicate_key, lane_idx) and stored_dst_rank_idx >= 0) :
             ptx::gather(stored_dst_rank_idx >= 0);
         int topk_slot_idx[kNumTokensInLayout];
-        compute_topk_slots(
-            topk_slot_idx, reduce_valid_mask,
-            [=](const int& idx) {
-                return kUseRankLayout ? ptx::exchange(stored_dst_rank_idx, idx) : idx;
-            }
-        );
+        if constexpr (kHybridMode) {
+            const int my_map_entry = lane_idx < kNumTopk ?
+                token_map_at_dispatch[token_idx * kNumTopk + lane_idx] : -1;
+            compute_topk_slots(
+                topk_slot_idx, reduce_valid_mask,
+                [=](const int& idx) { return ptx::exchange(my_map_entry, idx); }
+            );
+        } else {
+            compute_topk_slots(
+                topk_slot_idx, reduce_valid_mask,
+                [=](const int& idx) {
+                    return kUseRankLayout ? ptx::exchange(stored_dst_rank_idx, idx) : idx;
+                }
+            );
+        }
 
         // Iterate over per-hidden-chunk stage
         using combine_vec_t = typename CombineVecTraits<kHidden * sizeof(nv_bfloat16)>::vec_t;
@@ -101,8 +137,16 @@ combine_reduce_epilogue_impl(nv_bfloat16* combined_x,
         combine_reduce<kHiddenVec, kUnrollFactor, kNumTokensInLayout>(
             lane_idx, topk_slot_idx, static_cast<combine_vec_t*>(tma_buffer.get_base_ptr()),
             /* Get source base */ [=](const int& slot_idx) {
-                return static_cast<combine_vec_t*>(
-                    comm_buffer.get_rank_buffer(slot_idx).get_token_buffer(token_idx).get_base_ptr());
+                if constexpr (kHybridMode) {
+                    int rank, slot, channel;
+                    unpack_combine_recv_addr(slot_idx, rank, slot, channel);
+                    const int recv_token_slot = channel * kNumSlotsPerChannel + slot;
+                    return static_cast<combine_vec_t*>(
+                        comm_buffer.get_rank_buffer(rank).get_token_buffer(recv_token_slot).get_base_ptr());
+                } else {
+                    return static_cast<combine_vec_t*>(
+                        comm_buffer.get_rank_buffer(slot_idx).get_token_buffer(token_idx).get_base_ptr());
+                }
             },
             /* Wait buffer release */ [=]() {
                 ptx::tma_store_wait();
@@ -130,10 +174,22 @@ combine_reduce_epilogue_impl(nv_bfloat16* combined_x,
             if (lane_idx < kNumTopk) {
                 float value = 0;
                 if (stored_dst_rank_idx >= 0) {
-                    const auto dst_ptr = comm_buffer
-                        .get_rank_buffer(kUseRankLayout ? stored_dst_rank_idx : master_lane_idx)
-                        .get_token_buffer(token_idx).get_topk_weights_ptr() + lane_idx;
-                    value = *dst_ptr;
+                    if constexpr (kHybridMode) {
+                        int rank, slot, channel;
+                        unpack_combine_recv_addr(
+                            token_map_at_dispatch[token_idx * kNumTopk + master_lane_idx],
+                            rank, slot, channel);
+                        const int recv_token_slot = channel * kNumSlotsPerChannel + slot;
+                        const auto dst_ptr = comm_buffer
+                            .get_rank_buffer(rank)
+                            .get_token_buffer(recv_token_slot).get_topk_weights_ptr() + lane_idx;
+                        value = *dst_ptr;
+                    } else {
+                        const auto dst_ptr = comm_buffer
+                            .get_rank_buffer(kUseRankLayout ? stored_dst_rank_idx : master_lane_idx)
+                            .get_token_buffer(token_idx).get_topk_weights_ptr() + lane_idx;
+                        value = *dst_ptr;
+                    }
                 }
                 combined_topk_weights[token_idx * kNumTopk + lane_idx] = value;
             }

--- a/deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh
+++ b/deep_ep/include/deep_ep/impls/combine_reduce_epilogue.cuh
@@ -28,6 +28,9 @@ template <bool kUseExpandedLayout, bool kAllowMultipleReduction,
           int kNumMaxTokensPerRank,
           int kNumExperts, int kNumTopk,
           int kNumChannels,
+          // Ordered (upstream) recv layout: partials live at `token_idx` per rank buffer
+          // instead of the unordered per-(channel, slot) map.
+          bool kOrderedLayout = false,
           int kNumThreads = kNumWarps * 32,
           int kNumHiddenBytes = kHidden * sizeof(nv_bfloat16),
           int kNumRanks = kNumScaleoutRanks == 1 ? kNumScaleupRanks : kNumScaleoutRanks,
@@ -56,7 +59,7 @@ combine_reduce_epilogue_impl(nv_bfloat16* combined_x,
     // Load buffers from scale-out or scale-up ranks
     extern __shared__ __align__(ptx::kNumTMAAlignBytes) int8_t smem[];
     const auto comm_token_layout = layout::TokenLayout(kNumHiddenBytes, 0, kNumTopk, false);
-    constexpr int kHybridMode = (kNumScaleoutRanks > 1);
+    constexpr int kHybridMode = (kNumScaleoutRanks > 1) and not kOrderedLayout;
     const auto comm_buffer = layout::BufferLayout<false>(
         comm_token_layout,
         kHybridMode ? kNumScaleoutRanks : kNumTokensInLayout,

--- a/deep_ep/include/deep_ep/impls/combine_utils.cuh
+++ b/deep_ep/include/deep_ep/impls/combine_utils.cuh
@@ -1,9 +1,50 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <stdexcept>
 
 
 namespace deep_ep::elastic {
+
+// Packing for `token_map_at_dispatch[token][k]`. Written by dispatch, read by the combine epilogue.
+// Layout (int32):
+//   bits [30:26] — dst_scaleout_rank (5 bits, 0..31)
+//   bits [25:12] — slot within `recv[dst_scaleout_rank][channel × slots_per_channel + slot]` (14 bits, 0..16383)
+//   bits [11:0]  — channel index (12 bits, 0..4095)
+// Field widths add up to 31, leaving bit 31 clear on any valid entry. The epilogue reuses the
+// `-1`/`< 0` sentinel convention that `compute_topk_slots` produces for trailing (unused) `topk_slot_idx`
+// entries — `combine_reduce` predicates loads via `ldg_with_gez_pred`'s sign check. Keeping bit 31
+// clear on valid entries preserves this shared sentinel invariant so no extra masking is needed.
+constexpr int kCombineRecvMapChannelBits = 12;
+constexpr int kCombineRecvMapSlotBits    = 14;
+constexpr int kCombineRecvMapRankBits    = 5;
+constexpr int kCombineRecvMapChannelMask = (1 << kCombineRecvMapChannelBits) - 1;
+constexpr int kCombineRecvMapSlotMask    = (1 << kCombineRecvMapSlotBits) - 1;
+constexpr int kCombineRecvMapRankMask    = (1 << kCombineRecvMapRankBits) - 1;
+constexpr int kCombineRecvMapSlotShift    = kCombineRecvMapChannelBits;
+constexpr int kCombineRecvMapRankShift    = kCombineRecvMapChannelBits + kCombineRecvMapSlotBits;
+
+__device__ __host__ __forceinline__
+int pack_combine_recv_addr(const int& rank, const int& slot, const int& channel) {
+    return (rank << kCombineRecvMapRankShift) | (slot << kCombineRecvMapSlotShift) | channel;
+}
+
+__device__ __host__ __forceinline__
+void unpack_combine_recv_addr(const int& packed, int& rank, int& slot, int& channel) {
+    rank    = (packed >> kCombineRecvMapRankShift) & kCombineRecvMapRankMask;
+    slot    = (packed >> kCombineRecvMapSlotShift) & kCombineRecvMapSlotMask;
+    channel = packed & kCombineRecvMapChannelMask;
+}
 
 template <bool kAllowMultipleReduction, int kNumRanks, int kNumTopk>
 constexpr bool use_rank_layout() {

--- a/deep_ep/include/deep_ep/impls/hybrid_combine_unordered.cuh
+++ b/deep_ep/include/deep_ep/impls/hybrid_combine_unordered.cuh
@@ -1,0 +1,895 @@
+#pragma once
+
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <deep_ep/common/comm.cuh>
+#include <deep_ep/common/layout.cuh>
+#include <deep_ep/common/math.cuh>
+#include <deep_ep/common/ptx.cuh>
+#include <deep_ep/impls/combine_utils.cuh>
+#include <deep_ep/impls/proxy_ring.cuh>
+
+namespace deep_ep::elastic {
+
+template <bool kUseExpandedLayout, bool kAllowMultipleReduction,
+          int kNumSMs,
+          int kNumScaleupWarps, int kNumForwardWarps,
+          int kNumScaleoutRanks, int kNumScaleupRanks,
+          int kHidden,
+          int kNumMaxTokensPerRank,
+          int kNumExperts, int kNumTopk,
+          int kNumQPs, int64_t kNumTimeoutCycles,
+          int kNumScaleupRanksPerLane = math::constexpr_ceil_div(kNumScaleupRanks, 32),
+          int kNumScaleupUpdateInterval = 3,
+          int kBatchSize = 12,
+          int kProxyRingDepth = kProxyRingDepthDefault,
+          int kNumChannelsPerSM = kNumForwardWarps,
+          int kNumChannels = kNumChannelsPerSM * kNumSMs,
+          int kNumMaxTokensPerChannel = math::constexpr_ceil_div(kNumMaxTokensPerRank, kNumChannels),
+          int kNumRanks = kNumScaleoutRanks * kNumScaleupRanks,
+          int kNumDataWarps = kNumScaleupWarps + kNumForwardWarps,
+          int kProxyWarpIdx = kNumDataWarps,
+          int kNumWarps = kNumDataWarps + 1,
+          int kNumThreads = kNumWarps * 32,
+          int kNumHiddenBytes = kHidden * sizeof(nv_bfloat16),
+          bool kUseScaleoutRankLayout = use_rank_layout<kAllowMultipleReduction, kNumScaleoutRanks, kNumTopk>(),
+          bool kUseScaleupRankLayout = use_rank_layout<kAllowMultipleReduction, kNumScaleupRanks, kNumTopk>(),
+          int kNumTokensInScaleoutLayout = get_num_tokens_in_layout<kAllowMultipleReduction, kNumScaleoutRanks, kNumTopk>(),
+          int kNumTokensInScaleupLayout = get_num_tokens_in_layout<kAllowMultipleReduction, kNumScaleupRanks, kNumTopk>()>
+__global__ void __launch_bounds__(kNumThreads, 1)
+hybrid_unordered_combine_impl(nv_bfloat16* x,
+                    float* topk_weights,
+                    int* src_metadata,
+                    int* psum_num_recv_tokens_per_scaleup_rank,
+                    int* token_metadata_at_forward,
+                    int* channel_linked_list,
+                    const int* token_map_at_dispatch,
+                    const ncclDevComm_t nccl_dev_comm, const ncclWindow_t nccl_window,
+                    void* buffer, void* workspace,
+                    const int scaleout_rank_idx, const int scaleup_rank_idx,
+                    int num_reduced_tokens, const int num_combined_tokens) {
+    // Utils
+    const auto sm_idx = static_cast<int>(blockIdx.x);
+    const auto thread_idx = static_cast<int>(threadIdx.x);
+    const auto warp_idx = ptx::get_warp_idx();
+    const auto lane_idx = ptx::get_lane_idx();
+    constexpr bool kDoExpandedSend = not kAllowMultipleReduction and kUseExpandedLayout;
+
+    // Combine vector type selection
+    using combine_vec_t = typename CombineVecTraits<kNumHiddenBytes>::vec_t;
+    constexpr int kHiddenVec = kNumHiddenBytes / sizeof(combine_vec_t);
+
+    // Workspaces
+    const auto workspace_layout = layout::WorkspaceLayout(workspace, kNumScaleoutRanks, kNumScaleupRanks, kNumExperts);
+
+    // We should assign the real number of received tokens if without CPU sync
+    if (num_reduced_tokens == kNumMaxTokensPerRank * kNumRanks)
+        num_reduced_tokens = __ldg(psum_num_recv_tokens_per_scaleup_rank + kNumScaleupRanks - 1);
+
+    // Token layouts
+    const auto token_layout = layout::TokenLayout(kNumHiddenBytes, 0, kNumTopk, false);
+
+    // TMA buffers — one per DATA warp only (scale-up + forward).
+    extern __shared__ __align__(ptx::kNumTMAAlignBytes) int8_t smem[];
+    const auto tma_buffer_layout = layout::BufferLayout<true>(token_layout, kNumDataWarps, 1, smem);
+    // The proxy warp never touches `tma_buffer`, clamp its index to 0.
+    const auto tma_buffer = tma_buffer_layout
+        .get_rank_buffer(warp_idx < kNumDataWarps ? warp_idx : 0).get_token_buffer(0);
+
+    // Proxy warp hand-off rings — placed in `smem[]` right after the TMA buffers.
+    const auto proxy_ring_layout = ProxyRingLayout(
+        kNumForwardWarps, kProxyRingDepth, tma_buffer_layout.get_buffer_end_ptr());
+    for (int f = thread_idx; f < kNumForwardWarps; f += kNumThreads) {
+        *proxy_ring_layout.get_head(f) = 0;
+        *proxy_ring_layout.get_tail(f) = 0;
+        *proxy_ring_layout.get_done(f) = 0;
+    }
+    __syncthreads();
+
+    // All the buffer layouts
+    auto scaleup_buffer = layout::BufferLayout<false>(
+        token_layout, kNumTokensInScaleupLayout, kNumScaleoutRanks * kNumMaxTokensPerRank,
+        buffer);
+    auto scaleout_recv_buffer = layout::BufferLayout<false>(
+        token_layout, kNumScaleoutRanks,
+        kNumChannels * (kNumMaxTokensPerChannel * (kAllowMultipleReduction ? 1 : kNumTopk)),
+        scaleup_buffer.get_buffer_end_ptr());
+    auto scaleout_send_buffer = layout::BufferLayout<false>(
+        token_layout, kNumScaleoutRanks,
+        kNumChannels * (kNumMaxTokensPerChannel * (kAllowMultipleReduction ? 1 : kNumTopk)),
+        scaleout_recv_buffer.get_buffer_end_ptr());
+
+    // Init TMA for scale-up and forward warps
+    ptx::arrival_phase phase = 0;
+    const auto mbarrier_ptr = tma_buffer.get_mbarrier_ptr();
+    if (ptx::elect_one_sync())
+        ptx::mbarrier_init_with_fence(mbarrier_ptr, 1);
+    __syncwarp();
+
+    // NCCL Gin handle
+    // For data warp, each warp is a channel, for proxy warp each lane is a channel.
+    const auto gin_channel_in_sm = warp_idx < kNumDataWarps ?
+        (warp_idx % kNumChannelsPerSM) :
+        (lane_idx < kNumForwardWarps ? lane_idx : 0);
+    const auto [qp_idx, sharing_mode] =
+        comm::get_qp_mode<kNumSMs, kNumQPs, kNumChannelsPerSM, true>(sm_idx, gin_channel_in_sm);
+    const auto gin = handle::NCCLGin(nccl_dev_comm, nccl_window, qp_idx, sharing_mode);
+
+    // Global parallel barriers for scale-out subteam and scale-up subteam
+    // NOTES: this barrier needs a grid sync, as there are channel scale-up tail cleaning before
+    comm::gpu_barrier<true, kNumScaleoutRanks, kNumScaleupRanks,
+                      kNumSMs, kNumThreads, kNumQPs, kNumTimeoutCycles, comm::kHybridCombineTag0, false, true, true>(
+        gin, workspace_layout, scaleout_rank_idx, scaleup_rank_idx, sm_idx, thread_idx);
+
+    // Adjust register count at certain cases
+    // TODO: support more cases, or try to make channel count more aligned
+    const bool kAdjustRegisters = (kNumChannelsPerSM == 4 or kNumChannelsPerSM == 8) and not kUseExpandedLayout;
+    constexpr int kNumRegistersForScaleupWarps = 40;
+    constexpr int kNumRegistersForForwardWarps = 256 - kNumRegistersForScaleupWarps;
+
+    // Different warp roles
+    if (warp_idx < kNumScaleupWarps) {
+        const auto channel_idx = sm_idx * kNumChannelsPerSM + warp_idx;
+
+        // Adjust registers
+        if constexpr (kAdjustRegisters)
+            ptx::warpgroup_reg_dealloc<kNumRegistersForScaleupWarps>();
+
+        // Shift into the right buffer if using rank layout
+        if constexpr (kUseScaleupRankLayout)
+            scaleup_buffer = scaleup_buffer.get_rank_buffer(scaleup_rank_idx);
+
+        // Expanding send mode must not be backward
+        if constexpr (kDoExpandedSend)
+            EP_DEVICE_ASSERT(topk_weights == nullptr);
+
+        // Tail issuer
+        // `st.release.sys` is pretty slow, so do it by an interval
+        int update_counter = 0;
+        int stored_num_tokens_sent[kNumScaleupRanksPerLane] = {};
+        int stored_old_num_tokens_sent[kNumScaleupRanksPerLane] = {};
+        const auto tail_ptr = workspace_layout.get_channel_scaleup_tail_ptr(channel_idx, scaleup_rank_idx);
+        const auto update_tails = [&](const bool& finish = false) {
+            ++ update_counter;
+            if (finish or update_counter == kNumScaleupUpdateInterval) {
+                // Wait all TMA stores to finish
+                ptx::tma_store_wait();
+                __syncwarp();
+
+                // Issue
+                #pragma unroll
+                for (int i = 0; i < kNumScaleupRanksPerLane; ++ i) {
+                    if (const auto j = i * 32 + lane_idx; i < (kNumScaleupRanksPerLane - 1) or j < kNumScaleupRanks) {
+                        // NOTES: save some traffic with `stored_old_num_tokens_sent`
+                        // Also, we cannot rewrite a finished slot, if the peer is going to clean it
+                        if (stored_num_tokens_sent[i] != stored_old_num_tokens_sent[i])
+                            ptx::st_release_sys(gin.get_sym_ptr<ncclTeamTagLsa>(tail_ptr, j), stored_num_tokens_sent[i]);
+                        stored_old_num_tokens_sent[i] = stored_num_tokens_sent[i];
+                    }
+                }
+                update_counter = 0;
+            }
+            __syncwarp();
+        };
+
+        // Shape of `channel_linked_list`: `[kNumChannels, kNumMaxTokensPerChannel + 1, kNumScaleupRanks]`
+        // Iterate until all scale-up peers finish
+        int dst_scaleup_rank_idx = channel_idx;
+        int stored_ll_idx[kNumScaleupRanksPerLane] = {}, stored_token_idx[kNumScaleupRanksPerLane] = {};
+        #pragma unroll
+        for (int i = 0; i < kNumScaleupRanksPerLane; ++ i)
+            stored_token_idx[i] = -1;
+        while (true) {
+            // Load token indices in the list
+            #pragma unroll
+            for (int i = 0; i < kNumScaleupRanksPerLane; ++ i) {
+                const auto j = i * 32 + lane_idx;
+                stored_token_idx[i] = i < (kNumScaleupRanksPerLane - 1) or j < kNumScaleupRanks ?
+                    __ldg(channel_linked_list +
+                          channel_idx * (kNumScaleoutRanks * kNumMaxTokensPerChannel + 1) * kNumScaleupRanks +
+                          stored_ll_idx[i] * kNumScaleupRanks + j) : -1;
+            }
+            __syncwarp();
+
+            // Check whether all ranks are finished
+            bool exited = true;
+            #pragma unroll
+            for (int i = 0; i < kNumScaleupRanksPerLane; ++ i)
+                exited &= ptx::all(stored_token_idx[i] < 0);
+            if (exited)
+                break;
+
+            // Process tokens for all ranks together using bitmask to skip inactive ranks
+            EP_STATIC_ASSERT(kNumScaleupRanks <= 64, "Too many scale-up ranks for 64-bit mask");
+            using mask_t = std::conditional_t<(kNumScaleupRanks <= 32), uint32_t, uint64_t>;
+            mask_t wip_mask = 0;
+            #pragma unroll
+            for (int j = 0; j < kNumScaleupRanksPerLane; ++ j)
+                wip_mask |= static_cast<mask_t>(ptx::gather(stored_token_idx[j] >= 0)) << (j * 32);
+            while (wip_mask) {
+                // Find next active rank after `dst_scaleup_rank_idx` (round-robin)
+                const auto start = (dst_scaleup_rank_idx + 1) % kNumScaleupRanks;
+                const auto hi_mask = (wip_mask >> start) << start;
+                dst_scaleup_rank_idx = hi_mask ? ptx::ffs(hi_mask) : ptx::ffs(wip_mask);
+                wip_mask ^= static_cast<mask_t>(1) << dst_scaleup_rank_idx;
+
+                // Exchange token index from the owning lane using static partition iteration
+                int token_idx = -1;
+                #pragma unroll
+                for (int j = 0; j < kNumScaleupRanksPerLane; ++ j) {
+                    const auto src_lane_idx = dst_scaleup_rank_idx - j * 32;
+                    token_idx = src_lane_idx == lane_idx ? stored_token_idx[j] : token_idx;
+                }
+                token_idx = ptx::exchange(token_idx, dst_scaleup_rank_idx % 32);
+
+                // Get source metadata and decide the destination buffer
+                constexpr int kMetadataStride = 2 + kNumTopk;
+                const auto src_global_token_idx = __ldg(src_metadata + token_idx * kMetadataStride + 0);
+                const auto src_token_idx = src_global_token_idx % kNumMaxTokensPerRank;
+                const auto src_scaleout_rank_idx = src_global_token_idx / (kNumMaxTokensPerRank * kNumScaleupRanks);
+                auto token_buffer = [&]() {
+                    if constexpr (kUseScaleupRankLayout) {
+                        const auto src_slot_idx = __ldg(src_metadata + token_idx * kMetadataStride + 1) / kNumTopk;
+                        return scaleup_buffer.get_token_buffer(src_slot_idx);
+                    } else {
+                        const auto master_topk_idx = __ldg(src_metadata + token_idx * kMetadataStride + 1) % kNumTopk;
+                        return scaleup_buffer
+                            .get_rank_buffer(master_topk_idx)
+                            .get_token_buffer(src_scaleout_rank_idx * kNumMaxTokensPerRank + src_token_idx);
+                    }
+                }();
+                token_buffer.set_base_ptr(gin.get_sym_ptr<ncclTeamTagLsa>(token_buffer.get_base_ptr(), dst_scaleup_rank_idx));
+
+                // Some checks
+                EP_STATIC_ASSERT(kHidden % (32 * sizeof(int4) / sizeof(nv_bfloat16)) == 0, "Invalid hidden");
+
+                // Read source indices for expand mode
+                int stored_topk_slot_idx = -1;
+                if constexpr (kUseExpandedLayout) {
+                    if (lane_idx < kNumTopk)
+                        stored_topk_slot_idx = __ldg(src_metadata + token_idx * kMetadataStride + (2 + lane_idx));
+                    __syncwarp();
+                }
+
+                // 3 cases:
+                //  - no-expand, expand + no-reduce
+                //  - expand + reduce
+                //  - expand + send all
+                auto reduce_valid_mask = ptx::gather(stored_topk_slot_idx >= 0);
+                auto no_local_reduce = not kUseExpandedLayout or (kAllowMultipleReduction and __popc(reduce_valid_mask) == 1);
+                if (no_local_reduce) {
+                    int token_idx_in_tensor = token_idx;
+                    if constexpr (kUseExpandedLayout)
+                        token_idx_in_tensor = ptx::exchange(stored_topk_slot_idx, ptx::get_master_lane_idx(reduce_valid_mask));
+
+                    // Directly load
+                    if (ptx::elect_one_sync()) {
+                        const auto load_ptr =
+                            math::advance_ptr(x, static_cast<int64_t>(token_idx_in_tensor) * kNumHiddenBytes);
+                        ptx::tma_store_wait();
+                        ptx::tma_load_1d(tma_buffer.get_base_ptr(), load_ptr, mbarrier_ptr, kNumHiddenBytes);
+                    }
+                    __syncwarp();
+                } else if constexpr (kAllowMultipleReduction) {
+                    // Do local reduction
+                    // Sort valid top-k indices to front
+                    int topk_slot_idx[kNumTopk];
+                    compute_topk_slots(
+                        topk_slot_idx, reduce_valid_mask,
+                        [=](const int& idx) {
+                            return ptx::exchange(stored_topk_slot_idx, idx);
+                        }
+                    );
+
+                    // Reduce into shared memory
+                    constexpr int kUnrollFactor = get_max_unroll_factor<kHiddenVec, 4>();
+                    combine_reduce<kHiddenVec, kUnrollFactor, math::constexpr_ceil_div(kNumTopk, kNumRanks)>(
+                        lane_idx, topk_slot_idx, static_cast<combine_vec_t*>(tma_buffer.get_base_ptr()),
+                        /* Get source base */ [=](const int& slot_idx) {
+                            return math::advance_ptr<combine_vec_t>(
+                                x, slot_idx * static_cast<int64_t>(kNumHiddenBytes));
+                        },
+                        /* Wait buffer release */ [=]() {
+                            ptx::tma_store_wait();
+                            __syncwarp();
+                        }
+                    );
+                    ptx::tma_store_fence();
+                    __syncwarp();
+                } else {
+                    // No local reduction, send all data (expanded send)
+                    #pragma unroll
+                    for (int k = 0; k < kNumTopk; ++ k) {
+                        int topk_slot_idx = ptx::exchange(stored_topk_slot_idx, k);
+                        if (topk_slot_idx < 0)
+                            continue;
+
+                        if (ptx::elect_one_sync()) {
+                            // Load
+                            const auto load_ptr = math::advance_ptr(x, static_cast<int64_t>(kDoExpandedSend ? topk_slot_idx : token_idx) * kNumHiddenBytes);
+                            ptx::tma_store_wait();
+                            ptx::tma_load_1d(tma_buffer.get_base_ptr(), load_ptr, mbarrier_ptr, kNumHiddenBytes);
+                            ptx::mbarrier_arrive_and_set_tx(mbarrier_ptr, kNumHiddenBytes);
+                            ptx::mbarrier_wait_and_flip_phase(mbarrier_ptr, phase);
+                            // NOTES: We don't need to care about `topk_weights` since we are in expand mode
+
+                            // Store
+                            const auto dst_token_buffer = scaleup_buffer
+                                .get_rank_buffer(k)
+                                .get_token_buffer(src_scaleout_rank_idx * kNumMaxTokensPerRank + src_token_idx);
+                            ptx::tma_store_1d(
+                                gin.get_sym_ptr<ncclTeamTagLsa>(dst_token_buffer.get_base_ptr(), dst_scaleup_rank_idx),
+                                tma_buffer.get_base_ptr(), token_layout.get_num_bytes<false>());
+                            ptx::tma_store_commit();
+                        }
+                        __syncwarp();
+                    }
+                }
+
+                // Write top-k weights (expanded send handled inside the loop above)
+                if (not kDoExpandedSend and topk_weights != nullptr and lane_idx < kNumTopk) {
+                    float value = 0;
+                    if constexpr (kUseExpandedLayout) {
+                        if (stored_topk_slot_idx >= 0)
+                            value = __ldg(topk_weights + stored_topk_slot_idx);
+                    } else {
+                        value = __ldg(topk_weights + (token_idx * kNumTopk + lane_idx));
+                    }
+                    tma_buffer.get_topk_weights_ptr()[lane_idx] = value;
+                    ptx::tma_store_fence();
+                }
+                __syncwarp();
+
+                // Issue TMA stores into remote scale-up buffer
+                // NOTES: `kDoExpandedSend` mode has already issued
+                if (not kDoExpandedSend and ptx::elect_one_sync()) {
+                    // Wait TMA arrival (only for non-reduced cases)
+                    if (no_local_reduce) {
+                        ptx::mbarrier_arrive_and_set_tx(mbarrier_ptr, kNumHiddenBytes);
+                        ptx::mbarrier_wait_and_flip_phase(mbarrier_ptr, phase);
+                    }
+
+                    // Issue stores
+                    ptx::tma_store_1d(
+                        token_buffer.get_base_ptr(), tma_buffer.get_base_ptr(),
+                        token_layout.get_num_bytes<false>());
+                    ptx::tma_store_commit();
+                }
+                #pragma unroll
+                for (int j = 0; j < kNumScaleupRanksPerLane; ++ j)
+                    stored_num_tokens_sent[j] += (j * 32 + lane_idx) == dst_scaleup_rank_idx;
+                __syncwarp();
+            }
+
+            // Update the tails together
+            // NOTES: TMA wait is inside
+            update_tails();
+
+            // Move linked list
+            #pragma unroll
+            for (int i = 0; i < kNumScaleupRanksPerLane; ++ i)
+                stored_ll_idx[i] += (stored_token_idx[i] >= 0);
+        }
+
+        // Update for the unissued ones
+        update_tails(true);
+    } else if (warp_idx < kNumDataWarps) {
+        const auto forward_warp_idx = warp_idx - kNumScaleupWarps;
+        const auto channel_idx = sm_idx * kNumChannelsPerSM + forward_warp_idx;
+
+        // Indexed-signal id owned by this channel within its GIN context. Uses the
+        // companion helper to `get_qp_mode` (called at kernel entry) so the id is
+        // unique among all channels sharing this warp's QP, regardless of which of
+        // `get_qp_mode`'s branches picked the mapping.
+        const auto signal_id = static_cast<ncclGinSignal_t>(
+            comm::get_qp_signal_id<kNumSMs, kNumQPs, kNumChannelsPerSM, true>(sm_idx, forward_warp_idx));
+
+        // Adjust registers
+        if constexpr (kAdjustRegisters)
+            ptx::warpgroup_reg_alloc<kNumRegistersForForwardWarps>();
+
+        constexpr int kNumSlotsPerChannel = kNumMaxTokensPerChannel * (kAllowMultipleReduction ? 1 : kNumTopk);
+        scaleout_send_buffer = scaleout_send_buffer.get_channel_buffer<kNumSlotsPerChannel>(channel_idx);
+        scaleout_recv_buffer = scaleout_recv_buffer.get_channel_buffer<kNumSlotsPerChannel>(channel_idx);
+
+        int slot_of_per_channel[kNumScaleoutRanks] = {};
+
+        // Shape of `token_metadata_at_forward`: `[kNumChannels, kNumScaleoutRanks * kNumMaxTokensPerChannel + 1, kNumForwardMetadataDims]`
+        constexpr int kNumForwardMetadataDims = 2 + kNumTopk * 2;
+        token_metadata_at_forward += channel_idx * ((kNumScaleoutRanks * kNumMaxTokensPerChannel + 1) * kNumForwardMetadataDims);
+
+        // Per Channel/ScaleOutRank batch metadata
+        int batch_count[kNumScaleoutRanks] = {};
+        int batch_start_slot[kNumScaleoutRanks];
+
+        ProxyPutDesc* const my_ring = proxy_ring_layout.get_ring(forward_warp_idx);
+        unsigned& my_head = *proxy_ring_layout.get_head(forward_warp_idx);
+        const unsigned* const my_tail_ptr = proxy_ring_layout.get_tail(forward_warp_idx);
+
+        // Hand a completed batch to the proxy instead of issuing the put here. Callers
+        // must be under `elect_one_sync`. Backpressure: spin while ring is full.
+        const auto issue_batched_rdma = [&](const int& dst) {
+            if (batch_count[dst] == 0)
+                return;
+            const auto send_ptr = scaleout_send_buffer
+                .get_rank_buffer(dst)
+                .get_token_buffer(batch_start_slot[dst])
+                .get_base_ptr();
+            const auto recv_ptr = scaleout_recv_buffer
+                .get_rank_buffer(scaleout_rank_idx)
+                .get_token_buffer(batch_start_slot[dst])
+                .get_base_ptr();
+
+            // Wait for a free ring slot.
+            while (my_head - ptx::ld_acquire_cta(my_tail_ptr) >= static_cast<unsigned>(kProxyRingDepth)) {}
+
+            const unsigned slot = my_head % static_cast<unsigned>(kProxyRingDepth);
+            my_ring[slot].send_ptr = send_ptr;
+            my_ring[slot].recv_ptr = recv_ptr;
+            my_ring[slot].num_bytes = batch_count[dst] * static_cast<int>(token_layout.get_num_bytes<false>());
+            my_ring[slot].dst = dst;
+
+            __threadfence();
+            ptx::st_release_cta(&my_head, my_head + 1);
+
+            batch_count[dst] = 0;
+        };
+
+        // Update per Channel/ScaleOutRank batch metadata and GIN PUT when threshold met
+        const auto record_slot_and_maybe_flush = [&](const int& dst, const int& slot) {
+            if (batch_count[dst] == 0)
+                batch_start_slot[dst] = slot;
+            batch_count[dst] += 1;
+            if (batch_count[dst] == kBatchSize)
+                issue_batched_rdma(dst);
+        };
+
+        int last_src_scaleout_rank_idx = -1;
+        int last_slot_written = -1;
+        const auto flush_last_tma_and_record_batch = [&]() {
+            if (last_src_scaleout_rank_idx >= 0 and ptx::elect_one_sync()) {
+                ptx::tma_store_wait();
+
+                 // Issue only if not local rank
+                if (last_src_scaleout_rank_idx != scaleout_rank_idx)
+                    record_slot_and_maybe_flush(last_src_scaleout_rank_idx, last_slot_written);
+            }
+            __syncwarp();
+        };
+
+        // Replay the dispatch
+        int stored_num_tokens_recv[kNumScaleupRanksPerLane] = {}, stored_cached_scaleup_tail[kNumScaleupRanksPerLane] = {};
+        for (int i = 0; ; ++ i) {
+            const auto src_token_global_idx = __ldg(token_metadata_at_forward + i * kNumForwardMetadataDims);
+            const auto src_rank_idx = src_token_global_idx / kNumMaxTokensPerRank;
+            const auto src_scaleout_rank_idx = src_rank_idx / kNumScaleupRanks;
+            const auto src_token_idx = src_token_global_idx % kNumMaxTokensPerRank;
+            auto stored_src_scaleup_rank_idx = lane_idx < kNumTopk ?
+                __ldg(token_metadata_at_forward + i * kNumForwardMetadataDims + 2 + lane_idx) : -1;
+            auto stored_src_slot_idx = lane_idx < kNumTopk ?
+                __ldg(token_metadata_at_forward + i * kNumForwardMetadataDims + 2 + kNumTopk + lane_idx) : -1;
+            if (src_token_global_idx < 0)
+                break;
+
+            // Scaleup rank mask
+            EP_STATIC_ASSERT(kNumScaleupRanks <= 64, "Too many scale-up peers");
+            using mask_t = std::conditional_t<kNumScaleupRanks <= 32, unsigned, unsigned long long>;
+            const auto scaleup_mask = ptx::reduce_or(
+                stored_src_scaleup_rank_idx >= 0 ?
+                (mask_t(1) << stored_src_scaleup_rank_idx) : mask_t(0));
+            bool stored_is_scaleup_rank_needed[kNumScaleupRanksPerLane];
+            #pragma unroll
+            for (int j = 0; j < kNumScaleupRanksPerLane; ++ j)
+                stored_is_scaleup_rank_needed[j] = (scaleup_mask >> (j * 32 + lane_idx)) & 1;
+
+            // Wait all tails to arrive
+            comm::timeout_while<kNumTimeoutCycles>([&](const bool& is_last_check) {
+                bool arrived = true;
+                #pragma unroll
+                for (int j = 0; j < kNumScaleupRanksPerLane; ++ j)
+                    arrived &= not stored_is_scaleup_rank_needed[j] or stored_num_tokens_recv[j] < stored_cached_scaleup_tail[j];
+                if (ptx::all(arrived))
+                    return true;
+
+                // Reload cached
+                #pragma unroll
+                for (int j = 0; j < kNumScaleupRanksPerLane; ++ j) {
+                    const auto k = j * 32 + lane_idx;
+                    stored_cached_scaleup_tail[j] = j < (kNumScaleupRanksPerLane - 1) or k < kNumScaleupRanks ?
+                        ptx::ld_acquire_sys(workspace_layout.get_channel_scaleup_tail_ptr(channel_idx, k)) : -1;
+                }
+
+                // Timeout
+                if (is_last_check) {
+                    #pragma unroll
+                    for (int j = 0; j < kNumScaleupRanksPerLane; ++ j) {
+                        printf("DeepEP combine (scale-up wait) timeout, scale-out: %d/%d, scale-up: %d/%d, "
+                               "channel: %d, lane: %d, recv: %d, tail: %d (wait=%d)\n",
+                               scaleout_rank_idx, kNumScaleoutRanks, scaleup_rank_idx, kNumScaleupRanks,
+                               channel_idx, j * 32 + lane_idx,
+                               stored_num_tokens_recv[j],
+                               stored_cached_scaleup_tail[j],
+                               stored_is_scaleup_rank_needed[j]);
+                    }
+                }
+                return false;
+            });
+
+            // Increase received count
+            #pragma unroll
+            for (int j = 0; j < kNumScaleupRanksPerLane; ++ j)
+                stored_num_tokens_recv[j] += static_cast<int>(stored_is_scaleup_rank_needed[j]);
+            
+            if constexpr (not kAllowMultipleReduction) {
+                // Cases where multiple reduction is disabled. We need to forward all data from scaleup peers to scaleout peers
+                // TODO: Let scale-up warps directly put data into `send_buffer`?
+                const auto src_slot_idx = src_scaleout_rank_idx * kNumMaxTokensPerRank + src_token_idx;
+                auto topk_valid_mask = kUseExpandedLayout ?
+                    ptx::gather(stored_src_scaleup_rank_idx >= 0) :
+                    ptx::gather(ptx::deduplicate(stored_src_scaleup_rank_idx, lane_idx) and stored_src_scaleup_rank_idx >= 0);  // Deduplicate w.r.t. scaleup rank index if expanded mode is disabled
+                const int num_valid_topk = __popc(topk_valid_mask);
+                if (ptx::elect_one_sync()) {
+                    int packed_offset_in_entry = 0;
+                    #pragma unroll
+                    for (int k = 0; k < kNumTopk; ++ k) {
+                        if ((topk_valid_mask & (1u << k)) == 0u)
+                            continue;
+
+                        // Issue TMA load, and wait
+                        ptx::tma_load_1d(
+                            tma_buffer.get_base_ptr(), scaleup_buffer.get_rank_buffer(k).get_token_buffer(src_slot_idx).get_base_ptr(),
+                            mbarrier_ptr, token_layout.get_num_bytes<false>());
+                        ptx::mbarrier_arrive_and_set_tx(mbarrier_ptr, token_layout.get_num_bytes<false>());
+                        ptx::mbarrier_wait_and_flip_phase(mbarrier_ptr, phase);
+
+                        const int slot = slot_of_per_channel[src_scaleout_rank_idx] + packed_offset_in_entry;
+                        const auto recv_buffer_ptr = scaleout_recv_buffer
+                            .get_rank_buffer(scaleout_rank_idx)
+                            .get_token_buffer(slot)
+                            .get_base_ptr();
+                        const auto send_buffer_ptr = src_scaleout_rank_idx == scaleout_rank_idx ?
+                            recv_buffer_ptr :
+                            scaleout_send_buffer
+                                .get_rank_buffer(src_scaleout_rank_idx)
+                                .get_token_buffer(slot)
+                                .get_base_ptr();
+                        ++ packed_offset_in_entry;
+                        ptx::tma_store_1d(send_buffer_ptr, tma_buffer.get_base_ptr(), token_layout.get_num_bytes<false>());
+                        ptx::tma_store_commit();
+                        ptx::tma_store_wait();
+
+                        topk_valid_mask ^= 1u << k;
+                        if (src_scaleout_rank_idx != scaleout_rank_idx)
+                            record_slot_and_maybe_flush(src_scaleout_rank_idx, slot);
+                    }
+                }
+                __syncwarp();
+                slot_of_per_channel[src_scaleout_rank_idx] += num_valid_topk;
+            } else {
+                // NOTES: we must do deduplicate and only add once from one rank
+                auto reduce_valid_mask = ptx::gather(
+                    ptx::deduplicate(stored_src_scaleup_rank_idx, lane_idx) and stored_src_scaleup_rank_idx >= 0);
+
+                // Calculate the source buffer index
+                int stored_src_buffer_idx = 0;
+                if constexpr (kUseScaleupRankLayout) {
+                    stored_src_buffer_idx =
+                        stored_src_scaleup_rank_idx * scaleup_buffer.num_max_tokens_per_rank + stored_src_slot_idx;
+                } else {
+                    const auto src_slot_idx = src_scaleout_rank_idx * kNumMaxTokensPerRank + src_token_idx;
+                    stored_src_buffer_idx = stored_src_slot_idx == -1 ? -1 :
+                        lane_idx * scaleup_buffer.num_max_tokens_per_rank + src_slot_idx;
+                }
+                
+                // Preprocess top-k indices
+                int topk_slot_idx[kNumTokensInScaleupLayout];
+                compute_topk_slots(
+                    topk_slot_idx, reduce_valid_mask,
+                    [=](const int& idx) {
+                        return ptx::exchange(stored_src_buffer_idx, idx);
+                    }
+                );
+
+                // Do reduce
+                constexpr int kUnrollFactor = get_max_unroll_factor<kHiddenVec, kAdjustRegisters ? 8 : 4>();
+                combine_reduce<kHiddenVec, kUnrollFactor, math::constexpr_ceil_div(kNumTopk, kNumScaleoutRanks)>(
+                    lane_idx, topk_slot_idx, static_cast<combine_vec_t*>(tma_buffer.get_base_ptr()),
+                    /* Get source base */ [=](const int& slot_idx) {
+                        return static_cast<combine_vec_t*>(scaleup_buffer.get_token_buffer(slot_idx, true).get_base_ptr());
+                    },
+                    /* Wait buffer release */ [=]() {
+                        flush_last_tma_and_record_batch();
+                    }
+                );
+
+                // Merge topk weights
+                // NOTES: the slot indices must follow the master lane
+                stored_src_buffer_idx = ptx::exchange(
+                    stored_src_buffer_idx, ptx::get_master_lane_idx(ptx::match(stored_src_scaleup_rank_idx)));
+                if (stored_src_scaleup_rank_idx >= 0) {
+                    tma_buffer.get_topk_weights_ptr()[lane_idx] =
+                        scaleup_buffer.get_token_buffer(stored_src_buffer_idx, true)
+                                    .get_topk_weights_ptr()[lane_idx];
+                }
+                ptx::tma_store_fence();
+                __syncwarp(); // Necessary to let the leader lane see the writes
+
+                // Assign send and receive buffers
+                // NOTES: as we only have 1 destination, we will use "send" as "recv" for local transfer
+                const int recv_slot = slot_of_per_channel[src_scaleout_rank_idx];
+                const auto recv_token_buffer = scaleout_recv_buffer
+                    .get_rank_buffer(scaleout_rank_idx)
+                    .get_token_buffer(recv_slot);
+                const auto send_token_buffer = src_scaleout_rank_idx == scaleout_rank_idx ?
+                    recv_token_buffer :
+                    scaleout_send_buffer
+                    .get_rank_buffer(src_scaleout_rank_idx)
+                    .get_token_buffer(slot_of_per_channel[src_scaleout_rank_idx]);
+                slot_of_per_channel[src_scaleout_rank_idx] += 1;
+
+                // Write into scale-out send buffer or local rank recv buffer bypass
+                if (ptx::elect_one_sync()) {
+                    ptx::tma_store_1d(send_token_buffer.get_base_ptr(), tma_buffer.get_base_ptr(),
+                                    token_layout.get_num_bytes<false>());
+                    ptx::tma_store_commit();
+                }
+                __syncwarp();
+
+                // Record RDMA info to issue later
+                last_src_scaleout_rank_idx = src_scaleout_rank_idx;
+                last_slot_written = recv_slot;
+            }
+        }
+
+        // Issue the last TMA and record operation for last RDMA
+        if constexpr (kAllowMultipleReduction)
+            flush_last_tma_and_record_batch();
+
+        // Issue the last RDMA per channel/scaleout-warp
+        if (ptx::elect_one_sync()) {
+            #pragma unroll
+            for (int dst = 0; dst < kNumScaleoutRanks; ++ dst)
+                issue_batched_rdma(dst);
+
+            ptx::st_release_cta(proxy_ring_layout.get_done(forward_warp_idx), 1);
+        }
+        __syncwarp();
+
+        // Clean scaleup tails
+        #pragma unroll
+        for (int j = 0; j < kNumScaleupRanksPerLane; ++ j) {
+            const auto k = j * 32 + lane_idx;
+            if (j < (kNumScaleupRanksPerLane - 1) or k < kNumScaleupRanks)
+                *workspace_layout.get_channel_scaleup_tail_ptr(channel_idx, k) = 0;
+        }
+        __syncwarp();
+
+        // Update, wait and clean
+        EP_STATIC_ASSERT(kNumScaleoutRanks <= 32, "Invalid ranks");
+
+        // Derive the expected inbound put count for this channel by counting my own
+        // outbound routing decisions during dispatch. Count "distinct valid non-local packed
+        // entries per T" — same rule works for reduce and expand modes because of how
+        // dispatch fills the map.
+        //
+        // Concrete example — token T=0 on channel C, topK=4, my scaleout_rank_idx=3,
+        // routing (k=0 → scaleout 1, k=1 → scaleout 0, k=2 → scaleout 0, k=3 → scaleout 3):
+        //
+        //   Reduce mode (map = [ pack(1,0,C), pack(0,0,C), pack(0,0,C), pack(3,0,C) ]):
+        //     k=0: valid, rank=1 (remote), first sight of pack(1,0,C)         → count
+        //     k=1: valid, rank=0 (remote), first sight of pack(0,0,C)         → count
+        //     k=2: valid, rank=0 (remote), pack(0,0,C) already seen (dup)     → skip
+        //     k=3: valid, rank=3 (== self, local-bypass, no put fires)        → skip
+        //   Expected puts for T=0 = 2. Peer R=0 sends one reduced partial covering k=1+k=2.
+        //
+        //   Expand mode (map = [ pack(1,0,C), pack(0,0,C), pack(0,1,C), pack(3,0,C) ]):
+        //     k=0: valid, rank=1 (remote), unique packed value  → count
+        //     k=1: valid, rank=0 (remote), unique packed value  → count
+        //     k=2: valid, rank=0 (remote), unique packed value  → count
+        //     k=3: valid, rank=3 (self)                          → skip
+        //   Expected puts for T=0 = 3. Peer R=0 sends two separate partials (k=1, k=2)
+        //   at distinct slots because each valid k has its own packed slot in expand mode.
+        int local_expected_count_per_rank[kNumScaleoutRanks] = {};
+        {
+            #pragma unroll
+            for (int t_in_channel = lane_idx; t_in_channel < kNumMaxTokensPerChannel; t_in_channel += 32) {
+                const int token_idx = channel_idx + t_in_channel * kNumChannels;
+                if (token_idx >= num_combined_tokens)
+                    continue;
+                // Load this token's map entries once, then dedup+count within the topK block.
+                int packed_entries[kNumTopk];
+                #pragma unroll
+                for (int k = 0; k < kNumTopk; ++ k)
+                    packed_entries[k] = __ldg(token_map_at_dispatch + token_idx * kNumTopk + k);
+                #pragma unroll
+                for (int k = 0; k < kNumTopk; ++ k) {
+                    const int p = packed_entries[k];
+                    if (p < 0)
+                        continue;
+                    int rank, slot, channel;
+                    unpack_combine_recv_addr(p, rank, slot, channel);
+                    // Sanity: token T dispatched by us with `T % kNumChannels == channel_idx`
+                    // must have its map entry's channel field equal to channel_idx.
+                    EP_DEVICE_ASSERT(channel == channel_idx);
+                    if (rank == scaleout_rank_idx)
+                        continue;   // local-bypass, no RDMA put
+                    bool is_duplicate = false;
+                    #pragma unroll
+                    for (int prior_k = 0; prior_k < k; ++ prior_k)
+                        is_duplicate |= (packed_entries[prior_k] == p);
+                    if (not is_duplicate)
+                        local_expected_count_per_rank[rank] += 1;
+                }
+            }
+        }
+
+        // Each lane in the Forward warp (= channel) accumulated the expected tokens per scale-out
+        // rank in its own slice of the map. All-reduce across lanes so every lane sees
+        // the full per-rank total. Then divide by the batch size, that's the aggregation
+        // granularity we expect on the wire.
+        int num_expected_arrivals = 0;
+        #pragma unroll
+        for (int r = 0; r < kNumScaleoutRanks; ++ r) {
+            const int rank_total = ptx::reduce_add(local_expected_count_per_rank[r]);
+            num_expected_arrivals += math::ceil_div(rank_total, kBatchSize);
+        }
+        __syncwarp();
+        // Wait for the per-channel indexed signal to accumulate `num_expected_arrivals`
+        // increments from the remote senders. Bump the shadow by the expected delta to
+        // get the target count, then poll the actual signal until it catches up. only
+        // one lane polls. We poll with a timeout (instead of the blocking
+        // `waitSignalMeetShadow`) so a stuck peer surfaces a diagnostic rather than
+        // hanging.
+        if (ptx::elect_one_sync()) {
+            const auto shadow_ptr = gin.gin.getSignalShadowPtr(signal_id);
+            const auto target = (*shadow_ptr += static_cast<uint64_t>(num_expected_arrivals));
+            comm::timeout_while<kNumTimeoutCycles>([=](const bool& is_last_check) {
+                const auto signal = gin.gin.readSignal(signal_id, 64, cuda::memory_order_acquire);
+                if (signal >= target)
+                    return true;
+
+                if (is_last_check) {
+                    printf("DeepEP combine (scale-out wait all) timeout, scale-out: %d/%d, scale-up: %d/%d, "
+                           "channel: %d, signal: %lu, target: %lu\n",
+                           scaleout_rank_idx, kNumScaleoutRanks, scaleup_rank_idx, kNumScaleupRanks,
+                           channel_idx, signal, target);
+                }
+                return false;
+            });
+        }
+        __syncwarp();
+    } else {
+        // Proxy warp loop shape: arch-selected at JIT compile time.
+        //   SM100+ (B200) -> sequential single-lane sweeper.
+        //   otherwise (H200) -> parallel multi-lane (each lane owns its ring).
+        //
+        // B200 forward warps run faster so batches arrive at the proxy unevenly,
+        // driving high lane divergence in the parallel design. H200 forward warps
+        // are slower, so batches arrive more evenly and most lanes have work
+        // together -> low divergence.
+        //
+        // Divergence cost per put step: sum(Ln for n in 0..kNumForwardWarps-1)
+        // (all lanes' PC time) + lane-context-switch overhead. On B200 that beats
+        // the serial sweep; on H200 the parallel throughput gain dominates.
+        #if __CUDA_ARCH__ >= 1000
+        constexpr bool kSingleLaneSweeper = true;
+        #else
+        constexpr bool kSingleLaneSweeper = false;
+        #endif
+
+        if constexpr (kSingleLaneSweeper) {
+            // Sequential design: one lane sweeps all rings, issues puts serially.
+            // Owns per-ring GIN contexts (built inline so each put routes to its
+            // channel's QP). Best when per-put cost is high enough that warp-lockstep
+            // parallelism doesn't pay off (B200 SM100).
+            if (ptx::elect_one_sync()) {
+                int num_forward_warps_done_cnt = 0;
+                unsigned tail[kNumForwardWarps] = {};
+                bool ring_done[kNumForwardWarps] = {};
+                ncclGinSignal_t ring_signal_id[kNumForwardWarps];
+
+                alignas(handle::NCCLGin) unsigned char gin_ctx_storage[kNumForwardWarps * sizeof(handle::NCCLGin)];
+                auto* const gin_ctx = reinterpret_cast<handle::NCCLGin*>(gin_ctx_storage);
+                #pragma unroll
+                for (int forward_warp_idx = 0; forward_warp_idx < kNumForwardWarps; ++ forward_warp_idx) {
+                    ring_signal_id[forward_warp_idx] = static_cast<ncclGinSignal_t>(
+                        comm::get_qp_signal_id<kNumSMs, kNumQPs, kNumChannelsPerSM, true>(sm_idx, forward_warp_idx));
+                    const auto [qp, mode] =
+                        comm::get_qp_mode<kNumSMs, kNumQPs, kNumChannelsPerSM, true>(sm_idx, forward_warp_idx);
+                    new (&gin_ctx[forward_warp_idx]) handle::NCCLGin(nccl_dev_comm, nccl_window, qp, mode);
+                }
+
+                while (num_forward_warps_done_cnt < kNumForwardWarps) {
+                    int gin_put_ops = 0;
+
+                    #pragma unroll
+                    for (int forward_warp_idx = 0; forward_warp_idx < kNumForwardWarps; ++ forward_warp_idx) {
+                        if (ring_done[forward_warp_idx])
+                            continue;
+
+                        const unsigned head = ptx::ld_acquire_cta(proxy_ring_layout.get_head(forward_warp_idx));
+
+                        if (tail[forward_warp_idx] == head) {
+                            if (ptx::ld_acquire_cta(proxy_ring_layout.get_done(forward_warp_idx)) == 1 and
+                                tail[forward_warp_idx] == ptx::ld_acquire_cta(proxy_ring_layout.get_head(forward_warp_idx))) {
+                                ring_done[forward_warp_idx] = true;
+                                ++ num_forward_warps_done_cnt;
+                            }
+                            continue;
+                        }
+
+                        const auto& desc = proxy_ring_layout.get_ring(forward_warp_idx)[
+                            tail[forward_warp_idx] % static_cast<unsigned>(kProxyRingDepth)];
+                        gin_ctx[forward_warp_idx].put<ncclTeamTagRail>(
+                            desc.recv_ptr, desc.send_ptr,
+                            desc.num_bytes,
+                            desc.dst,
+                            0, /*flags=0*/
+                            ncclGin_SignalAdd{ring_signal_id[forward_warp_idx], static_cast<uint64_t>(1)}
+                        );
+
+                        ++ tail[forward_warp_idx];
+                        ptx::st_release_cta(proxy_ring_layout.get_tail(forward_warp_idx), tail[forward_warp_idx]);
+                        ++ gin_put_ops;
+                    }
+
+                    if (gin_put_ops == 0)
+                        __nanosleep(1000);
+                }
+            }
+            __syncwarp();
+        } else {
+            // Parallel design: each lane represents one forward warp within this SM
+            // and drains its own ring. Warp-lockstep parallelism across up to
+            // kNumForwardWarps lanes — best when per-put cost is small (H200 SM90).
+            if (lane_idx < kNumForwardWarps) {
+                const auto channel_idx = sm_idx * kNumChannelsPerSM + lane_idx;
+                const auto signal_id = static_cast<ncclGinSignal_t>(
+                    comm::get_qp_signal_id<kNumSMs, kNumQPs, kNumChannelsPerSM, true>(sm_idx, lane_idx));
+
+                ProxyPutDesc* const ring = proxy_ring_layout.get_ring(lane_idx);
+                unsigned tail = 0;
+
+                while (true) {
+                    const unsigned head = ptx::ld_acquire_cta(proxy_ring_layout.get_head(lane_idx));
+                    if (tail == head) {
+                        if (ptx::ld_acquire_cta(proxy_ring_layout.get_done(lane_idx)) != 0) {
+                            // Re-check head to avoid missing a descriptor published just
+                            // before `done` became visible.
+                            if (tail == ptx::ld_acquire_cta(proxy_ring_layout.get_head(lane_idx)))
+                                break;
+                        } else if (tail != 0 and (tail % static_cast<unsigned>(kNumForwardWarps)) == 0) {
+                            __nanosleep(1000); // release context for data warps
+                        }
+                        continue;
+                    }
+
+                    const auto& desc = ring[tail % static_cast<unsigned>(kProxyRingDepth)];
+                    gin.put<ncclTeamTagRail>(
+                        desc.recv_ptr, desc.send_ptr,
+                        desc.num_bytes,
+                        desc.dst,
+                        0, /*flags=0*/
+                        ncclGin_SignalAdd{signal_id, static_cast<uint64_t>(1)}
+                    );
+
+                    ptx::st_release_cta(proxy_ring_layout.get_tail(lane_idx), tail + 1);
+                    ++ tail;
+                }
+            }
+        }
+    }
+
+    // No barrier at epilogue
+}
+
+}  // namespace deep_ep::elastic

--- a/deep_ep/include/deep_ep/impls/hybrid_dispatch_unordered.cuh
+++ b/deep_ep/include/deep_ep/impls/hybrid_dispatch_unordered.cuh
@@ -1,0 +1,1106 @@
+#pragma once
+
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <deep_ep/common/comm.cuh>
+#include <deep_ep/common/compiled.cuh>
+#include <deep_ep/common/exception.cuh>
+#include <deep_ep/common/gin_resource_alloc.cuh>
+#include <deep_ep/common/layout.cuh>
+#include <deep_ep/common/math.cuh>
+#include <deep_ep/common/ptx.cuh>
+#include <deep_ep/impls/combine_utils.cuh>
+
+
+namespace deep_ep::elastic {
+
+static constexpr int64_t kScaleoutHeaderWrittenBit = static_cast<int64_t>(1) << 63;
+
+__device__ __forceinline__ int64_t pack_scaleout_header(const int& iteration, const int& count,
+                                                        const bool& more) {
+    return kScaleoutHeaderWrittenBit
+         | (static_cast<int64_t>(iteration & 0x7fffffff) << 32)
+         | (static_cast<int64_t>(count & 0x3fffffff) << 1)
+         | (more ? static_cast<int64_t>(1) : static_cast<int64_t>(0));
+}
+
+__device__ __forceinline__ bool unpack_scaleout_header(const int64_t& header, const int& iteration,
+                                                       int& count, bool& more) {
+    count = static_cast<int>((header >> 1) & 0x3fffffff);
+    more = (header & 0x1) != 0;
+    return header < 0 and ((header >> 32) & 0x7fffffff) == (iteration & 0x7fffffff);
+}
+
+#ifndef EP_NUM_SUB_PARTS
+#define EP_NUM_SUB_PARTS 2
+#endif
+
+#ifndef EP_MIN_SUB_TOKENS
+#define EP_MIN_SUB_TOKENS 1
+#endif
+
+static constexpr int kNumSubPartsDefault = (EP_NUM_SUB_PARTS) > 1 ? (EP_NUM_SUB_PARTS) : 1;
+static constexpr int kMinSubTokensDefault = (EP_MIN_SUB_TOKENS) > 1 ? (EP_MIN_SUB_TOKENS) : 1;
+
+#ifndef EP_SM100_MIN_SUB_TOKENS
+#define EP_SM100_MIN_SUB_TOKENS 15
+#endif
+
+template <int kNumSubParts, int kMinSubTokens = kMinSubTokensDefault>
+__device__ __host__ __forceinline__ int num_sub_parts_at(const int& part_tokens) {
+    if constexpr (kNumSubParts <= 1) {
+        return 1;
+    } else {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+        constexpr int kArchMinSubTokens = (EP_SM100_MIN_SUB_TOKENS) > 1 ? (EP_SM100_MIN_SUB_TOKENS) : 1;
+#else
+        constexpr int kArchMinSubTokens = 1;
+#endif
+        constexpr int kEffMinSubTokens = kMinSubTokens > kArchMinSubTokens ? kMinSubTokens : kArchMinSubTokens;
+        int n = part_tokens < kNumSubParts ? part_tokens : kNumSubParts;
+        if constexpr (kEffMinSubTokens > 1) {
+            const int by_floor = part_tokens / kEffMinSubTokens;
+            n = n < by_floor ? n : by_floor;
+        }
+        return n > 1 ? n : 1;
+    }
+}
+
+template <int kNumSubParts>
+__device__ __host__ __forceinline__ int sub_part_size_at(const int& part_tokens, const int& sub) {
+    if constexpr (kNumSubParts <= 1) {
+        return part_tokens;
+    } else {
+        const int num_subs = num_sub_parts_at<kNumSubParts>(part_tokens);
+        const int base = part_tokens / num_subs;
+        const int rem = part_tokens - base * num_subs;
+        return base + (sub < rem ? 1 : 0);
+    }
+}
+
+template <int kNumSubParts>
+__device__ __host__ __forceinline__ int sub_part_offset_at(const int& part_tokens, const int& sub) {
+    if constexpr (kNumSubParts <= 1) {
+        return 0;
+    } else {
+        int off = 0;
+        for (int s = 0; s < sub; ++ s)
+            off += sub_part_size_at<kNumSubParts>(part_tokens, s);
+        return off;
+    }
+}
+
+template <int kNumParts, int kBatchSize, int kNumMaxTokensPerChannel>
+__device__ __host__ __forceinline__ constexpr int part_size_at(const int& part) {
+    constexpr int kFirst = kBatchSize / 3 > 4 ? kBatchSize / 3 : 4;
+    constexpr int kMidParts = kNumParts - 2;
+    constexpr int kMidTotal = kNumMaxTokensPerChannel - kFirst - kBatchSize;
+    if constexpr (kNumParts < 3 or kMidTotal < kMidParts) {
+        return kBatchSize;
+    } else {
+        if (part == 0)
+            return kFirst;
+        if (part == kNumParts - 1)
+            return kBatchSize;
+        const int mid_idx = part - 1;
+        return kMidTotal / kMidParts + (mid_idx < (kMidTotal % kMidParts) ? 1 : 0);
+    }
+}
+
+template <int kNumParts, int kBatchSize, int kNumMaxTokensPerChannel>
+__device__ __host__ __forceinline__ constexpr int part_offset_at(const int& part) {
+    int off = 0;
+    for (int p = 0; p < part; ++ p)
+        off += part_size_at<kNumParts, kBatchSize, kNumMaxTokensPerChannel>(p);
+    return off;
+}
+
+template <bool kDoCPUSync,
+          bool kReuseSlotIndices,
+          bool kAllowMultipleReduction,
+          bool kDoExpand,
+          bool kDoubleBufferForward,
+          int kNumSMs,
+          int kNumNotifyWarps, int kNumScaleoutWarps, int kNumForwardWarps,
+          int kNumScaleoutRanks, int kNumScaleupRanks,
+          int kNumHiddenBytes, int kNumSFPacks,
+          int kNumMaxTokensPerRank,
+          int kNumExperts, int kNumTopk, int kExpertAlignment,
+          int kNumQPs, int64_t kNumTimeoutCycles,
+          int kNumGinSignals,
+          int kNumScaleupRanksPerLane = math::constexpr_ceil_div(kNumScaleupRanks, 32),
+          int kNumChannelsPerSM = kNumScaleoutWarps,
+          int kNumChannels = kNumScaleoutWarps * kNumSMs,
+          int kNumParts = gin_alloc::constexpr_num_parts(
+              kNumGinSignals, kNumSMs, kNumQPs, (kNumNotifyWarps > 0), kNumScaleoutWarps),
+          int kNumMaxTokensPerChannel = math::constexpr_ceil_div(kNumMaxTokensPerRank, kNumChannels),
+          int kPartSize = math::constexpr_ceil_div(kNumMaxTokensPerChannel, kNumParts),
+          int kBatchSize = kPartSize,
+          int kNumSubParts = kNumSubPartsDefault < kBatchSize ? kNumSubPartsDefault : kBatchSize,
+          int kNumSlotsPerForwardChunk = 48,
+          int kNumRanks = kNumScaleoutRanks * kNumScaleupRanks,
+          int kNumNotifyThreads = kNumNotifyWarps * 32,
+          int kNumScaleoutSendThreads = kNumScaleoutWarps * 32,
+          int kNumForwardThreads = kNumForwardWarps * 32,
+          int kNumThreads = kNumNotifyThreads + kNumScaleoutSendThreads + kNumForwardThreads>
+__global__ void __launch_bounds__(kNumThreads, 1)
+hybrid_unordered_dispatch_impl(
+    void* x, sf_pack_t* sf, topk_idx_t* topk_idx, float* topk_weights,
+    topk_idx_t* copied_topk_idx,
+    int* cumulative_local_expert_recv_stats,
+    int* psum_num_recv_tokens_per_scaleup_rank,
+    int* psum_num_recv_tokens_per_expert,
+    int* num_unaligned_recv_tokens_per_expert,
+    int* dst_buffer_slot_idx,
+    int* token_metadata_at_forward,
+    int* token_map_at_dispatch,
+    const int num_tokens,
+    const int sf_token_stride, const int sf_hidden_stride,
+    // TODO(NCCL): so many params, plans to optimize?
+    const ncclDevComm_t nccl_dev_comm, const ncclWindow_t nccl_window,
+    void* buffer,
+    void* workspace, void* mapped_host_workspace,
+    const int scaleout_rank_idx, const int scaleup_rank_idx,
+    const int dispatch_iteration) {
+    constexpr int kNumExpertsPerRank = kNumExperts / kNumRanks;
+    constexpr int kNumExpertsPerScaleout = kNumExperts / kNumScaleoutRanks;
+    EP_STATIC_ASSERT(kNumExperts % kNumScaleupRanks == 0, "Invalid number of experts or ranks");
+    EP_STATIC_ASSERT(kNumNotifyWarps % 4 == 0, "Invalid warpgroup size");
+    EP_STATIC_ASSERT(kNumScaleoutWarps == kNumForwardWarps, "Invalid warp size");
+    EP_STATIC_ASSERT(kNumParts <= layout::WorkspaceLayout::kNumMaxParts,
+                     "kNumParts exceeds the per-part header workspace capacity");
+    EP_STATIC_ASSERT(kNumParts >= 1, "Invalid part count");
+    EP_STATIC_ASSERT(kNumSubParts >= 1, "Invalid sub-part count");
+    EP_STATIC_ASSERT(kNumSubParts <= kBatchSize,
+                     "More sub-parts than tokens in a part: every sub-part must own >= 1 token "
+                     "so its header has its own slot");
+    EP_STATIC_ASSERT(gin_alloc::constexpr_channels_per_sm(
+                         kNumGinSignals, kNumSMs, kNumQPs, (kNumNotifyWarps > 0), kNumScaleoutWarps)
+                         == kNumScaleoutWarps,
+                     "GIN signal budget cannot host the launched channel count");
+
+    // Utils
+    // NOTES: a warp is a channel (different channels may share QPs)
+    const auto sm_idx = static_cast<int>(blockIdx.x), thread_idx = static_cast<int>(threadIdx.x);
+    const auto warp_idx = ptx::get_warp_idx(), lane_idx = ptx::get_lane_idx();
+    const auto rank_idx = scaleout_rank_idx * kNumScaleupRanks + scaleup_rank_idx;
+
+    // Workspaces
+    const auto workspace_layout = layout::WorkspaceLayout(workspace, kNumScaleoutRanks, kNumScaleupRanks, kNumExperts);
+    const auto host_workspace_layout = layout::WorkspaceLayout(mapped_host_workspace, kNumScaleoutRanks, kNumScaleupRanks, kNumExperts);
+
+    // The kernel uses a fixed space of dynamic shared memory (no static shared memory)
+    extern __shared__ __align__(ptx::kNumTMAAlignBytes) int8_t smem[];
+    constexpr int kNumSmemBytesForNotify = kNumNotifyThreads > 0 ?
+        math::constexpr_align(kNumRanks + kNumExperts, kNumNotifyThreads) * sizeof(int) : 0;
+    EP_STATIC_ASSERT(kNumSmemBytesForNotify % ptx::kNumTMAAlignBytes == 0, "Invalid TMA alignment");
+
+    // Named barrier indices
+    constexpr int kNotifyBarrierIndex = 1;
+
+    // NCCL Gin handle
+    // Each warp is a channel
+    const auto [qp_idx, sharing_mode] = comm::get_qp_mode<kNumSMs, kNumQPs, kNumChannelsPerSM, (kNumNotifyWarps > 0)>(
+        sm_idx, (warp_idx - kNumNotifyWarps) % kNumChannelsPerSM, warp_idx < kNumNotifyWarps);
+    const auto gin = handle::NCCLGin(nccl_dev_comm, nccl_window, qp_idx, sharing_mode);
+
+    const auto token_layout = layout::TokenLayout(kNumHiddenBytes, kNumSFPacks * sizeof(sf_pack_t), kNumTopk, true);
+    const auto scaleout_token_layout = layout::TokenLayout(
+        kNumHiddenBytes, kNumSFPacks * sizeof(sf_pack_t), kNumTopk, true, nullptr, /*with_scaleout_hdr=*/true);
+    constexpr int kNumFwdBuffers = kDoubleBufferForward ? kNumDispatchFwdBuffers : 1;
+    const auto tma_pool = layout::BufferLayout<true>(
+        token_layout, kNumScaleoutWarps + kNumFwdBuffers * kNumForwardWarps, 1,
+        math::advance_ptr<int>(smem, kNumSmemBytesForNotify));
+    const bool is_forward_warp = warp_idx >= kNumNotifyWarps + kNumScaleoutWarps;
+    const int fwd_warp_idx = warp_idx - (kNumNotifyWarps + kNumScaleoutWarps);
+    const int tma_pool_base = is_forward_warp
+        ? kNumScaleoutWarps + kNumFwdBuffers * fwd_warp_idx
+        : (warp_idx - kNumNotifyWarps);
+    const auto tma_buffer = tma_pool.get_rank_buffer(tma_pool_base).get_token_buffer(0);
+    const auto tma_buffer_alt = tma_pool.get_rank_buffer(
+        tma_pool_base + (kDoubleBufferForward and is_forward_warp ? 1 : 0)).get_token_buffer(0);
+
+    constexpr int kNumSlotsPerChannel = kNumParts * kBatchSize;
+    const auto part_size = [&](const int& part) {
+        return part_size_at<kNumParts, kBatchSize, kNumMaxTokensPerChannel>(part);
+    };
+    const auto part_first_slot = [&](const int& part) {
+        return part_offset_at<kNumParts, kBatchSize, kNumMaxTokensPerChannel>(part);
+    };
+    // First slot of sub-part `sub_idx` within part `part_idx` (slots inside a sub-part are
+    // filled contiguously from here; its in-band header lives in this slot's header word).
+    const auto sub_slot = [&](const int& part_idx, const int& sub_idx) {
+        return part_first_slot(part_idx) +
+            sub_part_offset_at<kNumSubParts>(part_size(part_idx), sub_idx);
+    };
+    // Per-(channel, part) counting-signal id, shared by the sender and forward sides of the
+    // channel this warp serves (both sides reduce to the same channel warp index).
+    const auto part_signal_id = [&](const int& part_idx) {
+        return static_cast<ncclGinSignal_t>(
+            comm::get_per_part_signal_id<kNumSMs, kNumQPs, kNumChannelsPerSM,
+                                         kNumParts, (kNumNotifyWarps > 0)>(
+                sm_idx, (warp_idx - kNumNotifyWarps) % kNumChannelsPerSM, part_idx));
+    };
+
+    auto scaleup_buffer = layout::BufferLayout<false>(
+        token_layout, kNumScaleupRanks, kNumScaleoutRanks * kNumMaxTokensPerRank, buffer);
+    auto scaleout_send_buffer = layout::BufferLayout<false>(
+        scaleout_token_layout, kNumScaleoutRanks, kNumChannels * kNumSlotsPerChannel, scaleup_buffer.get_buffer_end_ptr());
+    auto scaleout_recv_buffer = layout::BufferLayout<false>(
+        scaleout_token_layout, kNumScaleoutRanks, kNumChannels * kNumSlotsPerChannel, scaleout_send_buffer.get_buffer_end_ptr());
+
+    comm::gpu_barrier<true, kNumScaleoutRanks, kNumScaleupRanks,
+                      kNumSMs, kNumThreads, kNumQPs, kNumTimeoutCycles, comm::kHybridDispatchTag0, false, true, true>(
+        gin, workspace_layout, scaleout_rank_idx, scaleup_rank_idx, sm_idx, thread_idx);
+
+    // Init TMA for scale-out and forward warps
+    ptx::arrival_phase phase = 0;
+    const auto mbarrier_ptr = tma_buffer.get_mbarrier_ptr();
+    ptx::arrival_phase phase_alt = 0;
+    const auto mbarrier_ptr_alt = tma_buffer_alt.get_mbarrier_ptr();
+    if (warp_idx >= kNumNotifyWarps and ptx::elect_one_sync()) {
+        ptx::mbarrier_init_with_fence(mbarrier_ptr, 1);
+        if (kDoubleBufferForward and is_forward_warp)
+            ptx::mbarrier_init_with_fence(mbarrier_ptr_alt, 1);
+    }
+    __syncwarp();
+
+    // Different warp roles
+    if (warp_idx < kNumNotifyWarps) {
+        // Assign shared memory
+        constexpr int kNumAlignedElems = kNumSmemBytesForNotify / sizeof(int);
+        const auto rank_expert_count = math::advance_ptr<int>(smem, 0);
+
+        // Clean initial counts
+        // NOTES: if you want to change the order of different warp roles, please take care of the `thread_idx`
+        int *rank_count = rank_expert_count, *expert_count = rank_expert_count + kNumRanks;
+        #pragma unroll
+        for (int i = 0; i < kNumAlignedElems / kNumNotifyThreads; ++ i)
+            rank_expert_count[i * kNumNotifyThreads + thread_idx] = 0;
+        ptx::named_barrier<kNumNotifyThreads>(kNotifyBarrierIndex);
+
+        // Atomic add on shared memory
+        EP_STATIC_ASSERT(kNumTopk <= 32, "Insufficient lanes");
+        const auto global_warp_idx = sm_idx * kNumNotifyWarps + warp_idx;
+        for (int i = global_warp_idx; i < num_tokens; i += kNumNotifyWarps * kNumSMs) {
+            // Expert choice can not be redundant
+            // NOTES: no assertions here as they are expensive
+            const auto dst_expert_idx = lane_idx < kNumTopk ?
+                static_cast<int>(__ldg(topk_idx + i * kNumTopk + lane_idx)) : -1;
+            if (dst_expert_idx >= 0)
+                atomicAdd_block(expert_count + dst_expert_idx, 1);
+
+            // Rank choice should do deduplication here
+            const auto dst_rank_idx = dst_expert_idx >= 0 ? dst_expert_idx / kNumExpertsPerRank : -1;
+            if (ptx::deduplicate(dst_rank_idx, lane_idx) and dst_rank_idx >= 0)
+                atomicAdd_block(rank_count + dst_rank_idx, 1);
+        }
+        ptx::named_barrier<kNumNotifyThreads>(kNotifyBarrierIndex);
+
+        // Do full-grid reduction
+        #pragma unroll
+        for (int i = thread_idx; i < kNumRanks + kNumExperts; i += kNumNotifyThreads) {
+            const int64_t counter = (1ll << 32ll) | rank_expert_count[i];
+            ptx::red_add(workspace_layout.get_notify_reduction_workspace_ptr() + i, counter);
+        }
+
+        // Do the remaining work by SM 0
+        if (sm_idx == 0) {
+            // Reduce all SM's count
+            // Wait all SMs' arrival
+            #pragma unroll
+            for (int i = thread_idx; i < kNumRanks + kNumExperts; i += kNumNotifyThreads) {
+                comm::timeout_while<kNumTimeoutCycles>([=](const bool& is_last_check) {
+                    const auto status = ptx::ld_volatile<int64_t>(workspace_layout.get_notify_reduction_workspace_ptr() + i);
+                    if ((status >> 32) == kNumSMs) {
+                        // Encode and write into the send buffer
+                        workspace_layout.get_scaleout_rank_expert_count_ptr<true>()[i] =
+                            math::encode_decode_positive<int>(status & 0xffffffffll);
+
+                        // Clean for the next usage
+                        workspace_layout.get_notify_reduction_workspace_ptr()[i] = 0;
+                        return true;
+                    }
+
+                    if (is_last_check) {
+                        printf("DeepEP hybrid notify (GPU reduction) timeout, scale-out: %d/%d, scale-up: %d/%d, "
+                               "thread: %d, status: %d | %d, expected: %d\n",
+                               scaleout_rank_idx, kNumScaleoutRanks, scaleup_rank_idx, kNumScaleupRanks, thread_idx,
+                               static_cast<int>(status >> 32), static_cast<int>(status & 0xffffffff), kNumSMs);
+                    }
+                    return false;
+                });
+            }
+            ptx::named_barrier<kNumNotifyThreads>(kNotifyBarrierIndex);
+
+            // Issue scaleout writes to peers
+            EP_STATIC_ASSERT(kReuseSlotIndices or kNumScaleoutRanks <= kNumNotifyThreads,
+                             "kNumScaleoutRanks must be less than kNumNotifyThreads");
+            if (thread_idx < kNumScaleoutRanks) {
+                const auto dst_scaleout_rank_idx = thread_idx;
+                gin.put<ncclTeamTagRail>(
+                    workspace_layout.get_scaleout_rank_count_ptr<false>(scaleout_rank_idx),
+                    workspace_layout.get_scaleout_rank_count_ptr<true>(dst_scaleout_rank_idx),
+                    kNumScaleupRanks * sizeof(int), dst_scaleout_rank_idx,
+                    ncclGinOptFlagsAggregateRequests);
+                gin.put<ncclTeamTagRail>(
+                    workspace_layout.get_scaleout_expert_count_ptr<false>(scaleout_rank_idx),
+                    workspace_layout.get_scaleout_expert_count_ptr<true>(dst_scaleout_rank_idx),
+                    kNumExpertsPerScaleout * sizeof(int), dst_scaleout_rank_idx);
+            }
+            __syncwarp();
+
+            // Util functions to get metadata from scale-out peers
+            // NOTES: this is correct as RDMA operations has a minimum write granularity of 1024 bytes (a whole integer write is atomic)
+            const auto recv_and_reduce = [=](const auto& get_ptr_func, const bool& is_expert_reduction = false) -> int {
+                int count = 0;
+                #pragma unroll
+                for (int j = 0; j < kNumScaleoutRanks; ++ j) {
+                    const auto ptr = get_ptr_func(j);
+                    int decoded;
+                    comm::timeout_while<kNumTimeoutCycles>([&](const bool& is_last_check){
+                        decoded = math::encode_decode_positive(ptx::ld_acquire_sys<int>(ptr));
+                        if (math::is_decoded_positive_ready(decoded))
+                            return true;
+
+                        if (is_last_check) {
+                            printf("DeepEP hybrid notify (scale-out %s reduction) timeout, "
+                                   "scale-out: %d, scale-up: %d, "
+                                   "thread: %d, wait scale-out: %d, decoded: %d\n",
+                                   is_expert_reduction ? "expert" : "rank",
+                                   scaleout_rank_idx, scaleup_rank_idx, thread_idx, j,
+                                   decoded);
+                        }
+                        return false;
+                    });
+
+                    // Add and clean for next usages
+                    count += decoded, *ptr = 0;
+                }
+                return count;
+            };
+
+            // Write into all scale-up peers' rank-level counters
+            #pragma unroll
+            for (int i = thread_idx; i < kNumScaleupRanks; i += kNumNotifyThreads) {
+                // Wait scale-out arrival and reduce
+                const auto count = recv_and_reduce([=](const int& scaleout_peer_idx) {
+                    return workspace_layout.get_scaleout_rank_count_ptr<false>(scaleout_peer_idx, i);
+                });
+
+                // Write into the remote scale-up peer
+                const int64_t counter = (static_cast<int64_t>(kNumScaleupRanks) << 32ll) | count;
+                gin.put_value<ncclTeamTagLsa>(
+                    workspace_layout.get_scaleup_rank_count_ptr<false>() + scaleup_rank_idx,
+                    counter, i);
+            }
+            __syncwarp();
+
+            // Atomic add into all scale-up peers' expert-level counters
+            #pragma unroll
+            for (int i = thread_idx; i < kNumExpertsPerScaleout; i += kNumNotifyThreads) {
+                // Wait scale-out arrival and reduce
+                const auto count = recv_and_reduce([=](const int& scaleout_peer_idx) {
+                    return workspace_layout.get_scaleout_expert_count_ptr<false>(scaleout_peer_idx, i);
+                }, true);
+
+                // Write into the remote scale-up peer
+                const int64_t counter = (1ll << 32ll) | count;
+                const auto dst_scaleup_rank_idx = i / kNumExpertsPerRank;
+                const auto expert_idx_in_dst_rank = i % kNumExpertsPerRank;
+                gin.red_add_rel<ncclTeamTagLsa>(
+                    workspace_layout.get_scaleup_expert_count_ptr<false>() + expert_idx_in_dst_rank,
+                    counter, dst_scaleup_rank_idx);
+            }
+            // There are shared memory reads above, a barrier is necessary
+            ptx::named_barrier<kNumNotifyThreads>(kNotifyBarrierIndex);
+
+            // NOTES: from now on, the `rank` and `expert`s size change into the local size
+            expert_count = rank_expert_count + kNumScaleupRanks;
+
+            // Wait local counters to be ready
+            // NOTES: here we only care the prefix sum by scale-up peers (used for later epilogue), not all ranks
+            EP_STATIC_ASSERT(kNumNotifyWarps == 0 or kNumScaleupRanks + kNumExpertsPerRank <= kNumNotifyWarps * 32,
+                             "Insufficient notify threads");
+            comm::timeout_while<kNumTimeoutCycles>(thread_idx < kNumScaleupRanks + kNumExpertsPerRank,
+                [&](const bool& is_last_check) {
+                const auto status = ptx::ld_volatile<int64_t>(workspace_layout.get_scaleup_rank_expert_count_ptr<false>() + thread_idx);
+                if ((status >> 32ull) == kNumScaleupRanks) {
+                    // Clean GPU workspace and write into host workspace
+                    const auto count = static_cast<int>(status & 0xffffffffll);
+                    const auto aligned_count = math::align<int>(
+                        count, thread_idx < kNumScaleupRanks ? 1 : kExpertAlignment);
+
+                    workspace_layout.get_scaleup_rank_expert_count_ptr<false>()[thread_idx] = 0;
+                    if constexpr (kDoCPUSync) {
+                        host_workspace_layout.get_scaleup_rank_expert_count_ptr<false>()[thread_idx] =
+                            math::encode_decode_positive(aligned_count);
+                    }
+
+                    // Update statistics counters
+                    if (cumulative_local_expert_recv_stats != nullptr and thread_idx >= kNumScaleupRanks)
+                        atomicAdd(cumulative_local_expert_recv_stats + (thread_idx - kNumScaleupRanks), count);
+
+                    // Write unaligned count before aligning
+                    if (num_unaligned_recv_tokens_per_expert != nullptr and thread_idx >= kNumScaleupRanks)
+                        num_unaligned_recv_tokens_per_expert[thread_idx - kNumScaleupRanks] = count;
+
+                    // Save for later prefix sum calculation
+                    rank_expert_count[thread_idx] = aligned_count;
+                    return true;
+                }
+
+                if (is_last_check) {
+                    printf("DeepEP hybrid notify (scale-up reduction) timeout,"
+                           "scale-out: %d/%d, scale-up: %d/%d, "
+                           "thread: %d, status: %d | %d, expected: %d\n",
+                           scaleout_rank_idx, kNumScaleoutRanks, scaleup_rank_idx, kNumScaleupRanks, thread_idx,
+                           static_cast<int>(status >> 32), static_cast<int>(status & 0xffffffff), kNumScaleupRanks);
+                }
+                return false;
+            });
+            ptx::named_barrier<kNumNotifyThreads>(kNotifyBarrierIndex);
+
+            // Do prefix sum by the warps of the first SM
+            // NOTES: we may have fast implementation with `cub::BlockScan`, but it is too heavy to use
+            const auto do_psum = [=](const int* count, int* out, const int n, const int is_exclusive) {
+                int psum = 0;
+                #pragma unroll
+                for (int i = 0; i < math::ceil_div(n + is_exclusive, 32); ++ i) {
+                    const auto idx = i * 32 + lane_idx;
+                    const auto mem_idx = idx - is_exclusive;
+                    const auto value = (0 <= mem_idx and mem_idx < n) ? count[mem_idx] : 0;
+                    const auto sum = psum + ptx::warp_inclusive_sum(value, lane_idx);
+
+                    // Store into global memory
+                    if (idx < n + is_exclusive)
+                        out[idx] = sum;
+
+                    // Update `psum` by using the last lane's value
+                    psum = ptx::exchange(sum, 31);
+                }
+            };
+            if (warp_idx == 0) {
+                // Inclusive prefix sum
+                do_psum(rank_count, psum_num_recv_tokens_per_scaleup_rank, kNumScaleupRanks, 0);
+            } else if (warp_idx == 1) {
+                // Exclusive prefix sum for later expanding
+                do_psum(expert_count, psum_num_recv_tokens_per_expert, kNumExpertsPerRank, 1);
+            }
+        }
+    } else if (warp_idx < kNumNotifyWarps + kNumScaleoutWarps) {
+        const int scaleout_warp_idx = warp_idx - kNumNotifyWarps;
+        const int channel_idx = sm_idx * kNumChannelsPerSM + scaleout_warp_idx;
+        const auto stage_part_header = [&](layout::BufferLayout<false>& send_ch,
+                                           const int& slot, const int& count, const bool& more) {
+            auto* hdr = send_ch.get_token_buffer(slot).get_hdr_ptr();
+            *hdr = pack_scaleout_header(dispatch_iteration, count, more);
+            ptx::fence_acq_rel_sys();
+        };
+        scaleout_recv_buffer = scaleout_recv_buffer.get_rank_buffer(scaleout_rank_idx);
+        scaleout_recv_buffer = scaleout_recv_buffer.get_channel_buffer<kNumSlotsPerChannel>(channel_idx);
+
+        // Channel metadata maintenance
+        EP_STATIC_ASSERT(kNumScaleoutRanks <= 32, "Invalid number of scale-out ranks");
+        int stored_scaleout_tail = 0, stored_old_scaleout_tail = 0;
+        int stored_combine_slot_tail = 0;
+        int coalesce_flushed = 0;
+        int stored_flushed_parts = 0;
+        int stored_flushed_subs = 0;
+        const auto cur_sub_size = [&]() {
+            const int p = stored_flushed_parts < kNumParts ? stored_flushed_parts : kNumParts - 1;
+            return sub_part_size_at<kNumSubParts>(part_size(p), stored_flushed_subs);
+        };
+        const auto is_last_sub_put = [&]() {
+            if (stored_flushed_parts != kNumParts - 1)
+                return false;
+            return stored_flushed_subs + 1 >=
+                num_sub_parts_at<kNumSubParts>(part_size(kNumParts - 1));
+        };
+        const auto flush_part = [&](const int& up_to, const bool& is_final) {
+            if (lane_idx >= kNumScaleoutRanks or lane_idx == scaleout_rank_idx)
+                return;
+            const int part_idx = stored_flushed_parts;
+            const int sub_idx = stored_flushed_subs;
+            const int count = up_to - coalesce_flushed;
+            const int slot = sub_slot(part_idx, sub_idx);
+            auto send_ch = scaleout_send_buffer.get_rank_buffer(lane_idx)
+                               .get_channel_buffer<kNumSlotsPerChannel>(channel_idx);
+            stage_part_header(send_ch, slot, count, /*more=*/not is_final);
+            const int num_put_tokens = count > 0 ? count : 1;
+            gin.put<ncclTeamTagRail>(
+                scaleout_recv_buffer.get_token_buffer(slot).get_base_ptr(),
+                send_ch.get_token_buffer(slot).get_base_ptr(),
+                scaleout_token_layout.get_num_bytes<false>() * num_put_tokens,
+                lane_idx, 0,
+                ncclGin_SignalAdd{part_signal_id(part_idx), 1ull});
+            coalesce_flushed = up_to;
+            if (sub_idx + 1 >= num_sub_parts_at<kNumSubParts>(part_size(part_idx))) {
+                stored_flushed_subs = 0;
+                stored_flushed_parts += 1;
+            } else {
+                stored_flushed_subs = sub_idx + 1;
+            }
+        };
+        const auto update_scaleout_tail = [&](const bool& finish_flag = false) {
+            if (lane_idx == scaleout_rank_idx and
+                (stored_scaleout_tail >= stored_old_scaleout_tail + kBatchSize or finish_flag)) {
+                const auto signaled_tail = math::pack2<int, int64_t>(finish_flag, stored_scaleout_tail);
+                const auto ptr = workspace_layout.get_scaleout_channel_signaled_tail_ptr(channel_idx, scaleout_rank_idx);
+                const auto old_signaled_tail = math::pack2<int, int64_t>(0, stored_old_scaleout_tail);
+
+                // NOTES: the "release" scope will be `sys` for the local rank (we may involve NVLink so not `gpu`)
+                // For RDMA requests, "release" is ensured by "atomic"
+                gin.red_add_rel<ncclTeamTagRail>(ptr, signaled_tail - old_signaled_tail, lane_idx);
+                stored_old_scaleout_tail = stored_scaleout_tail;
+            }
+            __syncwarp();
+        };
+
+        // Preload next token
+        const auto preload_next_token = [&](const int& token_idx) {
+            if (token_idx >= num_tokens)
+                return;
+
+            // Issue TMA load
+            const auto token_i64_idx = static_cast<int64_t>(token_idx);
+            if (ptx::elect_one_sync()) {
+                ptx::tma_load_1d(tma_buffer.get_hidden_ptr(), math::advance_ptr(x, token_i64_idx * kNumHiddenBytes),
+                                 mbarrier_ptr, kNumHiddenBytes);
+            }
+            __syncwarp();
+
+            // Issue SF `cp.async`
+            if constexpr (kNumSFPacks > 0) {
+                EP_STATIC_ASSERT(sizeof(sf_pack_t) % 4 == 0, "Unaligned SF element type");
+                const auto gmem_src_ptr = math::advance_ptr<sf_pack_t>(sf, token_i64_idx * sf_token_stride * sizeof(sf_pack_t));
+                const auto smem_dst_ptr = tma_buffer.get_sf_ptr();
+
+                constexpr auto kNumFullIters = kNumSFPacks / 32;
+                #pragma unroll
+                for (int k = 0; k < kNumFullIters; ++ k) {
+                    ptx::cp_async_ca(gmem_src_ptr + (k * 32 + lane_idx) * sf_hidden_stride,
+                                     smem_dst_ptr + k * 32 + lane_idx);
+                }
+                if (kNumFullIters * 32 + lane_idx < kNumSFPacks) {
+                    ptx::cp_async_ca(gmem_src_ptr + (kNumFullIters * 32 + lane_idx) * sf_hidden_stride,
+                                     smem_dst_ptr + kNumFullIters * 32 + lane_idx);
+                }
+                ptx::cp_async_mbarrier_arrive(mbarrier_ptr);
+                __syncwarp();
+            }
+        };
+
+        // Iterate all tokens
+        preload_next_token(channel_idx);
+        for (int token_idx = channel_idx; token_idx < num_tokens; token_idx += kNumChannels) {
+            // Load top-k indices and weights
+            EP_STATIC_ASSERT(kNumTopk <= 32, "Insufficient lanes for loading top-k indices");
+            int stored_dst_scaleout_rank_idx = -1, stored_dst_rank_idx = -1;
+            if (lane_idx < kNumTopk) {
+                const auto uncasted_dst_expert_idx = __ldg(topk_idx + token_idx * kNumTopk + lane_idx);
+                const auto dst_expert_idx = static_cast<int>(uncasted_dst_expert_idx);
+                stored_dst_scaleout_rank_idx = dst_expert_idx >= 0 ? dst_expert_idx / kNumExpertsPerScaleout : -1;
+                stored_dst_rank_idx = dst_expert_idx >= 0 ? dst_expert_idx / kNumExpertsPerRank : -1;
+                tma_buffer.get_topk_idx_ptr()[lane_idx] = dst_expert_idx;
+                if (topk_weights != nullptr)
+                    tma_buffer.get_topk_weights_ptr()[lane_idx] = __ldg(topk_weights + token_idx * kNumTopk + lane_idx);
+                if (copied_topk_idx != nullptr)
+                    copied_topk_idx[token_idx * kNumTopk + lane_idx] = uncasted_dst_expert_idx;
+            }
+            __syncwarp();
+
+            // Add source metadata (rank index and token index)
+            if (ptx::elect_one_sync())
+                *tma_buffer.get_src_token_global_idx_ptr() = rank_idx * kNumMaxTokensPerRank + token_idx;
+            ptx::tma_store_fence();
+            __syncwarp();
+
+            // Deduplicate ranks and assign slots
+            int stored_dst_slot_idx = -1;
+            const auto stored_old_slot_idx = ptx::exchange(
+                stored_scaleout_tail, stored_dst_scaleout_rank_idx >= 0 ? stored_dst_scaleout_rank_idx : 0);
+            if (ptx::deduplicate(stored_dst_scaleout_rank_idx, lane_idx) and stored_dst_scaleout_rank_idx >= 0)
+                stored_dst_slot_idx = stored_old_slot_idx;
+
+            // Update scale-out tail
+            const auto scaleout_rank_mask = ptx::reduce_or(stored_dst_scaleout_rank_idx >= 0 ? (1u << stored_dst_scaleout_rank_idx) : 0u);
+            stored_scaleout_tail += (scaleout_rank_mask >> lane_idx) & 1;
+
+            // Build the map that combine will use to gather partials back.
+            //
+            // Terminology:
+            //   T          — token index (per-rank, this rank's PyTorch tensor slot)
+            //   k          — top-k slot within a token
+            //   G          — global rank id (0 .. ScaleoutRank × ScaleupRank - 1)
+            //   scaleout   — G / ScaleupRank, i.e. which node this global rank sits on
+            //
+            // Setup: T=0, channel=7, topK=4, ScaleoutRank=8, ScaleUpRank=8 (64 global ranks total).
+            //   Routing: (k=0 → G=9 → scaleout=1),
+            //            (k=1 → G=2 → scaleout=0),
+            //            (k=2 → G=5 → scaleout=0),   ← same scaleout as k=1
+            //            (k=3 → G=20 → scaleout=2).
+            //
+            // Each map entry is a `pack(scaleout_rank, slot, channel)` tuple naming the recv slot
+            // where combine will place this k's return partial on my `scaleout_recv_buffer`.
+            //
+            // Reduce mode: k's targeting the same scaleout rank share one recv slot (combine
+            // reduces their partials into one before RDMA):
+            //   map[0][0..3] = [ pack(1,0,7), pack(0,0,7), pack(0,0,7), pack(2,0,7) ]
+            //                                              ^ k=2 shares k=1's slot on scaleout=0
+            //
+            // Expand mode: each valid k gets its own slot within its scaleout rank's group,
+            // packed contiguously:
+            //   map[0][0..3] = [ pack(1,0,7), pack(0,0,7), pack(0,1,7), pack(2,0,7) ]
+            //                                              ^ k=2 lands at slot=1 next to k=1's slot=0
+            //
+            // Plain mode (no expand, no multiple reduction): one slot per destination GLOBAL
+            // rank. k's routed to the same global rank share their master's slot; k's on
+            // different global ranks get their own slots even when those ranks sit on the
+            // same scaleout rank. With the routing above (k=1 -> G=2 and k=2 -> G=5 are
+            // different global ranks) the map matches the expand one:
+            //   map[0][0..3] = [ pack(1,0,7), pack(0,0,7), pack(0,1,7), pack(2,0,7) ]
+            // If k=2 instead targeted G=2 (same global rank as k=1), they would share:
+            //   map[0][0..3] = [ pack(1,0,7), pack(0,0,7), pack(0,0,7), pack(2,0,7) ]
+            //                                              ^ k=2 shares k=1's slot (same G)
+            if constexpr (not kReuseSlotIndices) {
+                int combine_slot;
+
+                const int combine_slot_base = ptx::exchange(
+                    stored_combine_slot_tail,
+                    stored_dst_scaleout_rank_idx >= 0 ? stored_dst_scaleout_rank_idx : 0);
+
+                // If reduction enabled, then each token consume signle slot per scaleout rank.
+                if constexpr (kAllowMultipleReduction) {
+                    combine_slot = combine_slot_base;
+                } else if constexpr (kDoExpand) {
+                    // Expanded combine returns one partial per valid k, each at its own slot.
+                    const uint32_t same_rank_mask = ptx::match(stored_dst_scaleout_rank_idx);
+                    const uint32_t below_mask = same_rank_mask & ((1u << lane_idx) - 1u);
+                    combine_slot = combine_slot_base + __popc(below_mask);
+                } else {
+                    // Plain combine returns one partial per destination rank, so k's sharing a
+                    // rank share their master's slot. Index by the master lane, which makes the
+                    // offset identical for every k of the group.
+                    const uint32_t master_mask = ptx::gather(
+                        ptx::deduplicate(stored_dst_rank_idx, lane_idx) and stored_dst_rank_idx >= 0);
+                    const uint32_t same_scaleout_mask = ptx::match(stored_dst_scaleout_rank_idx);
+                    const int master_lane_idx = ptx::get_master_lane_idx(ptx::match(stored_dst_rank_idx));
+                    const uint32_t below_mask = (1u << master_lane_idx) - 1u;
+                    combine_slot = combine_slot_base + __popc(master_mask & same_scaleout_mask & below_mask);
+                }
+
+                if (lane_idx < kNumTopk) {
+                    const int packed = stored_dst_scaleout_rank_idx >= 0
+                        ? pack_combine_recv_addr(stored_dst_scaleout_rank_idx, combine_slot, channel_idx)
+                        : -1;
+                    token_map_at_dispatch[token_idx * kNumTopk + lane_idx] = packed;
+                }
+                __syncwarp();
+
+                if constexpr (kAllowMultipleReduction) {
+                    stored_combine_slot_tail += (scaleout_rank_mask >> lane_idx) & 1;
+                } else {
+                    const uint32_t counted_mask = kDoExpand ?
+                        0xffffffffu :
+                        ptx::gather(ptx::deduplicate(stored_dst_rank_idx, lane_idx));
+                    int my_targeted_count = 0;
+                    #pragma unroll
+                    for (int k = 0; k < kNumTopk; ++ k) {
+                        const int R_k = __shfl_sync(0xffffffff, stored_dst_scaleout_rank_idx, k);
+                        const bool counted = (counted_mask >> k) & 1u;
+                        my_targeted_count += (R_k == lane_idx and R_k >= 0 and counted) ? 1 : 0;
+                    }
+                    stored_combine_slot_tail += my_targeted_count;
+                }
+            }
+
+            if (ptx::elect_one_sync()) {
+                ptx::mbarrier_arrive_and_set_tx(mbarrier_ptr, kNumHiddenBytes);
+                ptx::mbarrier_wait_and_flip_phase(mbarrier_ptr, phase);
+            }
+            __syncwarp();
+            if (stored_dst_slot_idx >= 0 and stored_dst_scaleout_rank_idx != scaleout_rank_idx) {
+                auto send_ch = scaleout_send_buffer.get_rank_buffer(stored_dst_scaleout_rank_idx)
+                                   .get_channel_buffer<kNumSlotsPerChannel>(channel_idx);
+                ptx::tma_store_1d(send_ch.get_token_buffer(stored_dst_slot_idx).get_base_ptr(),
+                                  tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
+            }
+            __syncwarp();
+
+            // Local rank can be bypassed
+            if (stored_dst_slot_idx >= 0 and stored_dst_scaleout_rank_idx == scaleout_rank_idx) {
+                ptx::tma_store_1d(scaleout_recv_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(),
+                                  tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
+            }
+            ptx::tma_store_commit();
+            ptx::tma_store_wait();
+            __syncwarp();
+
+            // Preload the next token (overlapping with the scale-out put issues)
+            preload_next_token(token_idx + kNumChannels);
+
+            if (stored_flushed_parts < kNumParts and
+                stored_scaleout_tail >= coalesce_flushed + cur_sub_size()) {
+                flush_part(stored_scaleout_tail, /*is_final=*/is_last_sub_put());
+            }
+            __syncwarp();
+
+            // Issue scale-out tail update
+            update_scaleout_tail();
+        }
+
+        if (stored_scaleout_tail > coalesce_flushed) {
+            flush_part(stored_scaleout_tail, /*is_final=*/true);
+        } else if (stored_flushed_parts < kNumParts) {
+            flush_part(coalesce_flushed, /*is_final=*/true);
+        }
+        __syncwarp();
+
+        // Flush unflushed tails
+        update_scaleout_tail(true);
+
+    } else {
+        const int forward_warp_idx = warp_idx - (kNumNotifyWarps + kNumScaleoutWarps);
+        const int channel_idx = sm_idx * kNumChannelsPerSM + forward_warp_idx;
+        int64_t rx_part_base[kNumParts];
+        #pragma unroll
+        for (int p = 0; p < kNumParts; ++ p)
+            rx_part_base[p] = static_cast<int64_t>(*gin.gin.getSignalShadowPtr(part_signal_id(p)));
+        scaleout_recv_buffer = scaleout_recv_buffer.get_channel_buffer<kNumSlotsPerChannel>(channel_idx);
+        scaleup_buffer = scaleup_buffer.get_rank_buffer(scaleup_rank_idx);
+
+        const auto read_batch_header = [&](const int& src, const int& part_idx, const int& sub_idx) -> int64_t {
+            return ptx::ld_acquire_sys<int64_t>(
+                scaleout_recv_buffer.get_rank_buffer(src)
+                    .get_token_buffer(sub_slot(part_idx, sub_idx)).get_hdr_ptr());
+        };
+
+        // Shape of `token_metadata_at_forward`: `[kNumChannels, kNumScaleoutRanks * kNumMaxTokensPerChannel + 1, kNumForwardMetadataDims]`
+        constexpr int kNumForwardMetadataDims = 2 + kNumTopk * 2;
+        token_metadata_at_forward += channel_idx * ((kNumScaleoutRanks * kNumMaxTokensPerChannel + 1) * kNumForwardMetadataDims);
+
+        // Shape of `dst_buffer_slot_idx`: `[kNumChannels, kNumScaleoutRanks, kNumMaxTokensPerChannel, kNumTopk]`
+        dst_buffer_slot_idx += channel_idx * (kNumScaleoutRanks * kNumMaxTokensPerChannel * kNumTopk);
+
+        // Transform linked list index
+        const auto transform_linked_list_idx = [=](const int& idx) {
+            constexpr int kNumTokensInLinkedList = kNumMaxTokensPerChannel * kNumScaleoutRanks + 1;
+            return channel_idx * (kNumTokensInLinkedList * kNumScaleupRanks) +
+                idx * kNumScaleupRanks + scaleup_rank_idx;
+        };
+
+        // Forward tokens from scale-out ranks
+        EP_STATIC_ASSERT(kNumScaleoutRanks <= 32, "Too many scale-out ranks");
+        int num_tokens_processed = 0;
+        int stored_scaleout_old_tail_idx = 0;
+        int stored_scaleup_send_counters[kNumScaleupRanksPerLane] = {};
+        int stored_finish_flag = lane_idx >= kNumScaleoutRanks;
+        int stored_scaleout_tail_idx = 0;
+        int recv_scaleout_rank_idx = channel_idx % kNumScaleoutRanks;
+        int stored_terminal_part = -1;
+        int stored_terminal_sub = -1;
+        uint32_t wip_mask;
+        while ((wip_mask = ptx::gather(stored_scaleout_tail_idx > stored_scaleout_old_tail_idx or stored_finish_flag == 0))) {
+            // Pick next rank in round-robin
+            const auto offset = (recv_scaleout_rank_idx + 1) % kNumScaleoutRanks;
+            const auto hi_mask = (wip_mask >> offset) << offset;
+            recv_scaleout_rank_idx = hi_mask ? ptx::ffs(hi_mask) : ptx::ffs(wip_mask);
+
+            // Wait for this rank to have data (or finish)
+            comm::timeout_while<kNumTimeoutCycles>([&](const bool& is_last_check) {
+                const uint32_t arrived_or_finished =
+                    stored_scaleout_tail_idx > stored_scaleout_old_tail_idx or stored_finish_flag > 0;
+                if (ptx::exchange(arrived_or_finished, recv_scaleout_rank_idx))
+                    return true;
+
+                // Timeout
+                if (is_last_check) {
+                    if (lane_idx < kNumScaleoutRanks) {
+                        printf("DeepEP hybrid dispatch (forwarding) timeout, scale-out: %d, scale-up: %d, "
+                               "channel: %d, lane: %d, old scale-out tail: %d, scale-out tail: (%d, %d)\n",
+                               scaleout_rank_idx, scaleup_rank_idx,
+                               channel_idx, lane_idx, stored_scaleout_old_tail_idx,
+                               stored_finish_flag, stored_scaleout_tail_idx);
+                    }
+                    return false;
+                }
+
+                const bool src_valid = lane_idx < kNumScaleoutRanks;
+                const bool is_local_src = (lane_idx == scaleout_rank_idx);
+                int intended_finish = 0, intended_tail = 0;
+                if (is_local_src) {
+                    const auto signaled_tail = ptx::ld_acquire_sys<int64_t>(
+                        workspace_layout.get_scaleout_channel_signaled_tail_ptr(channel_idx, lane_idx));
+                    math::unpack2<int, int64_t>(signaled_tail, intended_finish, intended_tail);
+                }
+                const bool is_remote_src = src_valid and not is_local_src;
+                int incremental_tail = stored_scaleout_tail_idx;
+                bool prefix_alive = is_remote_src;
+                bool my_finished = false;
+                #pragma unroll
+                for (int k = 0; k < kNumParts; ++ k) {
+                    const int64_t landed =
+                        static_cast<int64_t>(gin.gin.readSignal(part_signal_id(k)))
+                        - rx_part_base[k];
+
+                    const int num_subs = num_sub_parts_at<kNumSubParts>(part_size(k));
+                    int sub_count[kNumSubParts];
+                    bool sub_more[kNumSubParts];
+                    bool sub_valid[kNumSubParts];
+                    int num_valid = 0;
+                    #pragma unroll
+                    for (int s = 0; s < kNumSubParts; ++ s) {
+                        sub_count[s] = 0;
+                        sub_more[s] = false;
+                        sub_valid[s] = false;
+                        if (s < num_subs) {
+                            sub_valid[s] = is_remote_src and
+                                unpack_scaleout_header(read_batch_header(lane_idx, k, s),
+                                                       dispatch_iteration, sub_count[s], sub_more[s]);
+                            num_valid += __popc(ptx::gather(sub_valid[s]));
+                        }
+                    }
+                    const bool part_landed = landed >= static_cast<int64_t>(num_valid);
+
+                    #pragma unroll
+                    for (int s = 0; s < kNumSubParts; ++ s) {
+                        if (s >= num_subs)
+                            continue;
+                        const bool through = prefix_alive and sub_valid[s] and part_landed;
+                        if (through)
+                            incremental_tail = sub_slot(k, s) + sub_count[s];
+                        if (through and not sub_more[s]) {
+                            my_finished = true;
+                            stored_terminal_part = k;
+                            stored_terminal_sub = s;
+                        }
+                        prefix_alive = through;
+                    }
+                }
+                if (is_local_src) {
+                    stored_finish_flag       = intended_finish;
+                    stored_scaleout_tail_idx = intended_tail;
+                } else if (src_valid) {
+                    if (incremental_tail > stored_scaleout_tail_idx)
+                        stored_scaleout_tail_idx = incremental_tail;
+                    if (my_finished)
+                        stored_finish_flag = 1;
+                }
+                __syncwarp();
+                return false;
+            });
+
+            // Process one chunk from the current rank
+            const auto start_slot_idx = ptx::exchange(stored_scaleout_old_tail_idx, recv_scaleout_rank_idx);
+            const auto end_slot_idx = std::min(
+                ptx::exchange(stored_scaleout_tail_idx, recv_scaleout_rank_idx),
+                start_slot_idx + kNumSlotsPerForwardChunk
+            );
+            if (lane_idx == recv_scaleout_rank_idx)
+                stored_scaleout_old_tail_idx = end_slot_idx;
+
+            const auto recv_buffer = scaleout_recv_buffer.get_rank_buffer(recv_scaleout_rank_idx);
+
+            const layout::TokenLayout fwd_bufs[2] = {tma_buffer, tma_buffer_alt};
+            ptx::mbarrier* const fwd_mbs[2] = {mbarrier_ptr, mbarrier_ptr_alt};
+            ptx::arrival_phase* const fwd_phases[2] = {&phase, &phase_alt};
+            const auto issue_fwd_load = [&](const int& b, const int& slot) {
+                const auto tb = recv_buffer.get_token_buffer(slot);
+                if (ptx::elect_one_sync()) {
+                    ptx::tma_load_1d(fwd_bufs[b].get_base_ptr(), tb.get_base_ptr(),
+                                     fwd_mbs[b], token_layout.get_num_bytes<false>());
+                    ptx::mbarrier_arrive_and_set_tx(fwd_mbs[b], token_layout.get_num_bytes<false>());
+                }
+                __syncwarp();
+            };
+
+            if constexpr (kDoubleBufferForward) {
+                ptx::tma_store_wait();
+                __syncwarp();
+                if (start_slot_idx < end_slot_idx)
+                    issue_fwd_load(0, start_slot_idx);
+            }
+
+            for (int slot_idx = start_slot_idx; slot_idx < end_slot_idx; ++ slot_idx) {
+                const int cur = (slot_idx - start_slot_idx) & 1;
+                const auto& tma_buffer = fwd_bufs[kDoubleBufferForward ? cur : 0];
+
+                if constexpr (kDoubleBufferForward) {
+                    // Wait for this slot's load to complete.
+                    if (ptx::elect_one_sync())
+                        ptx::mbarrier_wait_and_flip_phase(fwd_mbs[cur], *fwd_phases[cur]);
+                    __syncwarp();
+
+                    if (slot_idx + 1 < end_slot_idx) {
+                        ptx::tma_store_wait();
+                        __syncwarp();
+                        issue_fwd_load(cur ^ 1, slot_idx + 1);
+                    }
+                } else {
+                    // Original single-buffer path: load this slot synchronously.
+                    ptx::tma_store_wait();
+                    __syncwarp();
+                    issue_fwd_load(0, slot_idx);
+                    if (ptx::elect_one_sync())
+                        ptx::mbarrier_wait_and_flip_phase(fwd_mbs[0], *fwd_phases[0]);
+                    __syncwarp();
+                }
+
+                // Read top-k indices
+                EP_STATIC_ASSERT(kNumTopk <= 32, "Too many top-k selections");
+                int stored_dst_scaleup_rank_idx = -1;
+                auto dst_expert_idx = lane_idx < kNumTopk ? tma_buffer.get_topk_idx_ptr()[lane_idx] : -1;
+                dst_expert_idx -= scaleout_rank_idx * kNumExpertsPerScaleout;
+                stored_dst_scaleup_rank_idx = 0 <= dst_expert_idx and dst_expert_idx < kNumExpertsPerScaleout ?
+                    dst_expert_idx / kNumExpertsPerRank : -1;
+
+                // Write the per-scaleup channel index for this token
+                int linked_list_idx = -1;
+                #pragma unroll
+                for (int j = 0; j < kNumScaleupRanksPerLane; ++ j) {
+                    const auto src_lane_idx = stored_dst_scaleup_rank_idx - j * 32;
+                    const bool valid = 0 <= src_lane_idx and src_lane_idx < 32;
+                    const auto exchanged = ptx::exchange(
+                        stored_scaleup_send_counters[j], valid ? src_lane_idx : 0);
+                    linked_list_idx = valid ? exchanged : linked_list_idx;
+                }
+                if (not kReuseSlotIndices and lane_idx < kNumTopk) {
+                    tma_buffer.get_linked_list_idx_ptr()[lane_idx] = transform_linked_list_idx(linked_list_idx);
+                    ptx::tma_store_fence();
+                }
+                __syncwarp();
+
+                // Deduplicate for scale-up ranks
+                int stored_dst_slot_idx = -1;
+                const auto dst_slot_idx_ptr = dst_buffer_slot_idx +
+                    recv_scaleout_rank_idx * (kNumMaxTokensPerChannel * kNumTopk) + slot_idx * kNumTopk;
+                if constexpr (kReuseSlotIndices) {
+                    if (lane_idx < kNumTopk)
+                        stored_dst_slot_idx = __ldg(dst_slot_idx_ptr + lane_idx);
+                } else {
+                    // Deduplicate for NVLink ranks
+                    if (ptx::deduplicate(stored_dst_scaleup_rank_idx, lane_idx) and stored_dst_scaleup_rank_idx >= 0)
+                        stored_dst_slot_idx = atomicAdd(workspace_layout.get_scaleup_atomic_sender_counter() + stored_dst_scaleup_rank_idx, 1);
+                }
+                __syncwarp();
+
+                // Issue TMAs
+                if (stored_dst_slot_idx >= 0) {
+                    const auto dst_ptr = gin.get_sym_ptr<ncclTeamTagLsa>(
+                        scaleup_buffer.get_token_buffer(stored_dst_slot_idx).get_base_ptr(),
+                        stored_dst_scaleup_rank_idx);
+                    ptx::tma_store_1d(dst_ptr, tma_buffer.get_base_ptr(), tma_buffer.get_num_bytes<false>());
+                    ptx::tma_store_commit();
+                }
+                __syncwarp();
+
+                // Add per-scale-up counter
+                EP_STATIC_ASSERT(kNumScaleupRanks <= 64, "Invalid number of scale-up peers");
+                using mask_t = std::conditional_t<kNumScaleupRanks <= 32, unsigned, unsigned long long>;
+                const auto scaleup_send_mask = ptx::reduce_or(
+                    stored_dst_scaleup_rank_idx >= 0 ?
+                    (mask_t(1) << stored_dst_scaleup_rank_idx) : mask_t(0));
+                #pragma unroll
+                for (int j = 0; j < kNumScaleupRanksPerLane; ++ j)
+                    stored_scaleup_send_counters[j] += (scaleup_send_mask >> (j * 32 + lane_idx)) & 1;
+
+                // Record metadata at forward
+                if constexpr (not kReuseSlotIndices) {
+                    EP_STATIC_ASSERT(kNumTopk <= 32, "Invalid number of selections");
+                    const auto metadata_ptr = token_metadata_at_forward +
+                        num_tokens_processed * kNumForwardMetadataDims;
+
+                    // Source token index and last token index flag
+                    if (ptx::elect_one_sync()) {
+                        metadata_ptr[0] = tma_buffer.get_src_token_global_idx_ptr()[0];
+                        metadata_ptr[1] = slot_idx == (end_slot_idx - 1);
+                    }
+
+                    // Second, original top-k indices and destination slots
+                    if (lane_idx < kNumTopk) {
+                        metadata_ptr[2 + lane_idx] = stored_dst_scaleup_rank_idx;
+                        metadata_ptr[2 + kNumTopk + lane_idx] = stored_dst_slot_idx;
+                        dst_slot_idx_ptr[lane_idx] = stored_dst_slot_idx;
+                    }
+                }
+                num_tokens_processed += 1;
+                __syncwarp();
+            }
+        }
+
+        // Assign the source token index part of the metadata into `-1` as an ending mark
+        if (not kReuseSlotIndices and ptx::elect_one_sync())
+            token_metadata_at_forward[num_tokens_processed * kNumForwardMetadataDims] = -1;
+        __syncwarp();
+
+        // Update linked list's ending position
+        if constexpr (not kReuseSlotIndices) {
+            const auto tail_ptr = workspace_layout.get_channel_scaleup_tail_ptr(channel_idx, scaleup_rank_idx);
+            #pragma unroll
+            for (int i = 0; i < kNumScaleupRanksPerLane; ++ i) {
+                if (const auto j = i * 32 + lane_idx; i < (kNumScaleupRanksPerLane - 1) or j < kNumScaleupRanks) {
+                    ptx::st_relaxed_sys(
+                        gin.get_sym_ptr<ncclTeamTagLsa>(tail_ptr, j),
+                        transform_linked_list_idx(stored_scaleup_send_counters[i]));
+                }
+            }
+        }
+        __syncwarp();
+
+        EP_STATIC_ASSERT(kNumParts <= 32, "One lane drains one part");
+        #pragma unroll
+        for (int k = 0; k < kNumParts; ++ k) {
+            const int num_subs_k = num_sub_parts_at<kNumSubParts>(part_size(k));
+            const int my_subs_k = stored_terminal_part > k  ? num_subs_k
+                                : stored_terminal_part == k ? stored_terminal_sub + 1
+                                                            : 0;
+            const int expected_k = ptx::reduce_add(my_subs_k);
+            if (lane_idx == k and expected_k > 0) {
+                comm::timeout_while<kNumTimeoutCycles>([&](const bool& is_last_check) {
+                    const int64_t landed =
+                        static_cast<int64_t>(gin.gin.readSignal(part_signal_id(k))) - rx_part_base[k];
+                    if (landed >= static_cast<int64_t>(expected_k))
+                        return true;
+                    if (is_last_check)
+                        printf("DeepEP hybrid dispatch (epilogue shadow drain) timeout, "
+                               "channel: %d, part: %d, landed: %lld, expected: %d\n",
+                               channel_idx, k, (long long)landed, expected_k);
+                    return false;
+                });
+                gin.gin.increaseSignalShadow(part_signal_id(k), static_cast<uint64_t>(expected_k));
+            }
+        }
+        __syncwarp();
+
+        if (lane_idx < kNumScaleoutRanks)
+            *workspace_layout.get_scaleout_channel_signaled_tail_ptr(channel_idx, lane_idx) = 0;
+        __syncwarp();
+    }
+
+    // Scale-up barrier to ensure data arrival
+    // As scale-out tokens have already been consumed by forwarders, no need to do scale-out barrier again
+    comm::gpu_barrier<true, kNumScaleoutRanks, kNumScaleupRanks,
+                      kNumSMs, kNumThreads, kNumQPs, kNumTimeoutCycles, comm::kHybridDispatchTag1, true, true, false>(
+        gin, workspace_layout, scaleout_rank_idx, scaleup_rank_idx, sm_idx, thread_idx, /* do not scale-out */ false, true);
+
+    // Trigger the copy epilogue kernel
+    cudaTriggerProgrammaticLaunchCompletion();
+
+    // Clean scale-up counters
+    // All scale-out counters should be cleaned before
+    EP_STATIC_ASSERT(kNumScaleupRanks <= kNumThreads, "Insufficient threads");
+    if (not kReuseSlotIndices and sm_idx == 0 and thread_idx < kNumScaleupRanks)
+        workspace_layout.get_scaleup_atomic_sender_counter()[thread_idx] = 0;
+}
+
+}  // namespace deep_ep::elastic

--- a/deep_ep/include/deep_ep/impls/pp_send_recv.cuh
+++ b/deep_ep/include/deep_ep/impls/pp_send_recv.cuh
@@ -1,5 +1,16 @@
 #pragma once
 
+// MIT License
+//
+// Copyright (c) 2025 DeepSeek
+// Changes and additions copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 #include <cooperative_groups.h>
 #include <deep_ep/common/comm.cuh>
 #include <deep_ep/common/layout.cuh>
@@ -21,11 +32,10 @@ __device__ __forceinline__ void check_signal(
     const ncclGinSignal_t& signal_idx,
     const int64_t& target,
     const timeout_print_t& timeout_print) {
-    const auto gdaki = static_cast<struct ncclGinGdakiGPUContext*>(gin.gin._ginHandle) + gin.gin.contextId;
-    const auto signal_ptr = reinterpret_cast<int64_t*>(
-        __ldg(reinterpret_cast<int64_t*>(&gdaki->signals_table.buffer))) + signal_idx;
+    // TODO(NCCL): Using the official NCCL wait signal API, after they added timeout check.
     comm::timeout_while<kNumTimeoutCycles>([=](const bool& is_last_check) {
-        const auto signal = ptx::ld_acquire_sys<int64_t>(signal_ptr);
+        const auto signal = static_cast<int64_t>(
+            gin.gin.readSignal(signal_idx, 64, cuda::memory_order_acquire));
         if (signal >= target)
             return true;
 

--- a/deep_ep/include/deep_ep/impls/proxy_ring.cuh
+++ b/deep_ep/include/deep_ep/impls/proxy_ring.cuh
@@ -1,0 +1,89 @@
+#pragma once
+
+// MIT License
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#include <cstdint>
+
+namespace deep_ep::elastic {
+
+struct ProxyPutDesc {
+    void* send_ptr;
+    void* recv_ptr;
+    int   num_bytes;
+    int   dst;
+};
+static_assert(sizeof(ProxyPutDesc) == 24, "ProxyPutDesc must be tightly packed (2 ptrs + 2 ints)");
+
+inline constexpr int kProxyRingDepthDefault = 20;
+inline constexpr int kProxyControlWordsPerForwardWarp = 3;   // head, tail, done
+
+// Shared-memory layout for the proxy warp hand-off rings
+// (n = num_forward_warps):
+//   memory layout = [ring[n*depth], head[n], tail[n], done[n]]
+struct ProxyRingLayout {
+    int num_forward_warps;
+    int ring_depth;
+    void* base;
+
+    __forceinline__ __device__ __host__
+    ProxyRingLayout(const int& num_forward_warps, const int& ring_depth, void* base = nullptr) :
+        num_forward_warps(num_forward_warps), ring_depth(ring_depth), base(base) {}
+
+    // Region starts (warp 0). Each region begins where the previous one ends.
+    __forceinline__ __device__ __host__
+    ProxyPutDesc* get_ring_base() const {
+        return reinterpret_cast<ProxyPutDesc*>(base);
+    }
+    __forceinline__ __device__ __host__
+    unsigned* get_head_base() const {
+        return reinterpret_cast<unsigned*>(get_ring_base() + num_forward_warps * ring_depth);
+    }
+    __forceinline__ __device__ __host__
+    unsigned* get_tail_base() const {
+        return get_head_base() + num_forward_warps;
+    }
+    __forceinline__ __device__ __host__
+    int* get_done_base() const {
+        return reinterpret_cast<int*>(get_tail_base() + num_forward_warps);
+    }
+
+    // Per-forward-warp entities.
+    __forceinline__ __device__ __host__
+    ProxyPutDesc* get_ring(const int& forward_warp_idx) const {
+        return get_ring_base() + forward_warp_idx * ring_depth;
+    }
+    __forceinline__ __device__ __host__
+    unsigned* get_head(const int& forward_warp_idx) const {
+        return get_head_base() + forward_warp_idx;
+    }
+    __forceinline__ __device__ __host__
+    unsigned* get_tail(const int& forward_warp_idx) const {
+        return get_tail_base() + forward_warp_idx;
+    }
+    __forceinline__ __device__ __host__
+    int* get_done(const int& forward_warp_idx) const {
+        return get_done_base() + forward_warp_idx;
+    }
+
+    __forceinline__ __device__ __host__
+    void* get_end_ptr() const {
+        return get_done_base() + num_forward_warps;
+    }
+
+    __forceinline__ __device__ __host__
+    static int64_t get_num_bytes(const int& num_forward_warps, const int& ring_depth) {
+        return static_cast<int64_t>(num_forward_warps) *
+               (static_cast<int64_t>(ring_depth) * static_cast<int64_t>(sizeof(ProxyPutDesc)) +
+                static_cast<int64_t>(kProxyControlWordsPerForwardWarp) * static_cast<int64_t>(sizeof(int)));
+    }
+};
+
+}  // namespace deep_ep::elastic


### PR DESCRIPTION
The hybrid (scale-out) dispatch/combine kernels synchronize through a trailing tail signal: the receiver assumes that when the tail arrives, all data written before it has landed. This holds on transports with ordered delivery and VA/strong signal support (e.g. IB RC), but not on unordered transports such as AWS EFA (SRD), it can be overcome with proxy thread but will hurt the performance. This PR adds an alternative kernel pair that only needs weak signals, so DeepEP's hybrid mode can run on those transports.                                                                              

The default behavior is unchanged: `EP_HYBRID_KERNEL` defaults to `ordered`, which runs the existing kernels under the existing communication configuration, untouched and under their original file names. Setting `EP_HYBRID_KERNEL=unordered` selects the new pair.  