### PR TITLE
fix: invalidate non-sync dispatch padding metadata

### DIFF
--- a/deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh
+++ b/deep_ep/include/deep_ep/impls/dispatch_copy_epilogue.cuh
@@ -59,8 +59,11 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
     // NOTES: PDL is used, please do not use `__ldg`
     cudaGridDependencySynchronize();
 
-    // For no CPU sync case, the number of received tokens should be read from the GPU tensor
-    if (num_recv_tokens == kNumMaxTokensPerRank * kNumRanks)
+    // For no CPU sync case, the number of received tokens should be read from the GPU tensor.
+    // Keep this flag so that the output capacity can be distinguished from the actual count
+    // after `num_recv_tokens` is overwritten below.
+    const bool has_worst_case_output = num_recv_tokens == kNumMaxTokensPerRank * kNumRanks;
+    if (has_worst_case_output)
         num_recv_tokens = psum_num_recv_tokens_per_scaleup_rank[kNumScaleupRanks - 1];
 
     // Current rank indices should be maintained
@@ -204,6 +207,21 @@ dispatch_copy_epilogue_impl(void* buffer, void* workspace,
             if (kDoExpand and lane_idx < kNumTopk)
                 recv_src_metadata[i * kMetadataStride + 2 + lane_idx] = dst_tensor_idx;
             __syncwarp();
+        }
+    }
+
+    // Non-expand/no-CPU-sync dispatch allocates output tensors for the worst case, while the
+    // copy loop above only writes the received prefix.  A stale top-k index in the unwritten
+    // suffix can be interpreted as a real expert by consumers that process the whole capture
+    // buffer.  Mark the suffix as invalid without adding another kernel launch.
+    if constexpr (not kDoExpand) {
+        if (has_worst_case_output) {
+            for (int i = num_recv_tokens + global_warp_idx;
+                 i < kNumMaxTokensPerRank * kNumRanks;
+                 i += kNumWarps * kNumSMs) {
+                if (lane_idx < kNumTopk)
+                    recv_topk_idx[i * kNumTopk + lane_idx] = static_cast<topk_idx_t>(-1);
+            }
         }
     }
 

--- a/tests/elastic/test_ep.py
+++ b/tests/elastic/test_ep.py
@@ -82,6 +82,7 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
 
     # Run all tests
     dist_print('Running all test cases:', once_in_node=True)
