### PR TITLE
[HybridEP] Keep overflow flag last in ragged permute handles

### DIFF
--- a/deep_ep/hybrid_ep_buffer.py
+++ b/deep_ep/hybrid_ep_buffer.py
@@ -518,8 +518,8 @@ class HybridEPBuffer:
         # 8. tokens_per_expert
         # 9. num_of_tokens_per_rank
         # 10. template_config: HybridEpConfigInstance
-        # 11. overflow_flag
-        # 12. num_of_valid_tokens
+        # 11. num_of_valid_tokens
+        # 12. overflow_flag (keep last for callers using handle[-1])
         handle: tuple = None,
         # If non_blocking is True, no stream synchronization will be used, the metadata outputs are on the GPU.
         # Otherwise, tokens_per_expert is copied through pinned memory so Python can derive num_permuted_tokens.
@@ -609,8 +609,8 @@ class HybridEPBuffer:
                     handle_impl.tokens_per_expert,
                     handle_impl.num_of_tokens_per_rank,
                     handle_impl.config,
-                    handle_impl.overflow_flag,
                     handle_impl.num_of_valid_tokens,
+                    handle_impl.overflow_flag,
                 ) = handle
                 self._check_handle_buffer_compat(handle_impl)
                 handle_impl.num_permuted_tokens = num_permuted_tokens
@@ -648,8 +648,8 @@ class HybridEPBuffer:
                 handle_impl.tokens_per_expert,
                 handle_impl.num_of_tokens_per_rank,
                 handle_impl.config,
-                handle_impl.overflow_flag,
                 handle_impl.num_of_valid_tokens,
+                handle_impl.overflow_flag,
             ),
         )
 
@@ -688,8 +688,8 @@ class HybridEPBuffer:
                 handle_impl.tokens_per_expert,
                 handle_impl.num_of_tokens_per_rank,
                 handle_impl.config,
-                handle_impl.overflow_flag,
                 handle_impl.num_of_valid_tokens,
+                handle_impl.overflow_flag,
             ) = handle
             self._check_handle_buffer_compat(handle_impl)
             combined_token, combined_probs = self.runtime.combine_with_unpermute(

--- a/docs/Hybrid-EP_Implementation.md
+++ b/docs/Hybrid-EP_Implementation.md
@@ -168,8 +168,8 @@ handle = (
     tokens_per_expert,           # [7] Tensor: Token count per local expert
     num_of_tokens_per_rank,      # [8] int: Group-uniform token-slot count
     config,                      # [9] HybridEpConfigInstance: Runtime configuration
-    overflow_flag,               # [10] Tensor: Buffer overflow indicator
-    num_of_valid_tokens,         # [11] int: Real local token count (== hidden.size(0))
+    num_of_valid_tokens,         # [10] int: Real local token count (== hidden.size(0))
+    overflow_flag,               # [11] Tensor: Buffer overflow indicator; kept last for handle[-1]
 )
 ```
 

--- a/tests/test_ragged_hybrid_ep.py
+++ b/tests/test_ragged_hybrid_ep.py
@@ -269,10 +269,6 @@ def test_ragged_dispatch_with_permute(buffer: deep_ep.HybridEPBuffer, ref: Torch
                     handle,
                 ) = buffer.dispatch_with_permute(**dispatch_kwargs)
 
-                # Preserve the overflow-at-tail contract used by downstream callers.
-                assert handle[-2] == num_valid, context
-                assert torch.is_tensor(handle[-1]) and handle[-1].item() == 0, context
-
                 assert_bitwise_equal("Ragged dispatch+permute hidden", ref_hidden, dispatched_hidden, context)
                 assert_bitwise_equal("Ragged dispatch+permute probs", ref_probs, dispatched_probs, context)
                 assert_bitwise_equal("Ragged dispatch+permute scaling_factor", ref_sf, dispatched_sf, context)
@@ -297,8 +293,6 @@ def test_ragged_dispatch_with_permute(buffer: deep_ep.HybridEPBuffer, ref: Torch
                     pad_multiple=PAD_MULTIPLE,
                     fuse_permute_dispatch=fuse_permute_dispatch,
                 )
-                assert _replay_handle[-2] == num_valid, context
-                assert _replay_handle[-1] is handle[-1], context
                 assert_bitwise_equal("Ragged replay hidden", dispatched_hidden, replay_hidden, context)
                 assert_bitwise_equal("Ragged replay scaling_factor", dispatched_sf, replay_sf, context)
                 if with_probs:

--- a/tests/test_ragged_hybrid_ep.py
+++ b/tests/test_ragged_hybrid_ep.py
@@ -269,6 +269,10 @@ def test_ragged_dispatch_with_permute(buffer: deep_ep.HybridEPBuffer, ref: Torch
                     handle,
                 ) = buffer.dispatch_with_permute(**dispatch_kwargs)
 
+                # Preserve the overflow-at-tail contract used by downstream callers.
+                assert handle[-2] == num_valid, context
+                assert torch.is_tensor(handle[-1]) and handle[-1].item() == 0, context
+
                 assert_bitwise_equal("Ragged dispatch+permute hidden", ref_hidden, dispatched_hidden, context)
                 assert_bitwise_equal("Ragged dispatch+permute probs", ref_probs, dispatched_probs, context)
                 assert_bitwise_equal("Ragged dispatch+permute scaling_factor", ref_sf, dispatched_sf, context)
@@ -293,6 +297,8 @@ def test_ragged_dispatch_with_permute(buffer: deep_ep.HybridEPBuffer, ref: Torch
                     pad_multiple=PAD_MULTIPLE,
                     fuse_permute_dispatch=fuse_permute_dispatch,
                 )
+                assert _replay_handle[-2] == num_valid, context
+                assert _replay_handle[-1] is handle[-1], context
                 assert_bitwise_equal("Ragged replay hidden", dispatched_hidden, replay_hidden, context)
                 assert_bitwise_equal("Ragged replay scaling_factor", dispatched_sf, replay_sf, context)
                 if with_probs:


### PR DESCRIPTION
Preserve downstream handle[-1] overflow checks by placing the valid-token count before the overflow flag. Update cached dispatch and combine unpacking, document the layout, and assert the contract in the ragged regression test.