### PR TITLE
Parse EP_BUFFER_DEBUG as an integer on the Python side

### DIFF
--- a/deep_ep/buffers/elastic.py
+++ b/deep_ep/buffers/elastic.py
@@ -308,7 +308,7 @@ class ElasticBuffer:
                 num_max_tokens_per_rank, hidden, num_topk, use_fp8_dispatch,
                 allow_hybrid_mode, allow_multiple_reduction)
 
-        if os.environ.get('EP_BUFFER_DEBUG', 0):
+        if int(os.environ.get('EP_BUFFER_DEBUG', '0')):
             print(f'Initializing EP elastic buffer with {num_bytes} bytes '
                   f'(cpu: {num_cpu_bytes}) at rank EP {group.rank()}/{group.size()}')
         self.num_bytes = num_bytes
@@ -825,7 +825,7 @@ class ElasticBuffer:
         num_sms = min(num_sms, num_device_sms)
 
         # Summary
-        if os.environ.get('EP_BUFFER_DEBUG', 0):
+        if int(os.environ.get('EP_BUFFER_DEBUG', '0')):
             print(f'EP SM approximation: '
                   f'{sm_read=}, {sm_write=}, {rdma_traffic=}, {nvlink_traffic=}, '
                   f'{rdma_gbs=}, {nvlink_gbs=}, '


### PR DESCRIPTION
Fixes #718.

The Python side tested the raw environment string for truthiness (`if os.environ.get('EP_BUFFER_DEBUG', 0):`), so `EP_BUFFER_DEBUG=0` — the documented "off" value — enabled the debug prints at both sites in `deep_ep/buffers/elastic.py`, while the C++ side (`get_env<int>` via `sscanf %d`) correctly treated it as off. Both sites now parse the value as an integer first, matching the C++ semantics and the README's `0`/`1` contract.

Quick check of the semantics change:

```
'0': old=True  new=False
'1': old=True  new=True
```

A non-numeric value now raises `ValueError` loudly instead of silently enabling debug output; #733 tracks the C++ side's handling of that same case.
