### PR TITLE
[HybridEP] Fix aarch64 inter-node JIT, CUDA graph capture, and test EP topology

### DIFF
--- a/csrc/hybrid_ep/executor/executor.cu
+++ b/csrc/hybrid_ep/executor/executor.cu
@@ -393,8 +393,13 @@ void Executor::dispatch_postprocess(HybridEpConfigInstance config, DispatchArgs&
     }else if(args.enable_permute && args.fuse_permute_dispatch) {
         // Fused permute: data already written to args output tensors by fused dispatch kernel. No-op.
     }else if(!args.enable_permute) {
-        // No permute: allocate output tensors and D2D copy from NVLink buffer
-        int num_dispatched_tokens = args.num_dispatched_tokens_tensor.value().item<int>();
+        // No permute: allocate output tensors and D2D copy from NVLink buffer.
+        // Reading the tensor back is a host-side read of a value the kernels only
+        // produce at run time, so a caller that needs static shapes (CUDA graph
+        // capture) must pass the count in instead.
+        int num_dispatched_tokens = args.num_dispatched_tokens >= 0
+            ? static_cast<int>(args.num_dispatched_tokens)
+            : args.num_dispatched_tokens_tensor.value().item<int>();
         size_t sizeof_token_data_type = get_token_data_type_size(intra_node_dispatch_buffers->data_type);
         args.local_expert_output_token = torch::empty(
             {num_dispatched_tokens, config.hidden_dim}, 

--- a/csrc/hybrid_ep/executor/executor.cuh
+++ b/csrc/hybrid_ep/executor/executor.cuh
@@ -70,6 +70,10 @@ public:
         torch::Tensor tokens_per_expert; 
 
         int64_t num_permuted_tokens = -1;
+        // Caller-supplied dispatched token count. When >= 0 it is used verbatim to
+        // size the outputs instead of reading num_dispatched_tokens_tensor back on
+        // the host, which is what makes the no-permute path CUDA-graph capturable.
+        int64_t num_dispatched_tokens = -1;
         // Misc
         int pad_multiple;  // Used in the padding case of permute
         bool enable_permute = false;

--- a/csrc/hybrid_ep/hybrid_ep.cu
+++ b/csrc/hybrid_ep/hybrid_ep.cu
@@ -177,7 +177,8 @@ HybridEPBuffer::dispatch(
          c10::optional<torch::Tensor> probs,
          c10::optional<torch::Tensor> scaling_factor,
          HandleImpl handle,
-         bool with_probs) {
+         bool with_probs,
+         c10::optional<int64_t> num_dispatched_tokens) {
   auto config = handle.config;
   // Check the input tensors
   assert(hidden.device().is_cuda());
@@ -203,6 +204,8 @@ HybridEPBuffer::dispatch(
   args.rdma_to_attn_map = handle.rdma_to_attn_map;
   args.attn_to_rdma_map = handle.attn_to_rdma_map;
   args.num_dispatched_tokens_tensor = handle.num_dispatched_tokens_tensor;
+  args.num_dispatched_tokens =
+      num_dispatched_tokens.has_value() ? num_dispatched_tokens.value() : -1;
   args.num_of_tokens_per_rank = handle.num_of_tokens_per_rank;
   args.enable_permute = false;
   args.stream = at::cuda::getCurrentCUDAStream();

--- a/csrc/hybrid_ep/hybrid_ep.cuh
+++ b/csrc/hybrid_ep/hybrid_ep.cuh
@@ -47,7 +47,8 @@ public:
   dispatch(torch::Tensor hidden, c10::optional<torch::Tensor> probs,
            c10::optional<torch::Tensor> scaling_factor,
            HandleImpl handle,
-           bool with_probs);
+           bool with_probs,
+           c10::optional<int64_t> num_dispatched_tokens);
 
   std::tuple<torch::Tensor, torch::Tensor>
   combine(torch::Tensor hidden, c10::optional<torch::Tensor> probs,

--- a/csrc/hybrid_ep/jit/compiler.cu
+++ b/csrc/hybrid_ep/jit/compiler.cu
@@ -68,7 +68,17 @@ NVCCCompiler::NVCCCompiler(std::string base_path, std::string comm_id):
     include += " -I" + nixl_home + "/include ";
     include += " -I" + nixl_home + "/include/gpu/ucx ";
     include += " -I" + ucx_home + "/include ";
-    std::string nixl_lib = nixl_home + "/lib/x86_64-linux-gnu";
+    // Must match the directory setup.py links against, otherwise the inter-node
+    // JIT cannot find libnixl. The default assumes a Debian multiarch layout;
+    // NIXL_LIB_DIR overrides it for other distros and architectures.
+    std::string nixl_lib = get_env("NIXL_LIB_DIR");
+    if (nixl_lib.empty()) {
+#if defined(__aarch64__)
+        nixl_lib = nixl_home + "/lib/aarch64-linux-gnu";
+#else
+        nixl_lib = nixl_home + "/lib/x86_64-linux-gnu";
+#endif
+    }
     library += " -L" + nixl_lib + " -lnixl -lnixl_build -lnixl_common ";
     library += " -Xlinker -rpath -Xlinker " + nixl_lib + " ";
 #else

--- a/csrc/hybrid_ep/pybind_hybrid_ep.cu
+++ b/csrc/hybrid_ep/pybind_hybrid_ep.cu
@@ -201,7 +201,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
              py::arg("probs") = c10::nullopt,
              py::arg("scaling_factor") = c10::nullopt,
              py::arg("handle"),
-             py::arg("with_probs"))
+             py::arg("with_probs"),
+             py::arg("num_dispatched_tokens") = c10::nullopt)
         .def("combine", &HybridEPBuffer::combine, py::kw_only(),
              py::arg("hidden"),
              py::arg("probs") = c10::nullopt,

--- a/deep_ep/hybrid_ep_buffer.py
+++ b/deep_ep/hybrid_ep_buffer.py
@@ -426,6 +426,17 @@ class HybridEPBuffer:
                 )
 
         if num_dispatched_tokens is None:
+            # The executor reads the count back on the host to size the outputs, so
+            # the pinned buffer has to hold a real value first. While a graph is being
+            # captured the kernel that fills it is only recorded, never run, so there
+            # is nothing to wait for and the caller has to supply the count instead.
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "dispatch() requires an explicit num_dispatched_tokens during CUDA "
+                    "graph capture, because the output shape is data dependent and the "
+                    "count cannot be read back from the device while capturing. Pass an "
+                    "upper bound on the number of tokens this rank will receive."
+                )
             # Synchronize the stream to make sure the data in the pinned_memory_buffer: num_dispatched_tokens_tensor is ready.
             torch.cuda.current_stream().synchronize()
 
@@ -436,6 +447,7 @@ class HybridEPBuffer:
                 scaling_factor=scaling_factor,
                 handle=handle_impl,
                 with_probs=probs is not None,
+                num_dispatched_tokens=num_dispatched_tokens,
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -111,13 +111,18 @@ def get_extension_hybrid_ep_cpp():
             ucx_home = os.getenv("UCX_HOME", "/usr")
             nixl_include = os.path.join(nixl_home, "include")
             nixl_gpu_include = os.path.join(nixl_home, "include/gpu/ucx")
-            import platform
-            machine = platform.machine()
-            if machine == "aarch64":
-                nixl_lib_suffix = "lib/aarch64-linux-gnu"
-            else:
-                nixl_lib_suffix = "lib/x86_64-linux-gnu"
-            nixl_lib = os.path.join(nixl_home, nixl_lib_suffix)
+            # The default assumes a Debian multiarch layout; NIXL_LIB_DIR overrides
+            # it for other distros and architectures. The inter-node JIT reads the
+            # same variable so the two cannot drift apart.
+            nixl_lib = os.getenv("NIXL_LIB_DIR", "")
+            if not nixl_lib:
+                import platform
+                machine = platform.machine()
+                if machine == "aarch64":
+                    nixl_lib_suffix = "lib/aarch64-linux-gnu"
+                else:
+                    nixl_lib_suffix = "lib/x86_64-linux-gnu"
+                nixl_lib = os.path.join(nixl_home, nixl_lib_suffix)
             include_dirs.extend([nixl_include, nixl_gpu_include, os.path.join(ucx_home, "include")])
             library_dirs.append(nixl_lib)
             runtime_library_dirs.append(nixl_lib)

--- a/tests/test_graphed_hybrid_ep.py
+++ b/tests/test_graphed_hybrid_ep.py
@@ -18,7 +18,6 @@ TOPK = int(os.environ.get("TOPK", 8))
 PAD_MULTIPLE = int(os.environ.get("PAD_MULTIPLE", 32))
 ITERATIONS = int(os.environ.get("ITERATIONS", 100))
 SEED = int(os.environ.get("SEED", 42))
-USE_MNNVL = os.environ.get("USE_MNNVL", "0").strip().lower() in {"1", "true", "t", "yes", "y", "on"}
 torch.manual_seed(SEED)
 torch.cuda.manual_seed(SEED)
 torch.cuda.manual_seed_all(SEED)
@@ -203,14 +202,14 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
                 # Set missing global vars - use buffer's detected values
                 global NUM_OF_RANKS_PER_NODE, NUM_OF_NODES, NUM_OF_EXPERTS
-                if USE_MNNVL:
-                    NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
-                    NUM_OF_NODES = buffer.num_of_nodes
-                    NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
-                else:
-                    NUM_OF_RANKS_PER_NODE = args.num_processes
-                    NUM_OF_NODES = group.size() // NUM_OF_RANKS_PER_NODE
-                    NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
+                # The NVLink domain the buffer detects may span several nodes
+                # (MNNVL), so it is not derivable from the launcher's per-node
+                # process count. The dispatched prob vector is indexed by
+                # rank-within-domain, and the reference must use the same width
+                # or it slices the wrong experts.
+                NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
+                NUM_OF_NODES = buffer.num_of_nodes
+                NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
 
                 ref = TorchRef(
                     ep_group=group,

--- a/tests/test_graphed_hybrid_ep.py
+++ b/tests/test_graphed_hybrid_ep.py
@@ -262,6 +262,13 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                 NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
                 NUM_OF_NODES = buffer.num_of_nodes
                 NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
+                if group.rank() == 0:
+                    # Surface the topology: if it is ever wrong, the symptom is
+                    # an expert-slicing mismatch, a confusing way to find out.
+                    print(f"[topology] ranks_per_nvlink_domain={NUM_OF_RANKS_PER_NODE} "
+                          f"num_of_nodes={NUM_OF_NODES} num_of_experts={NUM_OF_EXPERTS} "
+                          f"(from the buffer; override with "
+                          f"NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN)", flush=True)
 
                 ref = TorchRef(
                     ep_group=group,

--- a/tests/test_graphed_hybrid_ep.py
+++ b/tests/test_graphed_hybrid_ep.py
@@ -186,6 +186,58 @@ def test_hybrid_ep_correctness(buffer: deep_ep.HybridEPBuffer, ref: TorchRef, us
     torch.cuda.profiler.stop()
 
 
+def test_plain_dispatch_capture(buffer: deep_ep.HybridEPBuffer):
+    """Cover capturing dispatch() itself.
+
+    The cases above always hand dispatch_with_permute an explicit
+    num_permuted_tokens, so they never exercise the no-permute path whose
+    output shape has to come from the caller. Without a count that shape is
+    unknowable at capture time, and honouring a supplied count is what keeps
+    the recorded allocation and D2D copies correct.
+    """
+    hidden, probs, scaling_factor, routing_map = init_tensor(
+        hidden_dim=HIDDEN_DIM,
+        seq_len=NUM_TOKENS_PER_RANK,
+        topk=TOPK,
+        num_of_experts=NUM_OF_EXPERTS,
+    )
+
+    # Warm up outside capture. This also leaves the warmup's own count in the
+    # pinned buffer, which is what the explicit count below is checked against.
+    warm_token, _, _, _ = buffer.dispatch(
+        hidden=hidden, scaling_factor=scaling_factor,
+        routing_map=routing_map, probs=probs)
+    warm_count = warm_token.shape[0]
+    torch.cuda.synchronize()
+
+    # Without a count the shape cannot be known, so this has to be refused
+    # rather than capturing whatever the pinned buffer happens to hold.
+    try:
+        with torch.cuda.graph(torch.cuda.CUDAGraph()):
+            buffer.dispatch(hidden=hidden, scaling_factor=scaling_factor,
+                            routing_map=routing_map, probs=probs)
+        raise AssertionError("capturing dispatch() without a count should be refused")
+    except RuntimeError as exc:
+        assert "num_dispatched_tokens" in str(exc), f"unclear error: {exc}"
+
+    torch.cuda.synchronize()
+
+    # Stay below the warmup count so the sized copies are in bounds, while
+    # still differing from the value left in the pinned buffer.
+    target = max(1, warm_count - 128)
+    with torch.cuda.graph(torch.cuda.CUDAGraph()):
+        out_token, _, _, _ = buffer.dispatch(
+            hidden=hidden, scaling_factor=scaling_factor,
+            routing_map=routing_map, probs=probs,
+            num_dispatched_tokens=target)
+    assert out_token.shape[0] == target, (
+        f"output has {out_token.shape[0]} rows, expected {target}; the count was "
+        f"read back instead of honoured (warmup count was {warm_count})")
+
+    torch.cuda.synchronize()
+    print_in_order("test_plain_dispatch_capture passed")
+
+
 def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     _, _, group = init_dist(local_rank, num_local_ranks)
 
@@ -217,6 +269,9 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                     num_of_ranks_per_node=NUM_OF_RANKS_PER_NODE,
                 )
                 test_hybrid_ep_correctness(buffer, ref, use_fp8, with_probs, fused_permute_dispatch)
+
+                if not use_fp8 and with_probs and not fused_permute_dispatch:
+                    test_plain_dispatch_capture(buffer)
 
     dist.barrier()
     dist.destroy_process_group()

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -550,6 +550,13 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
             NUM_OF_NODES = buffer.num_of_nodes
             NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
+            if group.rank() == 0:
+                # Surface the topology: if it is ever wrong, the symptom is an
+                # expert-slicing mismatch, which is a confusing way to find out.
+                print(f"[topology] ranks_per_nvlink_domain={NUM_OF_RANKS_PER_NODE} "
+                      f"num_of_nodes={NUM_OF_NODES} num_of_experts={NUM_OF_EXPERTS} "
+                      f"(from the buffer; override with "
+                      f"NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN)", flush=True)
 
             ref = TorchRef(
                 ep_group=group,

--- a/tests/test_hybrid_ep.py
+++ b/tests/test_hybrid_ep.py
@@ -28,7 +28,6 @@ NUM_SMS_COMBINE      = _optional_int("NUM_SMS_COMBINE")
 NUM_BLOCKS_PERMUTE   = _optional_int("NUM_BLOCKS_PERMUTE")
 NUM_BLOCKS_UNPERMUTE = _optional_int("NUM_BLOCKS_UNPERMUTE")
 
-USE_MNNVL = os.environ.get("USE_MNNVL", "0").strip().lower() in {"1", "true", "t", "yes", "y", "on"}
 torch.manual_seed(SEED)
 torch.cuda.manual_seed(SEED)
 torch.cuda.manual_seed_all(SEED)
@@ -544,14 +543,13 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
             # Set missing global vars - use buffer's detected values
             global NUM_OF_RANKS_PER_NODE, NUM_OF_NODES, NUM_OF_EXPERTS
-            if USE_MNNVL:
-                NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
-                NUM_OF_NODES = buffer.num_of_nodes
-                NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
-            else:
-                NUM_OF_RANKS_PER_NODE = args.num_processes
-                NUM_OF_NODES = group.size() // NUM_OF_RANKS_PER_NODE
-                NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
+            # The NVLink domain the buffer detects may span several nodes (MNNVL),
+            # so it is not derivable from the launcher's per-node process count.
+            # The dispatched prob vector is indexed by rank-within-domain, and the
+            # reference must use the same width or it slices the wrong experts.
+            NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
+            NUM_OF_NODES = buffer.num_of_nodes
+            NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
 
             ref = TorchRef(
                 ep_group=group,

--- a/tests/test_ragged_hybrid_ep.py
+++ b/tests/test_ragged_hybrid_ep.py
@@ -533,6 +533,13 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
             NUM_OF_NODES = buffer.num_of_nodes
             NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
+            if group.rank() == 0:
+                # Surface the topology: if it is ever wrong, the symptom is an
+                # expert-slicing mismatch, which is a confusing way to find out.
+                print(f"[topology] ranks_per_nvlink_domain={NUM_OF_RANKS_PER_NODE} "
+                      f"num_of_nodes={NUM_OF_NODES} num_of_experts={NUM_OF_EXPERTS} "
+                      f"(from the buffer; override with "
+                      f"NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN)", flush=True)
 
             ref = TorchRef(
                 ep_group=group,

--- a/tests/test_ragged_hybrid_ep.py
+++ b/tests/test_ragged_hybrid_ep.py
@@ -31,8 +31,6 @@ TOPK = int(os.environ.get("TOPK", 8))
 PAD_MULTIPLE = int(os.environ.get("PAD_MULTIPLE", 32))
 SEED = int(os.environ.get("SEED", 1025))
 
-USE_MNNVL = os.environ.get("USE_MNNVL", "0").strip().lower() in {"1", "true", "t", "yes", "y", "on"}
-
 NUM_OF_RANKS_PER_NODE = None
 NUM_OF_NODES = None
 NUM_OF_EXPERTS = None
@@ -527,12 +525,13 @@ def test_main(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             )
 
             global NUM_OF_RANKS_PER_NODE, NUM_OF_NODES, NUM_OF_EXPERTS
-            if USE_MNNVL:
-                NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
-                NUM_OF_NODES = buffer.num_of_nodes
-            else:
-                NUM_OF_RANKS_PER_NODE = args.num_processes
-                NUM_OF_NODES = group.size() // NUM_OF_RANKS_PER_NODE
+            # The NVLink domain the buffer detects may span several nodes
+            # (MNNVL), so it is not derivable from the launcher's per-node
+            # process count. The dispatched prob vector is indexed by
+            # rank-within-domain, and the reference must use the same width
+            # or it slices the wrong experts.
+            NUM_OF_RANKS_PER_NODE = buffer.num_of_hybrid_ep_ranks_per_nvlink_domain
+            NUM_OF_NODES = buffer.num_of_nodes
             NUM_OF_EXPERTS = NUM_LOCAL_EXPERTS * NUM_OF_RANKS_PER_NODE * NUM_OF_NODES
 
             ref = TorchRef(


### PR DESCRIPTION
Three independent bugs found while bringing HybridEP up on 2x GB200 nodes with the NIXL backend. None depends on the others, so they are separate commits and can be taken independently.

Rebased onto `15f4acf` after #744 (ragged dispatch) merged. All commits applied without conflict, and everything below was re-verified on that base.

Two of them make HybridEP unusable on aarch64 / under CUDA graphs. The third makes a passing configuration look like a data-corruption bug, which is how I found the other two.

---

## 1. The inter-node JIT cannot link libnixl on aarch64

`setup.py` picks the multiarch suffix from `platform.machine()`:

```python
nixl_lib_suffix = "lib/aarch64-linux-gnu" if machine == "aarch64" else "lib/x86_64-linux-gnu"
```

but `csrc/hybrid_ep/jit/compiler.cu` hardcodes the x86_64 one. On aarch64 the JIT emits a `-L` pointing at a directory that does not exist, so **every** inter-node NIXL compile fails at link time and the NIXL cross-node path is unreachable on GB200 / Grace-Hopper.

Observed on baseline, with `NIXL_HOME` set correctly:

```
RuntimeError: Failed to compile the code, compile command: /usr/local/cuda/bin/nvcc -std=c++17 ...
  -L/lustre/.../nixl/install/lib/x86_64-linux-gnu -lnixl -lnixl_build -lnixl_common ...
```

Note the prefix is right and only the suffix is wrong.

**Fix:** select the same directory the extension links against. Since that suffix now appears in two places and only covers Debian-style layouts, both honour a `NIXL_LIB_DIR` override, so other distributions and future architectures do not need another patch and the two selections cannot drift apart.

## 2. `dispatch()` cannot be CUDA-graph captured

`HybridEPBuffer.dispatch()` synchronized the stream to make the pinned `num_dispatched_tokens_tensor` host-readable:

```python
if num_dispatched_tokens is None:
    torch.cuda.current_stream().synchronize()
```

Synchronizing is illegal while a graph is being captured, so capturing a dispatch without an explicit token count fails:

```
torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
Search for `cudaErrorStreamCaptureUnsupported' ...
```

This is not a hypothetical derived from reading the code: I hit it in TensorRT-LLM's `bench_moe_comm.py`, which graph-captures the MoE layer, and it is what currently prevents that integration from using HybridEP at all.

**Deleting the synchronize is not a fix, and an earlier revision of this PR did exactly that.** Thanks to the review for catching it. The underlying problem is that the no-permute dispatch has a *data-dependent output shape*, and the executor obtains that shape with a host read:

```cpp
// csrc/hybrid_ep/executor/executor.cu, dispatch_postprocess
int num_dispatched_tokens = args.num_dispatched_tokens_tensor.value().item<int>();
args.local_expert_output_token = torch::empty({num_dispatched_tokens, config.hidden_dim}, ...);
auto res_sz = static_cast<size_t>(num_dispatched_tokens) * config.hidden_dim * sizeof_token_data_type;
CUDA_CHECK(cudaMemcpyAsync(..., res_sz, cudaMemcpyDeviceToDevice, args.stream));
```

That read happens on the host *at capture time*, and both the allocation and the D2D copy sizes are frozen into the graph. The kernel that produces the real count is only recorded, never run, and with `handle=None` `metadata_preprocessing` allocates a fresh (uninitialized) pinned tensor for it. So removing the synchronize just replaces an illegal wait with a read of memory nothing wrote. Measured on baseline, capturing with an explicit count silently produced a **0-row output** — the fresh pinned page read as zero.

The other half of the problem is that `num_dispatched_tokens` never reached C++ at all. `runtime.dispatch()` took only `hidden, probs, scaling_factor, handle, with_probs`, so passing a count merely skipped the synchronize and the value itself was discarded, leaving the executor reading the pinned tensor regardless.

**Fix:** plumb `num_dispatched_tokens` through to the executor and honour it, so a caller that needs static shapes can supply an upper bound and get a graph whose allocation and copies are sized by that bound. When no count is supplied under capture, raise an error that says so instead of capturing a shape that cannot be known. Eager behaviour is unchanged: with no count the executor still reads the tensor back, after the same synchronize as before.

`tests/test_graphed_hybrid_ep.py` could not catch any of this, because it captures `dispatch_with_permute(..., num_permuted_tokens=...)` and therefore always supplies a count, so the no-permute path was never captured. A case covering it is included, checking both halves of the contract: capture without a count is refused with an actionable message, and a supplied count decides the output shape. The count used deliberately differs from the one the warmup leaves in the pinned buffer, so an implementation that reads the tensor back instead of honouring it fails the test.

## 3. The tests derive EP topology from the launcher instead of the buffer

The tests only read the detected NVLink-domain width when `USE_MNNVL` was set, and otherwise assumed one domain per physical node holding `--num-processes` ranks. On MNNVL hardware a domain can span several nodes, so the buffer forms a wider domain than the launcher implies.

The dispatched prob vector is indexed by rank-within-domain, so when the two disagree the reference slices the wrong expert columns and dispatch appears to return corrupt probabilities:

```
AssertionError: Dispatch probs mismatch (sparse routing, with_probs=True):
32552/178688 elements (18.22%), 65104 bytes differ, shape=[22336, 8]
```

Hidden states still compare clean because they are indexed by global rank, which makes this look like a transport bug specific to probs.

**Diagnosis.** On 2x GB200 nodes sharing an MNNVL clique the buffer reports `num_of_hybrid_ep_ranks_per_nvlink_domain=8` and `num_of_nodes=1`, so `dispatched_probs` is 64 wide (8 local experts x 8 ranks). The tests assumed 4 ranks/node and sliced at `(rank % 4) * 8`, so ranks 0-3 were correct by coincidence and ranks 4-7 compared against the columns belonging to ranks 0-3. Re-slicing the same run at the buffer-derived offset `(rank % 8) * 8` gives **0 mismatches on all 8 ranks**, i.e. the transported data was correct throughout.

**Fix:** take the topology from the buffer unconditionally. `USE_MNNVL` is still honoured by the C++ allocator as a switch to disable fabric allocation (`USE_MNNVL=0`); it just no longer selects how the reference is built. The now-unused Python-side `USE_MNNVL` constant is removed from the tests.

`tests/test_ragged_hybrid_ep.py`, added by #744 after this PR was opened, derives its topology the same way and so inherits the same bug. It is fixed here too, in its own commit. Unfixed it reports `Ragged dispatch probs mismatch ... 18.43%`, the same signature as above.

---

## A/B verification

Same test, same nodes, same container; the only difference is the source tree, selected with `PYTHONPATH` so both stay built and nothing is rebuilt between the A and B runs.

| # | Test | Config | Baseline `58397ea` | This PR |
|---|---|---|---|---|
| 1 | `test_hybrid_ep.py` | NIXL cross-node | FAIL — `Failed to compile the code`, `-L .../lib/x86_64-linux-gnu` | PASS (`rc=0`) |
| 2 | graph capture, no count | fabric | FAIL — opaque `cudaErrorStreamCaptureInvalidated` | PASS — refused, error names `num_dispatched_tokens` |
| 3 | graph capture, explicit count | fabric | FAIL — silently produced **0 rows** instead of the requested count | PASS — output shaped by the supplied count |
| 4 | `test_hybrid_ep.py` | fabric | FAIL — `Dispatch probs mismatch ... 18.22%` | PASS (`rc=0`) |
| 5 | `test_graphed_hybrid_ep.py` (with the new case) | fabric | FAIL — capture error is not actionable | PASS (`rc=0`) |
| 6 | `test_ragged_hybrid_ep.py` | fabric | FAIL — `Ragged dispatch probs mismatch ... 18.43%` | PASS (`rc=0`) |

Row 6 was run with the same library and only the test file swapped, so it isolates the test-side topology bug. Its baseline run ends `rc=1` on one node and `rc=124` on the other, the deadlock described below.

Rows 2 and 3 are the two halves of the added test case; run standalone against both trees they give the contrast above, and row 5 is the same check as committed.

On provenance: bugs 1 and 3 were both observed with the stock `tests/test_hybrid_ep.py`, unmodified. Bug 2 had no native test that could reach it, for the reason given in its section, and the failure it restates was first seen in TensorRT-LLM.

Two notes on how the baseline failures terminate, so the logs are not surprising: in row 4 rank 1 raises the assertion and the remaining ranks then block in the following collective, and in row 1 all ranks raise the compile error together.

## Performance

`test_hybrid_ep.py` run back to back on both trees, same allocation and nodes, both `rc=0` (measured on the pre-rebase base `58397ea`; the delta this PR adds is unchanged by the rebase). The baseline was given the test-only topology fix so it reaches the benchmark section, so the library is the only difference:

```
32 metrics (us, lower is better) | mean +0.02%  best -0.08%  worst +0.34%
```

Dispatch, combine, permute/unpermute and the fused paths are flat across BF16 and FP8. The worst case (FP8 dispatch with probs, 383.0 -> 384.3 us) is well inside run-to-run noise; the min/max spread within a single run is around 7% for the same kernels.

No kernel code changes here. The only hot-path addition is one host-side integer comparison in `dispatch_postprocess` choosing between the caller's count and reading the tensor back, and with no count supplied the eager path runs exactly the sequence it did before.

## How to reproduce

Environment used: 2x GB200 nodes, 4 GPUs each (EP=8), `nvcr.io/nvidia/pytorch:26.07-py3`, DeepEP built with `HYBRID_EP_MULTINODE=1 USE_NIXL=1`, UCX and NIXL installed, an etcd reachable from both nodes, and the defaults from `tests/test_hybrid_ep.py` (hidden 7168, 8 local experts, top-k 8, 4096 tokens/rank).

Common environment:

```bash
export NIXL_HOME=/path/to/nixl UCX_HOME=/path/to/ucx CUDA_HOME=/usr/local/cuda
export LD_LIBRARY_PATH=$NIXL_HOME/lib/aarch64-linux-gnu:$NIXL_HOME/lib:$UCX_HOME/lib:$LD_LIBRARY_PATH
export NIXL_PLUGIN_DIR=$NIXL_HOME/lib/aarch64-linux-gnu/plugins
export NIXL_ETCD_ENDPOINTS=http://$HEAD:2379
export MASTER_ADDR=$HEAD MASTER_PORT=31501 WORLD_SIZE=2 RANK=$SLURM_NODEID
```

**fabric configuration** (default auto-detect; on GB200 both nodes join one MNNVL domain) — reproduces bug 3:

```bash
python tests/test_hybrid_ep.py --only-bf16
```

**NIXL cross-node configuration** — reproduces bug 1. Fabric allocation has to be disabled and the domain pinned to one physical node, otherwise the two nodes form a single NVLink domain and the inter-node path is never taken:

```bash
export USE_MNNVL=0
export NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN=4
python tests/test_hybrid_ep.py --only-bf16
```

**CUDA graph capture** — reproduces bug 2. This is now covered by `tests/test_graphed_hybrid_ep.py`, so on this branch it is just:

```bash
python tests/test_graphed_hybrid_ep.py
```

To see the baseline behaviour, copy that file onto the baseline tree and run it there, or use this standalone version:

```python
import torch, torch.distributed as dist
import deep_ep
from utils import init_dist

def main(local_rank, num_local_ranks, _args=None):
    rank, world, group = init_dist(local_rank, num_local_ranks)
    num_experts = 8 * world
    buffer = deep_ep.HybridEPBuffer(group=group, hidden_dim=7168,
                                    max_num_of_tokens_per_rank=4096,
                                    num_local_experts=8, use_fp8=False)
    hidden = torch.randn(4096, 7168, device="cuda", dtype=torch.bfloat16)
    scaling_factor = torch.randn(4096, 56, device="cuda", dtype=torch.float32)
    probs = torch.zeros(4096, num_experts, device="cuda", dtype=torch.float32)
    routing_map = torch.zeros(4096, num_experts, device="cuda", dtype=torch.bool)
    for i in range(4096):
        sel = torch.randperm(num_experts, device="cuda")[:8]
        routing_map[i, sel] = True
        probs[i, sel] = 1.0

    # Warm up outside capture. This also leaves the warmup's own count in the
    # pinned buffer, which the explicit count below is checked against.
    warm, _, _, _ = buffer.dispatch(hidden=hidden, scaling_factor=scaling_factor,
                                    routing_map=routing_map, probs=probs)
    warm_count = warm.shape[0]
    torch.cuda.synchronize(); dist.barrier()

    # No count: the shape cannot be known, so this must be refused clearly.
    try:
        with torch.cuda.graph(torch.cuda.CUDAGraph()):
            buffer.dispatch(hidden=hidden, scaling_factor=scaling_factor,
                            routing_map=routing_map, probs=probs)
        print("case 1: capture unexpectedly succeeded")
    except RuntimeError as exc:
        ok = "num_dispatched_tokens" in str(exc)
        print(f"case 1: {'clear' if ok else 'UNCLEAR'} error: {exc}")
    torch.cuda.synchronize()

    # Explicit count: it must decide the output shape. Staying below the warmup
    # count keeps the sized copies in bounds while differing from the pinned value.
    target = max(1, warm_count - 128)
    with torch.cuda.graph(torch.cuda.CUDAGraph()):
        out, _, _, _ = buffer.dispatch(hidden=hidden, scaling_factor=scaling_factor,
                                       routing_map=routing_map, probs=probs,
                                       num_dispatched_tokens=target)
    print(f"case 2: {out.shape[0]} rows, expected {target} (warmup was {warm_count})")
    dist.barrier(); dist.destroy_process_group()

if __name__ == "__main__":
    torch.multiprocessing.spawn(main, args=(4, None), nprocs=4)
```

On baseline this reports an unclear `cudaErrorStreamCaptureInvalidated` for case 1 and `0 rows` for case 2; on this branch case 1 names `num_dispatched_tokens` and case 2 returns exactly `target` rows.