+    padding_poisoned = False
     for (do_handle_copy, expert_alignment, use_fp8_dispatch, num_bias,
          with_previous_event, async_with_compute_stream, allocate_on_comm_stream) in enumerate_ep_modes():
         dist_print(f' > Testing with '
@@ -141,6 +142,14 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
             torch.cuda.synchronize()
 
         # Do dispatch
+        if not args.skip_check and not args.do_cpu_sync and not padding_poisoned:
+            # Make stale allocator contents observable in the worst-case output suffix.
+            stale_recv_topk_idx = [torch.zeros(
+                (num_max_tokens_per_rank * buffer.num_ranks, num_topk),
+                dtype=topk_idx.dtype, device='cuda') for _ in range(2)]
+            torch.cuda.synchronize()
+            del stale_recv_topk_idx
+            padding_poisoned = True
         dispatch_args = dict(
             x=x, topk_idx=topk_idx, topk_weights=topk_weights,
             num_sms=num_sms, num_qps=num_qps,
@@ -181,6 +190,12 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
         assert num_recv_tokens == expanded_handle.psum_num_recv_tokens_per_scaleup_rank[-1].item(), \
                'Expand should not affect the number of received tokens.'
         num_expanded_tokens = expanded_handle.psum_num_recv_tokens_per_expert[-1].item()
+
+        if not args.skip_check and not args.do_cpu_sync:
+            assert (recv_topk_idx[num_recv_tokens:] == -1).all(), \
+                'Non-expand dispatch must invalidate worst-case output padding.'
+            assert (cached_recv_topk_idx[num_recv_tokens:] == -1).all(), \
+                'Cached non-expand dispatch must invalidate worst-case output padding.'
 
         # Construction the input data for DeepEP combine
         src_token_global_idx = handle.recv_src_metadata[:num_recv_tokens, 0]

--- a/tests/elastic/test_ep.py
+++ b/tests/elastic/test_ep.py
@@ -143,7 +143,8 @@ def test_dispatch_combine(buffer: deep_ep.ElasticBuffer, args: argparse.Namespac
 
         # Do dispatch
         if not args.skip_check and not args.do_cpu_sync and not padding_poisoned:
-            # Make stale allocator contents observable in the worst-case output suffix.
+            # Poison the normal and cached recv_topk_idx allocations. Zero is a valid local
+            # expert ID, so stale allocator contents remain observable in the output suffix.
             stale_recv_topk_idx = [torch.zeros(
                 (num_max_tokens_per_rank * buffer.num_ranks, num_topk),
                 dtype=topk_idx.dtype, device='cuda') for _ in range(2)]


### PR DESCRIPTION

## Summary

Initialize the unused suffix of `recv_topk_idx` to `-1` for non-expand
dispatches that allocate worst-case output buffers without a CPU
synchronization.

This fixes a correctness issue encountered by vLLM's DeepEP V2
decode/CUDA Graph path, where stale padding entries can be interpreted as
valid expert IDs and corrupt routing data. vLLM currently works around the
issue by sanitizing the metadata downstream:

https://github.com/vllm-project/vllm/commit/04c2a8deac44fdb1ca3e2b5ec3e6bf16f3f6a914

The initialization is performed by the existing dispatch copy epilogue, so it
does not add another kernel launch or require a host synchronization.

## Problem

When `ElasticBuffer.dispatch` runs with `do_cpu_sync=False` and
`do_expand=False`, its output tensors are allocated for the worst-case number
of received tokens. The dispatch copy epilogue reads the actual received token
count from the GPU prefix sum, but it only writes the valid prefix of each
output tensor.

Because `recv_topk_idx` is allocated with `torch::empty`, rows after the actual
received count may contain stale allocator data. A consumer that processes the
complete fixed-shape CUDA Graph buffer can interpret a stale, non-negative
value as a valid local expert ID. This can add padding rows to expert routing
lists and corrupt the results of valid tokens.

The linked vLLM fix sanitizes the same uninitialized DeepEP V2 metadata in its
downstream decode/CUDA Graph integration.

DeepEP's legacy dispatch kernels also use `-1` for unused `recv_topk_idx`
entries, so the fix makes the elastic path follow the existing invalid-expert
sentinel convention.

## Fix

Before replacing the worst-case `num_recv_tokens` argument with the
GPU-resident actual count, record whether the epilogue received a worst-case
output allocation. For non-expand dispatch, use the existing epilogue
kernel/grid to write `-1` to `recv_topk_idx[actual_count:capacity]`.

This change:

- covers both normal and cached non-sync dispatch;
- adds no kernel launch and no host synchronization;
- is compiled out for expand dispatch;
- does not change the observable result of CPU-synchronized dispatch; and
- supports both 32-bit and 64-bit `topk_idx_t`.

## Tests

- Added allocator-poisoning assertions for normal and cached non-expand,
  non-sync dispatch.
- Built the full extension for SM90 with CUDA 12.8 and NCCL 2.30.7.
- Compiled the changed CUDA template for SM90 with both 32-bit and 64-bit
  `topk_idx_t`.
- Ran a standalone CUDA suffix-sanitization probe on both available NVIDIA A100
  GPUs for actual counts `0`, `1`, `2`, `capacity - 1`, and `capacity`.
- Ran the standalone probe under `compute-sanitizer --tool memcheck`; result:
  `ERROR SUMMARY: 0 errors`.
- Ran Python syntax checks and `git diff --check`.

## CI note

The repository's current `format.sh` reports pre-existing `B023` findings in
`tests/elastic/test_ep.py` and YAPF formatting differences against the current
`main` version of that file. This change does not introduce a new Ruff finding;
the focused syntax and whitespace checks listed above pass.
